### PR TITLE
Use npm trusted publishers (OIDC) for publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ on:
         type: boolean
 permissions:
   contents: write
+  id-token: write
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,18 +33,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - run: pnpm run build
-      - run: pnpm publish packages/firestore-repository
+      - run: pnpm publish packages/firestore-repository --provenance
         if: ${{ inputs.firestore-repository }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm publish packages/firebase-js-sdk
+      - run: pnpm publish packages/firebase-js-sdk --provenance
         if: ${{ inputs.firebase-js-sdk }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm publish packages/google-cloud-firestore
+      - run: pnpm publish packages/google-cloud-firestore --provenance
         if: ${{ inputs.google-cloud-firestore }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create GitHub Release
         run: |
           VERSION=$(node -p "require('./packages/firestore-repository/package.json').version")


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for OIDC authentication with npm trusted publishers
- Add `--provenance` flag to all `pnpm publish` commands
- Remove `NPM_TOKEN` secret dependency (no longer needed)

## Notes
npm side configuration is also required: set up a Trusted Publisher for each package on npmjs.com (Settings → Publishing → Add a publisher → GitHub Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)