### PR TITLE
Rename Doc.ref to Doc.id and make mode type parameter optional

### DIFF
--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -309,7 +309,7 @@ const buildFirestoreUtilities = <T extends Collection>(db: Firestore, coll: T) =
   };
 
   const fromFirestore = {
-    documentMustExist: (document: DocumentSnapshot): Doc<T, 'read'> => {
+    documentMustExist: (document: DocumentSnapshot): Doc<T> => {
       const data = document.data();
       if (!data) {
         throw new Error('document must exist');
@@ -317,10 +317,10 @@ const buildFirestoreUtilities = <T extends Collection>(db: Firestore, coll: T) =
       return {
         id: fromFirestore.docRef(document.ref),
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Zod output is typed by schema
-        data: decodeSchema.parse(data) as DocData<T['schema'], 'read'>,
+        data: decodeSchema.parse(data) as DocData<T>,
       };
     },
-    document: (document: DocumentSnapshot): Doc<T, 'read'> | undefined => {
+    document: (document: DocumentSnapshot): Doc<T> | undefined => {
       if (!document.exists()) {
         return undefined;
       }

--- a/packages/firestore-repository/src/__test__/specification.ts
+++ b/packages/firestore-repository/src/__test__/specification.ts
@@ -119,7 +119,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 }) => {
   const defineTests = <T extends Collection>(params: TestCollectionParams<T>) => {
     const setup = (): RepositoryTestEnv<T, Env> => {
-      const items: [Doc<T, 'read'>, Doc<T, 'read'>, Doc<T, 'read'>] = [
+      const items: [Doc<T>, Doc<T>, Doc<T>] = [
         params.newData(),
         params.newData(),
         params.newData(),
@@ -147,7 +147,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
       return {
         repository,
         items,
-        expectDb: async (expected: Doc<T, 'read'>[]) => {
+        expectDb: async (expected: Doc<T>[]) => {
           const items = (
             await currentRepository.list(
               query({ collection: currentRepository.collection, group: true }),
@@ -200,7 +200,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           () => repository.set(updated3),
         ];
 
-        const received: (Doc<T, 'read'> | undefined)[] = [];
+        const received: (Doc<T> | undefined)[] = [];
         const unsubscribe = repository.getOnSnapshot(items[0].id, (snapshot) => {
           received.push(snapshot);
           const op = operations.shift();
@@ -250,7 +250,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           () => repository.delete(updated1.id),
         ];
 
-        const received: Doc<T, 'read'>[][] = [];
+        const received: Doc<T>[][] = [];
         const unsubscribe = repository.listOnSnapshot(
           query({ collection: repository.collection, group: true }),
           (list) => {
@@ -518,7 +518,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
     });
 
     describe('query', () => {
-      const setup = <T extends Collection, const Items extends Doc<T, 'read'>[]>(params: {
+      const setup = <T extends Collection, const Items extends Doc<T>[]>(params: {
         collection: T;
         items: Items;
       }) => {
@@ -529,7 +529,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
         return {
           repository,
           items: params.items,
-          expectQuery: async (query: Query<T>, expected: Doc<T, 'read'>[]) => {
+          expectQuery: async (query: Query<T>, expected: Doc<T>[]) => {
             const result = (await repository.list(query)).toArray();
             expect(result).toStrictEqual(expected);
           },
@@ -562,7 +562,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
               id: ['3'],
               data: { name: 'author3', profile: { age: 20 }, rank: 2, tag: ['c', 'd'] },
             },
-          ] as const satisfies Doc<AuthorsCollection, 'read'>[],
+          ] as const satisfies Doc<AuthorsCollection>[],
         });
 
         it('query without condition', async () => {
@@ -583,7 +583,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
               string,
               [
                 condition: FilterExpression<AuthorsCollection['schema']>,
-                expected: Doc<AuthorsCollection, 'read'>[],
+                expected: Doc<AuthorsCollection>[],
               ]
             > = {
               '==': [eq('name', 'author1'), [items[0]]],
@@ -805,7 +805,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           cursorFunc: typeof startAt | typeof startAfter | typeof endAt | typeof endBefore,
           tests: Record<
             keyof typeof queryCursorTestCases,
-            [unknown[], Doc<typeof repository.collection, 'read'>[]][]
+            [unknown[], Doc<typeof repository.collection>[]][]
           >,
         ) => {
           describe(cursorFunc.name, () => {
@@ -1020,7 +1020,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
       it('set/get', async () => {
         const docId = randomString();
-        const value: Doc<typeof allFieldTypesCollection, 'read'> = {
+        const value: Doc<typeof allFieldTypesCollection> = {
           id: [docId],
           data: {
             array: [1, 2, 'foo', 3, 'bar'],
@@ -1211,15 +1211,15 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
 export type RepositoryTestEnv<T extends Collection, Env extends FirestoreEnvironment> = {
   repository: PlainRepository<T, Env>;
-  items: [Doc<T, 'read'>, Doc<T, 'read'>, Doc<T, 'read'>, ...Doc<T, 'read'>[]];
-  expectDb: (expected: Doc<T, 'read'>[]) => Promise<void>;
+  items: [Doc<T>, Doc<T>, Doc<T>, ...Doc<T>[]];
+  expectDb: (expected: Doc<T>[]) => Promise<void>;
 };
 
 export type TestCollectionParams<T extends Collection = Collection> = {
   title: string;
   collection: T;
-  newData: () => Doc<T, 'read'>;
-  mutate: (data: Doc<T, 'read'>) => Doc<T, 'read'>;
+  newData: () => Doc<T>;
+  mutate: (data: Doc<T>) => Doc<T>;
   notExistDocId: () => DocRef<T>;
-  sortKey: (doc: Doc<T, 'read'>) => string;
+  sortKey: (doc: Doc<T>) => string;
 };

--- a/packages/firestore-repository/src/repository.test.ts
+++ b/packages/firestore-repository/src/repository.test.ts
@@ -33,7 +33,7 @@ describe('repository', () => {
   type CommentsCollection = typeof commentsCollection;
 
   it('Doc', () => {
-    expectTypeOf<Doc<AuthorsCollection, 'read'>>().toEqualTypeOf<{
+    expectTypeOf<Doc<AuthorsCollection>>().toEqualTypeOf<{
       id: [string];
       data: { name: string; registeredAt: Date };
     }>();
@@ -43,14 +43,14 @@ describe('repository', () => {
     }>();
 
     // read model type should be always compatible to write model
-    expectTypeOf<Doc<AuthorsCollection, 'read'>>().toExtend<Doc<AuthorsCollection, 'write'>>();
-    expectTypeOf<Doc<PostsCollection, 'read'>>().toExtend<Doc<PostsCollection, 'write'>>();
-    expectTypeOf<Doc<CommentsCollection, 'read'>>().toExtend<Doc<CommentsCollection, 'write'>>();
+    expectTypeOf<Doc<AuthorsCollection>>().toExtend<Doc<AuthorsCollection, 'write'>>();
+    expectTypeOf<Doc<PostsCollection>>().toExtend<Doc<PostsCollection, 'write'>>();
+    expectTypeOf<Doc<CommentsCollection>>().toExtend<Doc<CommentsCollection, 'write'>>();
 
     // TODO: this assertion should be passed
     (<T extends Collection>() => {
       // @ts-expect-error -- TODO: this assertion should be passed once generic constraint is resolved
-      expectTypeOf<Doc<T, 'read'>>().toExtend<Doc<T, 'write'>>();
+      expectTypeOf<Doc<T>>().toExtend<Doc<T, 'write'>>();
     })();
   });
 

--- a/packages/firestore-repository/src/repository.ts
+++ b/packages/firestore-repository/src/repository.ts
@@ -1,6 +1,6 @@
 import type { Aggregated, AggregateSpec } from './aggregate.js';
 import type { Query } from './query.js';
-import { Collection, DocumentSchema, FieldValue, MapType, RootCollection } from './schema.js';
+import { Collection, FieldValue, MapType, RootCollection } from './schema.js';
 import type { ToStringTuple } from './util.js';
 
 /**
@@ -73,7 +73,7 @@ export interface Repository<
 /** A mapper that converts between Firestore documents and application models */
 export type Mapper<T extends Collection = Collection, Model extends AppModel = AppModel> = {
   toDocRef: (id: Model['id']) => DocRef<T>;
-  fromFirestore: (doc: Doc<T, 'read'>) => Model['read'];
+  fromFirestore: (doc: Doc<T>) => Model['read'];
   toFirestore: (model: Model['write']) => Doc<T, 'write'>;
 };
 
@@ -104,20 +104,20 @@ export type PlainRepository<
 export type PlainModel<T extends Collection> = {
   id: DocRef<T>;
   write: Doc<T, 'write'>;
-  read: Doc<T, 'read'>;
+  read: Doc<T>;
 };
 
 /** A plain model for root collections where the id is a single string */
 export type RootCollectionPlainModel<T extends Collection> = {
   id: string;
-  write: { id: string; data: DocData<T['schema'], 'write'> };
-  read: { id: string; data: DocData<T['schema'], 'read'> };
+  write: { id: string; data: DocData<T, 'write'> };
+  read: { id: string; data: DocData<T> };
 };
 
 /** A Firestore document */
-export type Doc<T extends Collection, Mode extends 'read' | 'write'> = {
+export type Doc<T extends Collection, Mode extends 'read' | 'write' = 'read'> = {
   id: DocRef<T>;
-  data: DocData<T['schema'], Mode>;
+  data: DocData<T, Mode>;
 };
 
 /** A document reference represented as a tuple of document IDs */
@@ -126,11 +126,11 @@ export type DocRef<T extends Collection> = [...ParentDocRef<T>, string];
 /** A parent document reference of a subcollection */
 export type ParentDocRef<T extends Collection> = ToStringTuple<T['parent']>;
 
-/** The resolved TypeScript type of  document's data, derived from a schema. In write mode, fields additionally accept server-side operations (e.g. ServerTimestamp, Increment). */
+/** The resolved TypeScript type of the document's data, derived from a schema. In write mode, fields additionally accept server-side operations (e.g. ServerTimestamp, Increment). */
 export type DocData<
-  Schema extends DocumentSchema = DocumentSchema,
-  Mode extends 'read' | 'write' = 'read' | 'write',
-> = FieldValue<MapType<Schema>, Mode>;
+  T extends Collection = Collection,
+  Mode extends 'read' | 'write' = 'read',
+> = FieldValue<MapType<T['schema']>, Mode>;
 
 /** Creates a plain mapper that passes documents through without transformation */
 export const plainMapper = <T extends Collection>(_collection: T): Mapper<T, PlainModel<T>> => ({

--- a/packages/google-cloud-firestore/src/index.bench.ts
+++ b/packages/google-cloud-firestore/src/index.bench.ts
@@ -16,15 +16,15 @@ describe('repository', () => {
   const collection = uniqueCollection(authorsCollection);
   const repository = repositoryWithMapper(db, collection, plainMapper(collection));
 
-  const doc1: Doc<typeof collection, 'read'> = {
+  const doc1: Doc<typeof collection> = {
     id: ['1'],
     data: { name: 'author1', profile: { age: 20 }, rank: 1, tag: ['a', 'b'] },
   };
-  const doc2: Doc<typeof collection, 'read'> = {
+  const doc2: Doc<typeof collection> = {
     id: ['2'],
     data: { name: 'author2', profile: { age: 30 }, rank: 2, tag: ['b', 'c'] },
   };
-  const doc3: Doc<typeof collection, 'read'> = {
+  const doc3: Doc<typeof collection> = {
     id: ['3'],
     data: { name: 'author3', profile: { age: 40 }, rank: 1, tag: ['c', 'd'] },
   };

--- a/packages/google-cloud-firestore/src/index.ts
+++ b/packages/google-cloud-firestore/src/index.ts
@@ -313,7 +313,7 @@ const buildFirestoreUtilities = <T extends Collection>(db: firestore.Firestore, 
     },
   };
   const fromFirestore = {
-    documentMustExist: (document: firestore.DocumentSnapshot): Doc<T, 'read'> => {
+    documentMustExist: (document: firestore.DocumentSnapshot): Doc<T> => {
       const data = document.data();
       if (!data) {
         throw new Error('document must exist');
@@ -321,10 +321,10 @@ const buildFirestoreUtilities = <T extends Collection>(db: firestore.Firestore, 
       return {
         id: fromFirestore.docRef(document.ref),
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Zod output is typed by schema
-        data: decodeSchema.parse(data) as DocData<T['schema'], 'read'>,
+        data: decodeSchema.parse(data) as DocData<T>,
       };
     },
-    document: (document: firestore.DocumentSnapshot): Doc<T, 'read'> | undefined => {
+    document: (document: firestore.DocumentSnapshot): Doc<T> | undefined => {
       if (!document.exists) {
         return undefined;
       }


### PR DESCRIPTION
## Summary
- Rename `Doc.ref` field to `Doc.id` for clearer semantics
- Make `Mode` type parameter of `Doc<T, Mode>` and `DocData<T, Mode>` optional with default `'read'`, allowing callers to omit the parameter when read mode is intended

## Test plan
- [ ] Existing type tests pass (`Doc<T>` resolves identically to `Doc<T, 'read'>`)
- [ ] All spec tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)