### PR TITLE
Enable typescript/switch-exhaustiveness-check

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,6 +10,10 @@
     "typescript/no-explicit-any": "error",
     "typescript/no-non-null-assertion": "error",
     "typescript/no-unsafe-type-assertion": "error",
+    "typescript/switch-exhaustiveness-check": [
+      "error",
+      { "considerDefaultExhaustiveForUnions": false, "requireDefaultForNonUnion": true }
+    ],
     "typescript/no-meaningless-void-operator": "off",
     "typescript/restrict-template-expressions": "off",
     "typescript/no-duplicate-type-constituents": "off"


### PR DESCRIPTION
Enables `typescript/switch-exhaustiveness-check` (type-aware) in `.oxlintrc.json`:

- `considerDefaultExhaustiveForUnions: false` — a `default` clause does not count as covering the remaining union members; every member must be enumerated explicitly.
- `requireDefaultForNonUnion: true` — switches over non-union types (e.g. `string`) must have a `default`.

The intended style is exhaustive `case`s with `default` reserved for `assertNever(...)`, so adding a member to a union surfaces every handling site as a lint error instead of silently falling through. `main` already passes with the rule enabled (0 errors).

Split out of the `pipeline-query` branch so it can land first; the accompanying coding-guideline section follows with that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)