### PR TITLE
Rename Doc.ref field to Doc.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ All operations are **type-safe** based on the schema you defined. The `data` fie
 ```ts
 // Set a document
 await repository.set({
-  ref: 'user1',
+  id: 'user1',
   data: { name: 'John Doe', profile: { age: 42, gender: 'male' }, tag: ['new'] },
 });
 
 // Create a document (backend only)
 await repository.create({
-  ref: 'user2',
+  id: 'user2',
   data: { name: 'Charlie', profile: { age: 25, gender: 'male' }, tag: [] },
 });
 
@@ -139,8 +139,8 @@ const users = await repository.batchGet(['user1', 'user2']);
 
 // Set multiple documents
 await repository.batchSet([
-  { ref: 'user1', data: { name: 'Alice', profile: { age: 30, gender: 'female' }, tag: ['new'] } },
-  { ref: 'user2', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
+  { id: 'user1', data: { name: 'Alice', profile: { age: 30, gender: 'female' }, tag: ['new'] } },
+  { id: 'user2', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
 ]);
 
 // Delete multiple documents
@@ -157,7 +157,7 @@ import { writeBatch } from '@firebase/firestore';
 const batch = writeBatch(db);
 
 await repository.set(
-  { ref: 'user3', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
+  { id: 'user3', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
   { tx: batch },
 );
 await repository.batchSet(
@@ -189,8 +189,8 @@ await runTransaction(db, async (tx) => {
     await repository.set(doc, { tx });
     await repository.batchSet(
       [
-        { ...doc, ref: 'user2' },
-        { ...doc, ref: 'user3' },
+        { ...doc, id: 'user2' },
+        { ...doc, id: 'user3' },
       ],
       { tx },
     );
@@ -223,8 +223,8 @@ const posts = subCollection({
 
 const postRepository = subcollectionRepository(db, posts);
 
-// Set a document (ref is [parentDocId, docId])
-await postRepository.set({ ref: ['user1', 'post1'], data: { title: 'My first post' } });
+// Set a document (id is [parentDocId, docId])
+await postRepository.set({ id: ['user1', 'post1'], data: { title: 'My first post' } });
 
 // Get a document
 const post = await postRepository.get(['user1', 'post1']);
@@ -232,7 +232,7 @@ const post = await postRepository.get(['user1', 'post1']);
 
 ### Custom Mapper
 
-By default, `rootCollectionRepository` returns a repository with `{ ref: string, data: ... }` as its model type. If you want to use your own application model types, you can define a custom `Mapper` and use `repositoryWithMapper` to create a repository that automatically converts between Firestore documents and your models.
+By default, `rootCollectionRepository` returns a repository with `{ id: string, data: ... }` as its model type. If you want to use your own application model types, you can define a custom `Mapper` and use `repositoryWithMapper` to create a repository that automatically converts between Firestore documents and your models.
 
 A `Mapper` consists of three functions:
 
@@ -261,9 +261,9 @@ type User = {
 // Define a mapper
 const userMapper: Mapper<typeof users, AppModel<string, User, User>> = {
   toDocRef: (id) => [id],
-  fromFirestore: (doc) => ({ id: doc.ref[0], ...doc.data }),
+  fromFirestore: (doc) => ({ id: doc.id[0], ...doc.data }),
   toFirestore: (user) => ({
-    ref: [user.id],
+    id: [user.id],
     data: { name: user.name, profile: user.profile, tag: user.tag },
   }),
 };

--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -167,7 +167,7 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
 
     set: async (model: Model['write'], options?: WriteTransactionOption<Env>): Promise<void> => {
       const docToWrite = mapper.toFirestore(model);
-      const docRef = toFirestore.docRef(docToWrite.ref);
+      const docRef = toFirestore.docRef(docToWrite.id);
       const data = encode(docToWrite.data);
       await (options?.tx
         ? options.tx instanceof Transaction
@@ -187,13 +187,13 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
     ): Promise<void> => {
       const docs = models.map((m) => {
         const d = mapper.toFirestore(m);
-        return { ref: d.ref, data: encode(d.data) };
+        return { id: d.id, data: encode(d.data) };
       });
       await batchWriteOperation(
         docs,
         {
-          batch: (batch, d) => batch.set(toFirestore.docRef(d.ref), d.data),
-          transaction: (tx, d) => tx.set(toFirestore.docRef(d.ref), d.data),
+          batch: (batch, d) => batch.set(toFirestore.docRef(d.id), d.data),
+          transaction: (tx, d) => tx.set(toFirestore.docRef(d.id), d.data),
         },
         options,
       );
@@ -315,7 +315,7 @@ const buildFirestoreUtilities = <T extends Collection>(db: Firestore, coll: T) =
         throw new Error('document must exist');
       }
       return {
-        ref: fromFirestore.docRef(document.ref),
+        id: fromFirestore.docRef(document.ref),
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Zod output is typed by schema
         data: decodeSchema.parse(data) as DocData<T['schema'], 'read'>,
       };

--- a/packages/firestore-repository/src/__test__/specification.ts
+++ b/packages/firestore-repository/src/__test__/specification.ts
@@ -167,7 +167,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
       describe('get', () => {
         it('exists', async () => {
-          expect(await repository.get(items[0].ref)).toStrictEqual(items[0]);
+          expect(await repository.get(items[0].id)).toStrictEqual(items[0]);
         });
 
         it('not found', async () => {
@@ -176,8 +176,8 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
         it('transaction', async () => {
           const res = await db.transaction(async (tx) => {
-            const item0 = await repository.get(items[0].ref, { tx });
-            const item1 = await repository.get(items[1].ref, { tx });
+            const item0 = await repository.get(items[0].id, { tx });
+            const item1 = await repository.get(items[1].id, { tx });
             return [item0, item1];
           });
           expect(res).toStrictEqual([items[0], items[1]]);
@@ -196,12 +196,12 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         const operations: (() => Promise<void>)[] = [
           () => repository.set(updated1),
           () => repository.set(updated2),
-          () => repository.delete(updated2.ref),
+          () => repository.delete(updated2.id),
           () => repository.set(updated3),
         ];
 
         const received: (Doc<T, 'read'> | undefined)[] = [];
-        const unsubscribe = repository.getOnSnapshot(items[0].ref, (snapshot) => {
+        const unsubscribe = repository.getOnSnapshot(items[0].id, (snapshot) => {
           received.push(snapshot);
           const op = operations.shift();
           if (op) {
@@ -247,7 +247,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           () => repository.set(newItem),
           () => repository.set(updated0),
           () => repository.set(updated1),
-          () => repository.delete(updated1.ref),
+          () => repository.delete(updated1.id),
         ];
 
         const received: Doc<T, 'read'>[][] = [];
@@ -381,7 +381,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
       describe('delete', () => {
         it('success', async () => {
           const [target, ...rest] = items;
-          await repository.delete(target.ref);
+          await repository.delete(target.id);
           await expectDb(rest);
         });
 
@@ -393,16 +393,16 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         describe('transaction', () => {
           it('success', async () => {
             await db.transaction(async (tx) => {
-              await repository.delete(items[0].ref, { tx });
-              await repository.delete(items[1].ref, { tx });
+              await repository.delete(items[0].id, { tx });
+              await repository.delete(items[1].id, { tx });
             });
             await expectDb([items[2]]);
           });
 
           it('abort', async () => {
             const promise = db.transaction(async (tx) => {
-              await repository.delete(items[0].ref, { tx });
-              await repository.delete(items[1].ref, { tx });
+              await repository.delete(items[0].id, { tx });
+              await repository.delete(items[1].id, { tx });
               throw new Error('abort');
             });
             await expect(promise).rejects.toThrowError('abort');
@@ -412,8 +412,8 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
         it('writeBatch', async () => {
           const batch = db.writeBatch();
-          await repository.delete(items[0].ref, { tx: batch });
-          await repository.delete(items[1].ref, { tx: batch });
+          await repository.delete(items[0].id, { tx: batch });
+          await repository.delete(items[1].id, { tx: batch });
           await expectDb(items);
           await batch.commit();
           await expectDb([items[2]]);
@@ -428,14 +428,14 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         });
 
         it('multi', async () => {
-          await repository.batchDelete([target1.ref, target2.ref, params.notExistDocId()]);
+          await repository.batchDelete([target1.id, target2.id, params.notExistDocId()]);
           await expectDb(rest);
         });
 
         describe('transaction', () => {
           it('success', async () => {
             await db.transaction(async (tx) => {
-              await repository.batchDelete([target1.ref, target2.ref, params.notExistDocId()], {
+              await repository.batchDelete([target1.id, target2.id, params.notExistDocId()], {
                 tx,
               });
             });
@@ -444,7 +444,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           it('abort', async () => {
             const promise = db.transaction(async (tx) => {
-              await repository.batchDelete([target1.ref, target2.ref, params.notExistDocId()], {
+              await repository.batchDelete([target1.id, target2.id, params.notExistDocId()], {
                 tx,
               });
               throw new Error('abort');
@@ -456,8 +456,8 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
         it('writeBatch', async () => {
           const batch = db.writeBatch();
-          await repository.batchDelete([target1.ref], { tx: batch });
-          await repository.batchDelete([target2.ref], { tx: batch });
+          await repository.batchDelete([target1.id], { tx: batch });
+          await repository.batchDelete([target2.id], { tx: batch });
           await expectDb(items);
           await batch.commit();
           await expectDb(rest);
@@ -481,7 +481,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
       newData: () => {
         const id = baseId++;
         return {
-          ref: [`author${id}`],
+          id: [`author${id}`],
           data: {
             name: `name${id}`,
             profile: { age: randomNumber(), gender: 'male' as const },
@@ -495,7 +495,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         data: { ...data.data, name: `${data.data.name}_updated_${randomString()}` },
       }),
       notExistDocId: () => ['not-exists'],
-      sortKey: (a) => a.ref[0],
+      sortKey: (a) => a.id[0],
     });
 
     defineTests({
@@ -505,7 +505,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         const id = baseId++;
         const authorId = baseId++;
         return {
-          ref: [`author${authorId}`, `${id}`],
+          id: [`author${authorId}`, `${id}`],
           data: { title: `post${id}`, postedAt: new Date() },
         };
       },
@@ -514,7 +514,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         data: { ...data.data, title: `${data.data.title}_updated_${randomString()}` },
       }),
       notExistDocId: () => ['author0', `${randomNumber()}`],
-      sortKey: (doc) => `${doc.ref[1]}-${doc.ref[0]}`,
+      sortKey: (doc) => `${doc.id[1]}-${doc.id[0]}`,
     });
 
     describe('query', () => {
@@ -541,7 +541,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           collection: authorsCollection,
           items: [
             {
-              ref: ['1'],
+              id: ['1'],
               data: {
                 name: 'author1',
                 profile: { age: 40, gender: 'male' },
@@ -550,7 +550,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
               },
             },
             {
-              ref: ['2'],
+              id: ['2'],
               data: {
                 name: 'author2',
                 profile: { age: 90, gender: 'female' },
@@ -559,7 +559,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
               },
             },
             {
-              ref: ['3'],
+              id: ['3'],
               data: { name: 'author3', profile: { age: 20 }, rank: 2, tag: ['c', 'd'] },
             },
           ] as const satisfies Doc<AuthorsCollection, 'read'>[],
@@ -950,9 +950,9 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         const { repository, expectQuery, items } = setup({
           collection: postsCollection,
           items: [
-            { ref: ['author1', '1'], data: { title: 'post1', postedAt: new Date('2020-02-01') } },
-            { ref: ['author1', '2'], data: { title: 'post2', postedAt: new Date('2020-01-01') } },
-            { ref: ['author2', '3'], data: { title: 'post3', postedAt: new Date('2020-03-01') } },
+            { id: ['author1', '1'], data: { title: 'post1', postedAt: new Date('2020-02-01') } },
+            { id: ['author1', '2'], data: { title: 'post2', postedAt: new Date('2020-01-01') } },
+            { id: ['author2', '3'], data: { title: 'post3', postedAt: new Date('2020-03-01') } },
           ],
         });
 
@@ -1021,7 +1021,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
       it('set/get', async () => {
         const docId = randomString();
         const value: Doc<typeof allFieldTypesCollection, 'read'> = {
-          ref: [docId],
+          id: [docId],
           data: {
             array: [1, 2, 'foo', 3, 'bar'],
             boolean: false,
@@ -1042,7 +1042,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         };
         await repository.set(value);
 
-        const dbValue = await repository.get(value.ref);
+        const dbValue = await repository.get(value.id);
         assert(dbValue);
 
         expect(dbValue).toStrictEqual(value);
@@ -1079,13 +1079,13 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           {
             toDocRef: (id) => [id],
             fromFirestore: (doc) => ({
-              id: doc.ref[0],
+              id: doc.id[0],
               createdAt: doc.data.createdAt,
               location: { lat: doc.data.location.latitude, lng: doc.data.location.longitude },
               content: doc.data.content,
             }),
             toFirestore: (model) => ({
-              ref: [model.id],
+              id: [model.id],
               data: {
                 createdAt: model.createdAt,
                 location: { latitude: model.location.lat, longitude: model.location.lng },
@@ -1134,7 +1134,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           const now = Date.now();
           await repository.set({
-            ref: [id],
+            id: [id],
             data: { updatedAt: serverTimestamp(), counter: 1, tags: [] },
           });
 
@@ -1149,7 +1149,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           // Verify increment works with set() without runtime error
           await repository.set({
-            ref: [id],
+            id: [id],
             data: { updatedAt: new Date(), counter: increment(5), tags: [] },
           });
 
@@ -1167,7 +1167,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           // Verify arrayUnion works with set() without runtime error
           await repository.set({
-            ref: [id],
+            id: [id],
             data: { updatedAt: new Date(), counter: 0, tags: arrayUnion('tag1', 'tag2') },
           });
 
@@ -1185,13 +1185,13 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           // First create a document with some tags
           await repository.set({
-            ref: [id],
+            id: [id],
             data: { updatedAt: new Date(), counter: 0, tags: ['tag1', 'tag2'] },
           });
 
           // Verify arrayRemove works with set() without runtime error
           await repository.set({
-            ref: [id],
+            id: [id],
             data: { updatedAt: new Date(), counter: 0, tags: arrayRemove('tag1') },
           });
 

--- a/packages/firestore-repository/src/repository.test.ts
+++ b/packages/firestore-repository/src/repository.test.ts
@@ -34,11 +34,11 @@ describe('repository', () => {
 
   it('Doc', () => {
     expectTypeOf<Doc<AuthorsCollection, 'read'>>().toEqualTypeOf<{
-      ref: [string];
+      id: [string];
       data: { name: string; registeredAt: Date };
     }>();
     expectTypeOf<Doc<AuthorsCollection, 'write'>>().toEqualTypeOf<{
-      ref: [string];
+      id: [string];
       data: { name: string; registeredAt: Date | ServerTimestamp };
     }>();
 

--- a/packages/firestore-repository/src/repository.ts
+++ b/packages/firestore-repository/src/repository.ts
@@ -107,16 +107,17 @@ export type PlainModel<T extends Collection> = {
   read: Doc<T, 'read'>;
 };
 
-export type Doc<T extends Collection, Mode extends 'read' | 'write'> = {
-  ref: DocRef<T>;
-  data: DocData<T['schema'], Mode>;
-};
-
 /** A plain model for root collections where the id is a single string */
 export type RootCollectionPlainModel<T extends Collection> = {
   id: string;
-  write: { ref: string; data: DocData<T['schema'], 'write'> };
-  read: { ref: string; data: DocData<T['schema'], 'read'> };
+  write: { id: string; data: DocData<T['schema'], 'write'> };
+  read: { id: string; data: DocData<T['schema'], 'read'> };
+};
+
+/** A Firestore document */
+export type Doc<T extends Collection, Mode extends 'read' | 'write'> = {
+  id: DocRef<T>;
+  data: DocData<T['schema'], Mode>;
 };
 
 /** A document reference represented as a tuple of document IDs */
@@ -144,7 +145,7 @@ export const rootCollectionPlainMapper = <T extends RootCollection>(
 ): Mapper<T, RootCollectionPlainModel<T>> => ({
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- type system doesn't expand DocRef<T> into [string]
   toDocRef: (id) => [id] as unknown as DocRef<T>,
-  fromFirestore: (doc) => ({ ref: doc.ref[0], data: doc.data }),
+  fromFirestore: (doc) => ({ id: doc.id[0], data: doc.data }),
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- type system doesn't expand DocRef<T> into [string]
-  toFirestore: (model) => ({ ref: [model.ref] as unknown as DocRef<T>, data: model.data }),
+  toFirestore: (model) => ({ id: [model.id] as unknown as DocRef<T>, data: model.data }),
 });

--- a/packages/google-cloud-firestore/src/index.bench.ts
+++ b/packages/google-cloud-firestore/src/index.bench.ts
@@ -17,15 +17,15 @@ describe('repository', () => {
   const repository = repositoryWithMapper(db, collection, plainMapper(collection));
 
   const doc1: Doc<typeof collection, 'read'> = {
-    ref: ['1'],
+    id: ['1'],
     data: { name: 'author1', profile: { age: 20 }, rank: 1, tag: ['a', 'b'] },
   };
   const doc2: Doc<typeof collection, 'read'> = {
-    ref: ['2'],
+    id: ['2'],
     data: { name: 'author2', profile: { age: 30 }, rank: 2, tag: ['b', 'c'] },
   };
   const doc3: Doc<typeof collection, 'read'> = {
-    ref: ['3'],
+    id: ['3'],
     data: { name: 'author3', profile: { age: 40 }, rank: 1, tag: ['c', 'd'] },
   };
 
@@ -34,7 +34,7 @@ describe('repository', () => {
   });
 
   bench('get', async () => {
-    await repository.get(doc1.ref);
+    await repository.get(doc1.id);
   });
 
   bench('set', async () => {
@@ -50,6 +50,6 @@ describe('repository', () => {
   });
 
   bench('batchGet', async () => {
-    await repository.batchGet([doc1.ref, doc2.ref, doc3.ref]);
+    await repository.batchGet([doc1.id, doc2.id, doc3.id]);
   });
 });

--- a/packages/google-cloud-firestore/src/index.test.ts
+++ b/packages/google-cloud-firestore/src/index.test.ts
@@ -92,11 +92,11 @@ describe('repository', async () => {
         it('not empty', async () => {
           expect(
             await repository.batchGet([
-              items[0].ref,
-              items[2].ref,
-              items[1].ref,
+              items[0].id,
+              items[2].id,
+              items[1].id,
               notExistDocId(),
-              items[2].ref,
+              items[2].id,
             ]),
           ).toStrictEqual([items[0], items[2], items[1], undefined, items[2]]);
         });
@@ -104,7 +104,7 @@ describe('repository', async () => {
         it('transaction', async () => {
           const res = await db.runTransaction(async (tx) => {
             return await repository.batchGet(
-              [items[0].ref, items[2].ref, items[1].ref, notExistDocId(), items[2].ref],
+              [items[0].id, items[2].id, items[1].id, notExistDocId(), items[2].id],
               { tx },
             );
           });
@@ -140,14 +140,14 @@ describe('repository', async () => {
     const repository = repositoryWithMapper(db, coll, plainMapper(coll));
     const items = [
       {
-        ref: ['1'],
+        id: ['1'],
         data: { name: 'author1', profile: { age: 20, gender: 'male' }, rank: 1, tag: ['a', 'b'] },
       },
       {
-        ref: ['2'],
+        id: ['2'],
         data: { name: 'author2', profile: { age: 40, gender: 'female' }, rank: 1, tag: ['b', 'c'] },
       },
-      { ref: ['3'], data: { name: 'author3', profile: { age: 60 }, rank: 2, tag: ['c', 'd'] } },
+      { id: ['3'], data: { name: 'author3', profile: { age: 60 }, rank: 2, tag: ['c', 'd'] } },
     ] as const satisfies Doc<typeof authorsCollection, 'write'>[];
 
     beforeAll(async () => {

--- a/packages/google-cloud-firestore/src/index.ts
+++ b/packages/google-cloud-firestore/src/index.ts
@@ -158,14 +158,14 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
 
     create: async (model: Model['write'], options?: WriteTransactionOption<Env>): Promise<void> => {
       const docToWrite = mapper.toFirestore(model);
-      const docRef = toFirestore.docRef(docToWrite.ref);
+      const docRef = toFirestore.docRef(docToWrite.id);
       const data = encode(docToWrite.data);
       await (options?.tx ? options.tx.create(docRef, data) : docRef.create(data));
     },
 
     set: async (model: Model['write'], options?: WriteTransactionOption<Env>): Promise<void> => {
       const docToWrite = mapper.toFirestore(model);
-      const docRef = toFirestore.docRef(docToWrite.ref);
+      const docRef = toFirestore.docRef(docToWrite.id);
       const data = encode(docToWrite.data);
       await (options?.tx
         ? options.tx instanceof Transaction
@@ -200,13 +200,13 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
     ): Promise<void> => {
       const docs = models.map((m) => {
         const d = mapper.toFirestore(m);
-        return { ref: d.ref, data: encode(d.data) };
+        return { id: d.id, data: encode(d.data) };
       });
       await batchWriteOperation(
         docs,
         {
-          batch: (batch, doc) => batch.set(toFirestore.docRef(doc.ref), doc.data),
-          transaction: (tx, doc) => tx.set(toFirestore.docRef(doc.ref), doc.data),
+          batch: (batch, doc) => batch.set(toFirestore.docRef(doc.id), doc.data),
+          transaction: (tx, doc) => tx.set(toFirestore.docRef(doc.id), doc.data),
         },
         options,
       );
@@ -218,13 +218,13 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
     ): Promise<void> => {
       const docs = models.map((m) => {
         const d = mapper.toFirestore(m);
-        return { ref: d.ref, data: encode(d.data) };
+        return { id: d.id, data: encode(d.data) };
       });
       await batchWriteOperation(
         docs,
         {
-          batch: (batch, doc) => batch.create(toFirestore.docRef(doc.ref), doc.data),
-          transaction: (tx, doc) => tx.create(toFirestore.docRef(doc.ref), doc.data),
+          batch: (batch, doc) => batch.create(toFirestore.docRef(doc.id), doc.data),
+          transaction: (tx, doc) => tx.create(toFirestore.docRef(doc.id), doc.data),
         },
         options,
       );
@@ -319,7 +319,7 @@ const buildFirestoreUtilities = <T extends Collection>(db: firestore.Firestore, 
         throw new Error('document must exist');
       }
       return {
-        ref: fromFirestore.docRef(document.ref),
+        id: fromFirestore.docRef(document.ref),
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Zod output is typed by schema
         data: decodeSchema.parse(data) as DocData<T['schema'], 'read'>,
       };

--- a/packages/readme-example/src/index.test.ts
+++ b/packages/readme-example/src/index.test.ts
@@ -105,14 +105,14 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
   describe('Basic operations for a single document', () => {
     it('set', async () => {
       await repository.set({
-        ref: 'user1',
+        id: 'user1',
         data: { name: 'John Doe', profile: { age: 42, gender: 'male' }, tag: ['new'] },
       });
     });
 
     onlyGoogleCloudFirestore('create', async (repository) => {
       await repository.create({
-        ref: 'user2',
+        id: 'user2',
         data: { name: 'Charlie', profile: { age: 25, gender: 'male' }, tag: [] },
       });
     });
@@ -164,10 +164,10 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
     it('batchSet', async () => {
       await repository.batchSet([
         {
-          ref: 'user1',
+          id: 'user1',
           data: { name: 'Alice', profile: { age: 30, gender: 'female' }, tag: ['new'] },
         },
-        { ref: 'user2', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
+        { id: 'user2', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
       ]);
     });
 
@@ -182,7 +182,7 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
     it('include multiple different operations in a batch', async () => {
       const batch = db.writeBatch();
       await repository.set(
-        { ref: 'user3', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
+        { id: 'user3', data: { name: 'Bob', profile: { age: 20, gender: 'male' }, tag: [] } },
         { tx: batch },
       );
       await repository.batchSet(
@@ -206,8 +206,8 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
         await repository.set(doc, { tx });
         await repository.batchSet(
           [
-            { ...doc, ref: 'user2' },
-            { ...doc, ref: 'user3' },
+            { ...doc, id: 'user2' },
+            { ...doc, id: 'user3' },
           ],
           { tx },
         );
@@ -226,7 +226,7 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
 
     it('set', async () => {
       await subcollectionRepository.set({
-        ref: ['user1', 'post1'],
+        id: ['user1', 'post1'],
         data: { title: 'My first post' },
       });
     });
@@ -246,9 +246,9 @@ const defineReadmeExampleTests = <Env extends FirestoreEnvironment>({
 
     const userMapper: Mapper<UsersCollection, AppModel<string, User, User>> = {
       toDocRef: (id) => [id],
-      fromFirestore: (doc) => ({ id: doc.ref[0], ...doc.data }),
+      fromFirestore: (doc) => ({ id: doc.id[0], ...doc.data }),
       toFirestore: (user) => ({
-        ref: [user.id],
+        id: [user.id],
         data: { name: user.name, profile: user.profile, tag: user.tag },
       }),
     };


### PR DESCRIPTION
## Summary

- Rename the `ref` field of the `Doc<T, Mode>` type to `id` for consistency with other ID fields in the codebase
- Update all usages across implementation files, tests, benchmarks, and documentation

## Test plan

- [ ] TypeScript compilation passes with no new errors
- [ ] Existing tests continue to pass