### PR TITLE
Add rootDir to tsconfig.build.json for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
-  "compilerOptions": { "noEmit": false, "outDir": "${configDir}/build/esm" },
+  "compilerOptions": { "noEmit": false, "outDir": "${configDir}/build/esm", "rootDir": "${configDir}/src" },
   "exclude": ["**/vitest.*.ts", "**/__test__/*", "**/*.test.ts", "**/*.bench.ts"]
 }


### PR DESCRIPTION
## Summary
- TypeScript 6 requires `rootDir` to be explicitly set when `outDir` is specified (TS5011)
- Add `"rootDir": "${configDir}/src"` to `tsconfig.build.json` to fix the build
- This unblocks the Dependabot PR #169 that bumps TypeScript to 6.0.2

## Test plan
- [x] Build passes with TypeScript 5 (current)
- [ ] Build passes with TypeScript 6 (verified via CI on Dependabot PR after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)