### PR TITLE
Point Zed's formatter at oxfmt

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,10 @@
 {
   "auto_install_extensions": { "oxc": true },
-  "lsp": { "oxlint": { "initialization_options": { "settings": { "typeAware": true } } } }
+  "lsp": { "oxlint": { "initialization_options": { "settings": { "typeAware": true } } } },
+  "formatter": {
+    "external": {
+      "command": "pnpm",
+      "arguments": ["exec", "oxfmt", "--stdin-filepath", "{buffer_path}"]
+    }
+  }
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -3,8 +3,8 @@
   "lsp": { "oxlint": { "initialization_options": { "settings": { "typeAware": true } } } },
   "formatter": {
     "external": {
-      "command": "pnpm",
-      "arguments": ["exec", "oxfmt", "--stdin-filepath", "{buffer_path}"]
+      "command": "node_modules/.bin/oxfmt",
+      "arguments": ["--stdin-filepath", "{buffer_path}"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Without a `formatter` entry, Zed falls back to Prettier on save, which reformats files in a way that diverges heavily from the project's `oxfmt` output — every save produced a large unrelated diff.
- Wire Zed's external formatter to `pnpm exec oxfmt --stdin-filepath {buffer_path}` so save-format matches `pnpm check:fmt` / `pnpm fix:fmt`.

## Test plan
- [ ] Open a `.ts` file in Zed, save, and confirm no spurious diff is produced.
- [ ] Run `pnpm check:fmt` after saving and confirm it passes.