### PR TITLE
Implement the select stage end-to-end

### DIFF
--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -49,6 +49,32 @@ typescript/no-unsafe-type-assertion` comment stating the specific compiler
   rules, and oxlint's custom JS plugins don't expose type information. Until
   such a rule exists, it is upheld by review.
 
+## Type-level / runtime mirroring
+
+Some computations exist twice: once in the type system (e.g.
+`BuildSelectionSchema`) and once at runtime (e.g. `buildSelectionSchema`),
+bridged by a type assertion. The two MUST stay in lockstep — a divergence makes
+the types lie about runtime values. To keep them checkable:
+
+- **Mirror the decomposition, not just the result.** Give every type-level
+  operator a runtime counterpart with the same name and the same structure:
+  if the type is `FoldSelections<Context, DropOverriddenSelections<Args>>`,
+  the runtime is `foldSelections(schema, dropOverriddenSelections(args))` —
+  each helper pairs 1:1 with its type-level twin
+  (`PathToSchema`/`pathToSchema`, `MergeSchemas`/`mergeSchemas`, ...), so each
+  step can be reviewed against its twin, including branch-for-branch behavior
+  (e.g. a per-recursion-level guard in the type must sit at the same level in
+  the runtime helper).
+- **Confine the bridging assertion to the entry point** (the one function that
+  returns the type-level result), never inside the helpers.
+- **Test both sides against one oracle.** For each case, write a single
+  hand-written expected value and assert it twice: `toStrictEqual(oracle)`
+  checks the runtime value, `expectTypeOf(actual).toEqualTypeOf(oracle)`
+  checks the type-level computation (the function's return type IS the
+  type-level operator applied to the inputs). If either side drifts, one of
+  the two assertions fails. See `buildSelectionSchema (runtime)` in
+  `pipelines/selection.test.ts`.
+
 ## Declaration order
 
 - Order declarations within a file **top-down by abstraction level** (the

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -133,10 +133,13 @@ Key points (probed on `enterprise-native-playground`, `@google-cloud/firestore@8
   2026-07): `field("name").as("__name__")` →
   `INVALID_ARGUMENT: Stage 'select': field name '__name__' is reserved and can
 not be overwritten.` — the `.as("__name__")` row in the table above works
-  only because the source is `field("__name__")` itself. Accordingly the
-  repository bans `'__name__'` as an alias at the type level
-  (`ExpressionBase.as`), including the legal self re-attach, because `select`
-  is currently modelled as unconditionally identity-dropping.
+  only because the source is `field("__name__")` itself. The repository
+  deliberately does **not** guard this (neither type- nor runtime-level): the
+  backend's own validation is authoritative and fails loudly, so a client
+  check would only duplicate it. The guiding rule: type-ban only what would
+  **silently succeed** against the type model (bare `'__name__'` selections,
+  which re-attach identity while `select` claims `Id = undefined`); leave
+  loud failures to the backend.
 - **A nested `'__name__'` path segment is NOT special** (probed 2026-07):
   `field("name").as("a.__name__")` succeeds and lands as an ordinary map key —
   `{ a: { __name__: "alice" } }`. Only the top-level output name is reserved.

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -129,6 +129,17 @@ Key points (probed on `enterprise-native-playground`, `@google-cloud/firestore@8
   fields) and the metadata is **not** restored.
 - Wrapping in an expression (e.g. `documentId(...)`) and renaming also fails to
   restore metadata.
+- **Overwriting a reserved name with any other value is an error** (probed
+  2026-07): `field("name").as("__name__")` →
+  `INVALID_ARGUMENT: Stage 'select': field name '__name__' is reserved and can
+not be overwritten.` — the `.as("__name__")` row in the table above works
+  only because the source is `field("__name__")` itself. Accordingly the
+  repository bans `'__name__'` as an alias at the type level
+  (`ExpressionBase.as`), including the legal self re-attach, because `select`
+  is currently modelled as unconditionally identity-dropping.
+- **A nested `'__name__'` path segment is NOT special** (probed 2026-07):
+  `field("name").as("a.__name__")` succeeds and lands as an ordinary map key —
+  `{ a: { __name__: "alice" } }`. Only the top-level output name is reserved.
 - **No recovery once dropped**: `select("name") → select("__name__")` yields no
   identity (the first `select` already discarded `__name__`), whereas
   `select("name", "__name__") → select("__name__")` keeps it. The ratchet holds

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -78,6 +78,14 @@ FIRESTORE_REPOSITORY_INTEGRATION_TEST_DB=enterprise-native-playground \
 pnpm exec vitest run -t 'pipeline specification'
 ```
 
+The firebase (client) adapter's pipeline suite additionally requires
+`FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY` (a real Firebase API
+key): the client SDK cannot reach a non-emulator DB without one (and is
+subject to security rules), unlike the admin SDK which authenticates via ADC
+and bypasses rules. Without the extra var the firebase pipeline suite is
+skipped, so a root-level `pnpm test` with only the two shared vars runs the
+admin adapter live and skips the client adapter instead of failing.
+
 Without those two env vars the pipeline `describe` is `skipIf`-skipped. See the
 test-infra note under "Per-SDK adapters" for why the admin SDK can target the
 real backend while the repository tests still use the emulator in the same run.

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -57,8 +57,10 @@ to reach a non-emulator DB.
   runtime counterpart of the `FieldTypeOfPath` type), covered by
   `schema.field-type-of-path.test.ts`.
 - `select` / `addFields` / `distinct` use `const` type params, so callback
-  selections infer as tuples without `as const`. Only bare data-field-path
-  string selections work so far (no `.as(...)` / aliased expressions yet).
+  selections infer as tuples without `as const`. `select` is fully implemented
+  (bare paths, nested dotted paths, `.as(...)` aliased expressions, last-wins
+  conflicts) and verified live; every expression node now carries an SDK-style
+  `.as(alias)` producing an `ExpressionWithAlias`.
 
 **Executors** (`packages/{firebase-js-sdk,google-cloud-firestore}/src/pipeline.ts`):
 `executor(db)` walks the stage chain into `db.pipeline()...`, translates `sort`
@@ -236,8 +238,8 @@ Input stages (the `input` stage now carries an `InputSource` payload — see
 - [x] `collection` — builds `{ kind: 'collection', collection, parent }`;
       covers root collections and specific subcollection instances (the trailing
       `parent` doc-ids argument is required iff the definition is a subcollection).
-- [ ] `collectionGroup(id)` — builds `{ kind: 'collectionGroup', ... }`;
-      executor support not implemented.
+- [x] `collectionGroup(id)` — builds `{ kind: 'collectionGroup', ... }`;
+      executors run it via `db.pipeline().collectionGroup(name)`.
 - [ ] `database()` / `documents([...refs])` — source payloads are stubbed
       (`{ kind: 'database' | 'documents' }`, no data); executor throws.
 - [ ] `literals([...])` — stubbed (`{ kind: 'literals' }`); executor throws.
@@ -245,7 +247,12 @@ Input stages (the `input` stage now carries an `InputSource` payload — see
 Transformation stages already stubbed:
 
 - [ ] `where(condition)` — real runtime + AST node + tests.
-- [ ] `select(...)` — runtime + identity break + tests.
+- [x] `select(...)` — runtime schema fold (`buildSelectionSchema`, the runtime
+      mirror of `BuildSelectionSchema`), stage AST carries conflict-resolved
+      selections, executors translate to `sdk.select(...)`, rows decode with
+      the pipeline's leaf schema. Verified live (nested dotted selects come
+      back **nested**, matching `PathToSchema`; last-wins matches the type
+      tests; `.as()` field + computed `equal` expressions work).
 - [ ] `addFields(...)` — Context augmentation + identity preserve.
 - [ ] `removeFields(...)` — Context shrinkage + identity preserve.
 - [ ] `distinct(...)` — Context shrinkage + identity break.

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -315,6 +315,25 @@ Deferred to a later iteration (still tracked here, not currently in scope):
 
 ## Expressions — remaining gaps
 
+- [ ] **Restructure `FunctionCall` into shape-grouped classes when the ~85
+      factories return.** Decided design (2026-07): don't do one class per
+      function (SDK-style, ~85 classes, giant `Expression` union) and don't
+      keep the current single `FunctionCall` with untyped `args: Expression[]`
+      (forces runtime arity guards in every executor — see
+      `toSdkFunctionCall`'s `left === undefined` checks). Instead, one class
+      per **shape** (`UnaryFunction` / `BinaryFunction` / `VariadicFunction` /
+      individual classes for irregulars like `findNearest` / `cond`), each
+      with typed payload fields (`left` / `right` / `operands`) and a
+      per-shape `name: <Shape>FunctionName` string-literal union. - Executors then translate each shape with a
+      `Record<BinaryFunctionName, (l, r) => SdkExpr>` lookup table — the
+      `Record` requires every key, giving the same exhaustiveness guarantee
+      as `assertNever` without per-function `case`s, and the arity guards
+      disappear into the types. - Rationale: a Visitor and a `name` string-union switch are the same
+      case-analysis over a closed sum (same side of the expression problem);
+      the only substantive win available is typed payloads, and shape
+      granularity gets it with ~5 classes instead of ~85. Per-function
+      individuality (operand/return typing like `equal`'s overloads) stays
+      in the factory signatures.
 - [ ] Per-op numeric return type refinement (Int64-pair → Int64 vs
       auto-widen to Double) — TODO comments already in `expression.ts`.
 - [ ] Improve `constant(value)` type inference from runtime value

--- a/packages/firebase-js-sdk/src/index.test.ts
+++ b/packages/firebase-js-sdk/src/index.test.ts
@@ -42,14 +42,22 @@ describe('repository', async () => {
   });
 
   // Pipeline queries require a Firestore Enterprise database (the emulator
-  // cannot run them). These tests run only when both FIRESTORE_REPOSITORY_INTEGRATION_TEST_*
-  // env vars are set; otherwise vitest reports them as skipped.
+  // cannot run them). Unlike the admin SDK (which authenticates via ADC and
+  // bypasses security rules), the client SDK needs a real Firebase API key —
+  // so these tests additionally require FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY
+  // on top of the FIRESTORE_REPOSITORY_INTEGRATION_TEST_* vars; otherwise
+  // vitest reports them as skipped (and a root `pnpm test` with only the two
+  // shared vars set still runs the admin adapter live without failing here).
   const enterpriseProject = process.env['FIRESTORE_REPOSITORY_INTEGRATION_TEST_PROJECT'];
   const enterpriseDbId = process.env['FIRESTORE_REPOSITORY_INTEGRATION_TEST_DB'];
-  describe.skipIf(!enterpriseProject || !enterpriseDbId)('pipeline', () => {
+  const clientApiKey = process.env['FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY'];
+  describe.skipIf(!enterpriseProject || !enterpriseDbId || !clientApiKey)('pipeline', () => {
     // A separate app/db targeting the real Enterprise backend (not the emulator).
     const enterpriseDb = getFirestore(
-      initializeApp({ projectId: enterpriseProject ?? '' }, 'pipeline-enterprise'),
+      initializeApp(
+        { projectId: enterpriseProject ?? '', apiKey: clientApiKey ?? '' },
+        'pipeline-enterprise',
+      ),
       enterpriseDbId ?? '(default)',
     );
     definePipelineSpecificationTests<Env>({

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -1,10 +1,19 @@
 import type { Firestore } from '@firebase/firestore';
 import {
+  constant as sdkConstant,
+  equal as sdkEqual,
   execute as executePipeline,
   field,
+  type Expression as SdkExpression,
   type Pipeline as SdkPipeline,
+  type Selectable as SdkSelectable,
 } from '@firebase/firestore/pipelines';
 import { collectionPath } from 'firestore-repository/path';
+import type {
+  Expression,
+  ExpressionWithAlias,
+  FunctionCall,
+} from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
   Pipeline,
@@ -16,6 +25,7 @@ import type { TransformStage } from 'firestore-repository/pipelines/stage';
 import type { Collection, DocumentSchema } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
+import { buildDecodeSchema } from './codec.js';
 import { buildFirestoreUtilities } from './index.js';
 
 /**
@@ -56,9 +66,12 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
     }
 
     const { fromFirestore } = buildFirestoreUtilities(db, collection);
+    // Rows are decoded with the pipeline's FINAL schema (the leaf node's), not
+    // the source collection's — stages like `select` reshape the rows.
+    const decodeRow = buildDecodeSchema(pipeline.node.schema);
     const snapshot = await executePipeline(sdk);
     return snapshot.results.map((r) => {
-      const data = fromFirestore.decode(r.data());
+      const data = decodeRow.parse(r.data());
       const id = r.ref ? fromFirestore.docRef(r.ref) : undefined;
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `data`/`id` are runtime values matching the caller's Schema/Id, which the compiler cannot prove here
       return (id === undefined ? { data } : { data, id }) as PipelineResult<Schema, Id>;
@@ -73,8 +86,14 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       const [first, ...rest] = stage.orderings.map(toSdkOrdering);
       return first === undefined ? sdk : sdk.sort(first, ...rest);
     }
+    case 'select': {
+      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      if (first === undefined) {
+        throw new Error('firebase pipeline executor: select requires at least one selection');
+      }
+      return sdk.select(first, ...rest);
+    }
     case 'where':
-    case 'select':
     case 'addFields':
     case 'removeFields':
     case 'limit':
@@ -91,6 +110,43 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       throw new Error(`firebase pipeline executor: stage "${stage.kind}" not supported yet`);
     default:
       return assertNever(stage);
+  }
+};
+
+/** Translates a selection (bare path or aliased expression) into an SDK selectable. */
+const toSdkSelectable = (s: string | ExpressionWithAlias): SdkSelectable | string =>
+  typeof s === 'string' ? s : toSdkExpression(s.expression).as(s.alias);
+
+/** Translates the repository expression AST into an SDK expression. */
+const toSdkExpression = (expression: Expression): SdkExpression => {
+  switch (expression.kind) {
+    case 'field':
+      return field(expression.path);
+    case 'constant':
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `Constant.value` is untyped (TODO in expression.ts); the SDK's `constant` overloads want a concrete primitive, but the raw value passes through unchanged at runtime
+      return sdkConstant(expression.value as string);
+    case 'functionCall':
+      return toSdkFunctionCall(expression);
+    default:
+      return assertNever(expression);
+  }
+};
+
+// `FunctionCall.name` is an open string (not a union), so `default` is the
+// unsupported-function guard rather than `assertNever`.
+const toSdkFunctionCall = (expression: FunctionCall): SdkExpression => {
+  switch (expression.name) {
+    case 'equal': {
+      const [left, right] = expression.args;
+      if (left === undefined || right === undefined) {
+        throw new Error('firebase pipeline executor: equal requires two arguments');
+      }
+      return sdkEqual(toSdkExpression(left), toSdkExpression(right));
+    }
+    default:
+      throw new Error(
+        `firebase pipeline executor: function "${expression.name}" not supported yet`,
+      );
   }
 };
 

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -137,6 +137,9 @@ const toSdkExpression = (expression: Expression): SdkExpression => {
 const toSdkFunctionCall = (expression: FunctionCall): SdkExpression => {
   switch (expression.name) {
     case 'equal': {
+      // TODO: this runtime arity guard disappears once FunctionCall is
+      // restructured into shape-grouped classes with typed payload fields —
+      // see "Restructure FunctionCall" in docs/plan/pipeline-query.md.
       const [left, right] = expression.args;
       if (left === undefined || right === undefined) {
         throw new Error('firebase pipeline executor: equal requires two arguments');

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,6 +1,6 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
-import { alias, constant, equal } from '../pipelines/expression.js';
+import { constant, equal } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
   Pipeline,
@@ -164,7 +164,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
 
       it('projects a field expression bound to an alias', async () => {
         await expectPipeline(
-          source().select((field) => [alias(field('name'), 'authorName')]),
+          source().select((field) => [field('name').as('authorName')]),
           [
             { data: { authorName: 'alice' } },
             { data: { authorName: 'bob' } },
@@ -176,10 +176,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
 
       it('projects a computed expression bound to an alias', async () => {
         await expectPipeline(
-          source().select((field) => [
-            'name',
-            alias(equal(field('rank'), constant(2)), 'isSecond'),
-          ]),
+          source().select((field) => ['name', equal(field('rank'), constant(2)).as('isSecond')]),
           [
             { data: { name: 'alice', isSecond: false } },
             { data: { name: 'bob', isSecond: true } },
@@ -196,7 +193,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       it('last-wins: the same output name selected twice', async () => {
         // The later aliased expression replaces the earlier field selection.
         await expectPipeline(
-          source().select((field) => ['name', alias(field('rank'), 'name')]),
+          source().select((field) => ['name', field('rank').as('name')]),
           [{ data: { name: 1 } }, { data: { name: 2 } }, { data: { name: 3 } }],
           { ordered: false },
         );

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,5 +1,6 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
+import { constant, equal } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
   Pipeline,
@@ -106,6 +107,132 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         await expectPipeline(
           source().sort((field) => [desc(field('rank'))]),
           [a3, a2, a1],
+        );
+      });
+    });
+
+    describe('select', () => {
+      it('projects a single top-level field, dropping row identity', async () => {
+        // `select` breaks read-identity: the result rows carry no `id`.
+        await expectPipeline(
+          source().select(() => ['name']),
+          [{ data: { name: 'alice' } }, { data: { name: 'bob' } }, { data: { name: 'carol' } }],
+          { ordered: false },
+        );
+      });
+
+      it('projects multiple fields', async () => {
+        await expectPipeline(
+          source().select(() => ['name', 'rank']),
+          [
+            { data: { name: 'alice', rank: 1 } },
+            { data: { name: 'bob', rank: 2 } },
+            { data: { name: 'carol', rank: 3 } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('projects a nested (dotted) field, keeping the nested shape', async () => {
+        // A dotted path selects the nested value at its original position —
+        // `{ profile: { age } }`, not a flat `'profile.age'` key (mirrors
+        // `BuildSelectionSchema` / `PathToSchema`).
+        await expectPipeline(
+          source().select(() => ['profile.age']),
+          [
+            { data: { profile: { age: 20 } } },
+            { data: { profile: { age: 30 } } },
+            { data: { profile: { age: 40 } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('merges sibling selections under the same parent map', async () => {
+        // Two dotted paths sharing a parent deep-merge into one nested map
+        // (mirrors `MergeSchemas`). `gender` is optional and absent on a2.
+        await expectPipeline(
+          source().select(() => ['profile.age', 'profile.gender']),
+          [
+            { data: { profile: { age: 20, gender: 'female' } } },
+            { data: { profile: { age: 30 } } },
+            { data: { profile: { age: 40, gender: 'male' } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('projects a field expression aliased via `.as()`', async () => {
+        await expectPipeline(
+          source().select((field) => [field('name').as('authorName')]),
+          [
+            { data: { authorName: 'alice' } },
+            { data: { authorName: 'bob' } },
+            { data: { authorName: 'carol' } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('projects a computed expression aliased via `.as()`', async () => {
+        await expectPipeline(
+          source().select((field) => ['name', equal(field('rank'), constant(2)).as('isSecond')]),
+          [
+            { data: { name: 'alice', isSecond: false } },
+            { data: { name: 'bob', isSecond: true } },
+            { data: { name: 'carol', isSecond: false } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      // The three last-wins cases mirror the `BuildSelectionSchema` type tests
+      // in `selection.test.ts` — the runtime rows must match what the type
+      // computes.
+
+      it('last-wins: the same output name selected twice', async () => {
+        // The later aliased expression replaces the earlier field selection.
+        await expectPipeline(
+          source().select((field) => ['name', field('rank').as('name')]),
+          [{ data: { name: 1 } }, { data: { name: 2 } }, { data: { name: 3 } }],
+          { ordered: false },
+        );
+      });
+
+      it('last-wins: a child path after its parent narrows to the child', async () => {
+        await expectPipeline(
+          source().select(() => ['profile', 'profile.age']),
+          [
+            { data: { profile: { age: 20 } } },
+            { data: { profile: { age: 30 } } },
+            { data: { profile: { age: 40 } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('last-wins: a parent path after its child selects the full subtree', async () => {
+        await expectPipeline(
+          source().select(() => ['profile.age', 'profile']),
+          [
+            { data: { profile: { age: 20, gender: 'female' } } },
+            { data: { profile: { age: 30 } } },
+            { data: { profile: { age: 40, gender: 'male' } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('composes with a subsequent sort over the projected schema', async () => {
+        await expectPipeline(
+          source()
+            .select(() => ['name', 'rank'])
+            .sort((field) => [desc(field('rank'))]),
+          [
+            { data: { name: 'carol', rank: 3 } },
+            { data: { name: 'bob', rank: 2 } },
+            { data: { name: 'alice', rank: 1 } },
+          ],
         );
       });
     });

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,6 +1,6 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
-import { constant, equal } from '../pipelines/expression.js';
+import { alias, constant, equal } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
   Pipeline,
@@ -162,9 +162,9 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
-      it('projects a field expression aliased via `.as()`', async () => {
+      it('projects a field expression bound to an alias', async () => {
         await expectPipeline(
-          source().select((field) => [field('name').as('authorName')]),
+          source().select((field) => [alias(field('name'), 'authorName')]),
           [
             { data: { authorName: 'alice' } },
             { data: { authorName: 'bob' } },
@@ -174,9 +174,12 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
-      it('projects a computed expression aliased via `.as()`', async () => {
+      it('projects a computed expression bound to an alias', async () => {
         await expectPipeline(
-          source().select((field) => ['name', equal(field('rank'), constant(2)).as('isSecond')]),
+          source().select((field) => [
+            'name',
+            alias(equal(field('rank'), constant(2)), 'isSecond'),
+          ]),
           [
             { data: { name: 'alice', isSecond: false } },
             { data: { name: 'bob', isSecond: true } },
@@ -193,7 +196,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       it('last-wins: the same output name selected twice', async () => {
         // The later aliased expression replaces the earlier field selection.
         await expectPipeline(
-          source().select((field) => ['name', field('rank').as('name')]),
+          source().select((field) => ['name', alias(field('rank'), 'name')]),
           [{ data: { name: 1 } }, { data: { name: 2 } }, { data: { name: 3 } }],
           { ordered: false },
         );

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -5,53 +5,87 @@ import { bool, type BoolType, type DoubleType, type FieldType, type Int64Type } 
 // SDK expression factories (arithmetic / string / array / map / timestamp /
 // vector / ...) was removed pending a rework — see docs/plan/pipeline-query.md.
 
+/**
+ * An expression AST node. A discriminated union **of classes** (see
+ * {@link ExpressionBase}): keep this union — not the base class — as the
+ * public type, so `switch (expr.kind)` narrowing and `assertNever`
+ * exhaustiveness keep working (a base-class-typed value would not narrow).
+ */
 export type Expression<T extends FieldType = FieldType> = FunctionCall<T> | Constant<T> | Field<T>;
 
 /**
  * An expression bound to an output name — the aliased form of a `select` /
  * `addFields` selection (the counterpart of the SDK's `expr.as(alias)`
- * selectable). Built with {@link alias}.
+ * selectable). Built with {@link ExpressionBase.as}.
  */
-export type ExpressionWithAlias<T extends FieldType = FieldType, Alias extends string = string> = {
-  expression: Expression<T>;
-  alias: Alias;
-};
+export type ExpressionWithAlias<
+  T extends FieldType = FieldType,
+  Alias extends string = string,
+> = WithAlias<Expression<T>, Alias>;
+
+/** The `{ expression, alias }` pair, generic over the expression node type. */
+type WithAlias<E, Alias extends string> = { expression: E; alias: Alias };
 
 /**
- * Binds an expression to an output name: `alias(field('rank'), 'r')` /
- * `alias(equal(...), 'flag')` build an {@link ExpressionWithAlias} usable as a
- * `select` / `addFields` selection. A standalone function (not a method on the
- * expression nodes) so the AST stays plain data.
+ * Base class of all expression nodes, carrying the SDK-style fluent methods
+ * (`field('rank').as('r')`, `equal(...).as('flag')`). The polymorphic `this`
+ * in the return type resolves to the concrete node class at the call site, so
+ * the result satisfies {@link ExpressionWithAlias} without any assertion.
  */
-export const alias = <T extends FieldType, Alias extends string>(
-  expression: Expression<T>,
-  alias: Alias,
-): ExpressionWithAlias<T, Alias> => ({ expression, alias });
+export abstract class ExpressionBase {
+  /** Binds this expression to an output name, forming a `select` / `addFields` selection. */
+  as<Alias extends string>(alias: Alias): WithAlias<this, Alias> {
+    return { expression: this, alias };
+  }
+}
 
-export type Field<T extends FieldType = FieldType, Path extends string = string> = {
-  kind: 'field';
-  type: T;
-  path: Path;
-};
+export class Field<
+  T extends FieldType = FieldType,
+  Path extends string = string,
+> extends ExpressionBase {
+  readonly kind = 'field';
+  constructor(
+    readonly type: T,
+    readonly path: Path,
+  ) {
+    super();
+  }
+}
 
 /** Builds a field-reference expression node carrying its resolved `type`. */
 export const field = <T extends FieldType, Path extends string>(
   type: T,
   path: Path,
-): Field<T, Path> => ({ kind: 'field', type, path });
+): Field<T, Path> => new Field(type, path);
 
-export type Constant<T extends FieldType> = {
-  kind: 'constant';
-  type: T;
-  value: unknown; // TODO add type
-};
+export class Constant<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'constant';
+  constructor(
+    readonly type: T,
+    readonly value: unknown, // TODO add type
+  ) {
+    super();
+  }
+}
 
-export type FunctionCall<T extends FieldType = FieldType> = {
-  kind: 'functionCall';
-  name: string;
-  type: T;
-  args: readonly Expression[];
-};
+export const constant = <T extends FieldType>(value: unknown): Constant<T> =>
+  new Constant(
+    // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
+    'todo' as unknown as T,
+    value,
+  );
+
+export class FunctionCall<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'functionCall';
+  constructor(
+    readonly name: string,
+    readonly type: T,
+    readonly args: readonly Expression[],
+  ) {
+    super();
+  }
+}
 
 /** Convenience union for numeric expression inputs. */
 type NumericType = Int64Type | DoubleType;
@@ -60,15 +94,7 @@ const fn = <T extends FieldType>(
   name: string,
   type: T,
   args: readonly Expression[],
-): FunctionCall<T> => ({ kind: 'functionCall', name, type, args });
-
-export const constant = <T extends FieldType>(value: unknown): Constant<T> => ({
-  kind: 'constant',
-  // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
-  type: 'todo' as unknown as T,
-  value,
-});
+): FunctionCall<T> => new FunctionCall(name, type, args);
 
 // A comparison op has two overloads:
 //   1) numeric-pair — lets Int64 and Double mix while rejecting numeric-vs-other.

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -33,11 +33,32 @@ type WithAlias<E, Alias extends string> = { expression: E; alias: Alias };
  * the result satisfies {@link ExpressionWithAlias} without any assertion.
  */
 export abstract class ExpressionBase {
-  /** Binds this expression to an output name, forming a `select` / `addFields` selection. */
-  as<Alias extends string>(alias: Alias): WithAlias<this, Alias> {
+  /**
+   * Binds this expression to an output name, forming a `select` / `addFields`
+   * selection. The reserved `'__name__'` is rejected at the type level: the
+   * backend refuses overwriting it with any other value (`INVALID_ARGUMENT:
+   * field name '__name__' is reserved and can not be overwritten` — verified
+   * live). The one call the backend does allow —
+   * `field('__name__').as('__name__')`, an identity re-attach — is rejected
+   * too, deliberately: `select` is currently modelled as always
+   * identity-dropping (`Id = undefined`), and permitting it would make that
+   * type lie (the conditional-identity model is deferred — see
+   * `docs/pipeline-query-identity-research.md`). A **nested** `'__name__'`
+   * segment (e.g. `'a.__name__'`) is an ordinary map key and stays allowed.
+   */
+  as<Alias extends string>(alias: Alias & ReservedAliasGuard<Alias>): WithAlias<this, Alias> {
     return { expression: this, alias };
   }
 }
+
+/**
+ * Compile-time rejection of the reserved `'__name__'` alias (see
+ * {@link ExpressionBase.as}); the message string becomes the type the invalid
+ * literal fails to satisfy.
+ */
+type ReservedAliasGuard<Alias extends string> = Alias extends '__name__'
+  ? "the reserved '__name__' cannot be used as an alias"
+  : unknown;
 
 export class Field<
   T extends FieldType = FieldType,

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -7,30 +7,56 @@ import { bool, type BoolType, type DoubleType, type FieldType, type Int64Type } 
 
 export type Expression<T extends FieldType = FieldType> = FunctionCall<T> | Constant<T> | Field<T>;
 
+/**
+ * An expression bound to an output name — the aliased form of a `select` /
+ * `addFields` selection (mirrors the SDK's `expr.as(alias)` selectable).
+ */
+export type ExpressionWithAlias<T extends FieldType = FieldType, Alias extends string = string> = {
+  expression: Expression<T>;
+  alias: Alias;
+};
+
+/**
+ * SDK-style aliasing carried by every expression node:
+ * `field('rank').as('r')` / `equal(...).as('flag')` build an
+ * {@link ExpressionWithAlias} usable as a `select` / `addFields` selection.
+ */
+type Aliasable<T extends FieldType> = {
+  as<Alias extends string>(alias: Alias): ExpressionWithAlias<T, Alias>;
+};
+
 export type Field<T extends FieldType = FieldType, Path extends string = string> = {
   kind: 'field';
   type: T;
   path: Path;
-};
+} & Aliasable<T>;
 
 /** Builds a field-reference expression node carrying its resolved `type`. */
 export const field = <T extends FieldType, Path extends string>(
   type: T,
   path: Path,
-): Field<T, Path> => ({ kind: 'field', type, path });
+): Field<T, Path> => {
+  const node: Field<T, Path> = {
+    kind: 'field',
+    type,
+    path,
+    as: (alias) => ({ expression: node, alias }),
+  };
+  return node;
+};
 
 export type Constant<T extends FieldType> = {
   kind: 'constant';
   type: T;
   value: unknown; // TODO add type
-};
+} & Aliasable<T>;
 
 export type FunctionCall<T extends FieldType = FieldType> = {
   kind: 'functionCall';
   name: string;
   type: T;
   args: readonly Expression[];
-};
+} & Aliasable<T>;
 
 /** Convenience union for numeric expression inputs. */
 type NumericType = Int64Type | DoubleType;
@@ -39,15 +65,28 @@ const fn = <T extends FieldType>(
   name: string,
   type: T,
   args: readonly Expression[],
-): FunctionCall<T> => ({ kind: 'functionCall', name, type, args });
+): FunctionCall<T> => {
+  const node: FunctionCall<T> = {
+    kind: 'functionCall',
+    name,
+    type,
+    args,
+    as: (alias) => ({ expression: node, alias }),
+  };
+  return node;
+};
 
-export const constant = <T extends FieldType>(value: unknown): Constant<T> => ({
-  kind: 'constant',
-  // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
-  type: 'todo' as unknown as T,
-  value,
-});
+export const constant = <T extends FieldType>(value: unknown): Constant<T> => {
+  const node: Constant<T> = {
+    kind: 'constant',
+    // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
+    type: 'todo' as unknown as T,
+    value,
+    as: (alias) => ({ expression: node, alias }),
+  };
+  return node;
+};
 
 // A comparison op has two overloads:
 //   1) numeric-pair — lets Int64 and Double mix while rejecting numeric-vs-other.

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -35,30 +35,24 @@ type WithAlias<E, Alias extends string> = { expression: E; alias: Alias };
 export abstract class ExpressionBase {
   /**
    * Binds this expression to an output name, forming a `select` / `addFields`
-   * selection. The reserved `'__name__'` is rejected at the type level: the
-   * backend refuses overwriting it with any other value (`INVALID_ARGUMENT:
-   * field name '__name__' is reserved and can not be overwritten` — verified
-   * live). The one call the backend does allow —
-   * `field('__name__').as('__name__')`, an identity re-attach — is rejected
-   * too, deliberately: `select` is currently modelled as always
-   * identity-dropping (`Id = undefined`), and permitting it would make that
-   * type lie (the conditional-identity model is deferred — see
-   * `docs/pipeline-query-identity-research.md`). A **nested** `'__name__'`
-   * segment (e.g. `'a.__name__'`) is an ordinary map key and stays allowed.
+   * selection.
+   *
+   * The reserved `'__name__'` alias is deliberately NOT modelled here — no
+   * type guard, no runtime guard: the backend rejects overwriting it
+   * (`INVALID_ARGUMENT: field name '__name__' is reserved and can not be
+   * overwritten` — verified live), loudly and at the source of truth, so a
+   * client-side check would only duplicate that validation. (Contrast with
+   * bare `'__name__'` selections, which the backend *accepts* while
+   * re-attaching identity — those ARE type-banned in `Selection`, because
+   * they would silently succeed against `select`'s `Id = undefined` model.
+   * The rule: ban what would silently succeed against the type model; leave
+   * what fails loudly to the backend. See
+   * `docs/pipeline-query-identity-research.md`.)
    */
-  as<Alias extends string>(alias: Alias & ReservedAliasGuard<Alias>): WithAlias<this, Alias> {
+  as<Alias extends string>(alias: Alias): WithAlias<this, Alias> {
     return { expression: this, alias };
   }
 }
-
-/**
- * Compile-time rejection of the reserved `'__name__'` alias (see
- * {@link ExpressionBase.as}); the message string becomes the type the invalid
- * literal fails to satisfy.
- */
-type ReservedAliasGuard<Alias extends string> = Alias extends '__name__'
-  ? "the reserved '__name__' cannot be used as an alias"
-  : unknown;
 
 export class Field<
   T extends FieldType = FieldType,

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -9,7 +9,8 @@ export type Expression<T extends FieldType = FieldType> = FunctionCall<T> | Cons
 
 /**
  * An expression bound to an output name — the aliased form of a `select` /
- * `addFields` selection (mirrors the SDK's `expr.as(alias)` selectable).
+ * `addFields` selection (the counterpart of the SDK's `expr.as(alias)`
+ * selectable). Built with {@link alias}.
  */
 export type ExpressionWithAlias<T extends FieldType = FieldType, Alias extends string = string> = {
   expression: Expression<T>;
@@ -17,46 +18,40 @@ export type ExpressionWithAlias<T extends FieldType = FieldType, Alias extends s
 };
 
 /**
- * SDK-style aliasing carried by every expression node:
- * `field('rank').as('r')` / `equal(...).as('flag')` build an
- * {@link ExpressionWithAlias} usable as a `select` / `addFields` selection.
+ * Binds an expression to an output name: `alias(field('rank'), 'r')` /
+ * `alias(equal(...), 'flag')` build an {@link ExpressionWithAlias} usable as a
+ * `select` / `addFields` selection. A standalone function (not a method on the
+ * expression nodes) so the AST stays plain data.
  */
-type Aliasable<T extends FieldType> = {
-  as<Alias extends string>(alias: Alias): ExpressionWithAlias<T, Alias>;
-};
+export const alias = <T extends FieldType, Alias extends string>(
+  expression: Expression<T>,
+  alias: Alias,
+): ExpressionWithAlias<T, Alias> => ({ expression, alias });
 
 export type Field<T extends FieldType = FieldType, Path extends string = string> = {
   kind: 'field';
   type: T;
   path: Path;
-} & Aliasable<T>;
+};
 
 /** Builds a field-reference expression node carrying its resolved `type`. */
 export const field = <T extends FieldType, Path extends string>(
   type: T,
   path: Path,
-): Field<T, Path> => {
-  const node: Field<T, Path> = {
-    kind: 'field',
-    type,
-    path,
-    as: (alias) => ({ expression: node, alias }),
-  };
-  return node;
-};
+): Field<T, Path> => ({ kind: 'field', type, path });
 
 export type Constant<T extends FieldType> = {
   kind: 'constant';
   type: T;
   value: unknown; // TODO add type
-} & Aliasable<T>;
+};
 
 export type FunctionCall<T extends FieldType = FieldType> = {
   kind: 'functionCall';
   name: string;
   type: T;
   args: readonly Expression[];
-} & Aliasable<T>;
+};
 
 /** Convenience union for numeric expression inputs. */
 type NumericType = Int64Type | DoubleType;
@@ -65,28 +60,15 @@ const fn = <T extends FieldType>(
   name: string,
   type: T,
   args: readonly Expression[],
-): FunctionCall<T> => {
-  const node: FunctionCall<T> = {
-    kind: 'functionCall',
-    name,
-    type,
-    args,
-    as: (alias) => ({ expression: node, alias }),
-  };
-  return node;
-};
+): FunctionCall<T> => ({ kind: 'functionCall', name, type, args });
 
-export const constant = <T extends FieldType>(value: unknown): Constant<T> => {
-  const node: Constant<T> = {
-    kind: 'constant',
-    // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
-    type: 'todo' as unknown as T,
-    value,
-    as: (alias) => ({ expression: node, alias }),
-  };
-  return node;
-};
+export const constant = <T extends FieldType>(value: unknown): Constant<T> => ({
+  kind: 'constant',
+  // TODO: derive the schema type from `value` (e.g. number -> DoubleType, string -> StringType).
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- placeholder result type until the TODO above is implemented (pipeline queries are WIP)
+  type: 'todo' as unknown as T,
+  value,
+});
 
 // A comparison op has two overloads:
 //   1) numeric-pair — lets Int64 and Double mix while rejecting numeric-vs-other.

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -1,11 +1,31 @@
 import { describe, it } from 'vitest';
 
-import { authorsCollection, postsCollection } from '../__test__/specification.js';
+import {
+  type AuthorsCollection,
+  authorsCollection,
+  postsCollection,
+} from '../__test__/specification.js';
+import type { DocRef } from '../repository.js';
+import type { StringType } from '../schema.js';
 import { equal } from './expression.js';
-import { collection } from './index.js';
+import { collection, type Pipeline } from './index.js';
 
 describe('pipeline', () => {
   const base = collection(authorsCollection);
+
+  it('Id is structurally anchored: pipelines with different identities do not interchange', () => {
+    // `Id` appears in a (phantom) property position, not only in recursive
+    // method returns — otherwise TypeScript's coinductive comparison would make
+    // every `Pipeline<Schema, *>` mutually assignable and an identity-dropped
+    // pipeline could pose as identity-preserving (claiming an `id` that does
+    // not exist at runtime).
+    const selected = base.select(() => ['name']);
+
+    // @ts-expect-error -- identity-dropped (`Id = undefined`) cannot pose as identity-preserving
+    const _lie: Pipeline<{ name: StringType }, DocRef<AuthorsCollection>> = selected;
+    // @ts-expect-error -- nor can identity-preserving pose as identity-dropped
+    const _widen: Pipeline<AuthorsCollection['schema'], undefined> = base;
+  });
 
   it('root collections take an optional empty parent; subcollections require one', () => {
     collection(authorsCollection, []); // the empty tuple is a root's valid ParentDocRef: ok

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -15,7 +15,13 @@ import {
 import { AggregateWithAlias } from './aggregate.js';
 import { field, type Expression, type Field } from './expression.js';
 import { Ordering } from './ordering.js';
-import type { BuildAddFieldsSchema, BuildSelectionSchema, Selection } from './selection.js';
+import {
+  type BuildAddFieldsSchema,
+  type BuildSelectionSchema,
+  buildSelectionSchema,
+  dropOverriddenSelections,
+  type Selection,
+} from './selection.js';
 import type { InputStage, TransformStage } from './stage.js';
 
 /**
@@ -99,9 +105,16 @@ export class Pipeline<
    * `createTime` / `updateTime`, is deferred — see `docs/plan/pipeline-query.md`).
    */
   select<const Selections extends readonly Selection<Schema>[]>(
-    _selections: (field: FieldProvider<Schema>) => Selections,
+    selections: (field: FieldProvider<Schema>) => Selections,
   ): Pipeline<BuildSelectionSchema<Schema, Selections>, undefined> {
-    return unimplemented();
+    const resolved = selections(fieldProvider(this.node.schema));
+    return new Pipeline<BuildSelectionSchema<Schema, Selections>, undefined>({
+      schema: buildSelectionSchema(this.node.schema, resolved),
+      // Resolve last-wins here so the stage carries a conflict-free list that
+      // matches the schema (and executors translate it 1:1).
+      stage: { kind: 'select', selections: dropOverriddenSelections(resolved) },
+      parent: this.node,
+    });
   }
   addFields<const Selections extends readonly Selection<Schema>[]>(
     _fields: (field: FieldProvider<Schema>) => Selections,

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -61,6 +61,17 @@ export class Pipeline<
   Id extends PipelineRowIdentity = PipelineRowIdentity,
 > {
   /**
+   * Type-level anchor for `Id` (never exists at runtime — `declare` emits
+   * nothing). Without it `Id` would appear only in recursive method-return
+   * positions, which TypeScript compares coinductively, making every
+   * `Pipeline<Schema, *>` mutually assignable — so an identity-dropped
+   * pipeline could be assigned to an identity-preserving type and `execute()`
+   * would claim an `id` that does not exist at runtime. Anchoring `Id` in a
+   * (covariant) property position makes such assignments compile errors.
+   */
+  declare private readonly _rowIdentity: Id;
+
+  /**
    * The type-erased AST node this builder wraps. The class *has* a node rather
    * than *being* one: `Pipeline` is a single class that can sit anywhere in the
    * chain, but a node is either a source (the head) or a stage — so the class

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -413,15 +413,12 @@ describe('buildSelectionSchema (runtime)', () => {
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
-  it("rejects '__name__' as an alias; a nested '__name__' is an ordinary key", () => {
-    // The backend refuses aliasing to the reserved top-level `'__name__'`
-    // (`INVALID_ARGUMENT: field name '__name__' is reserved and can not be
-    // overwritten` — verified live), so it is a compile error; a nested
-    // `'__name__'` segment is just a map key and passes through unchanged.
-
-    // @ts-expect-error -- the reserved '__name__' cannot be used as an alias
-    field(schema.name, 'name').as('__name__');
-
+  it("treats '__name__' in an alias like any other key (no special-casing)", () => {
+    // The reserved-name rule is deliberately not modelled client-side:
+    // aliasing to top-level `'__name__'` is rejected by the backend itself
+    // (`INVALID_ARGUMENT`, verified live), and a nested `'__name__'` segment
+    // is an ordinary map key there — so the schema fold treats both as plain
+    // keys. See `ExpressionBase.as`.
     const oracle = { a: map({ __name__: schema.name }) };
     const actual = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
     expect(actual).toStrictEqual(oracle);

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -340,10 +340,13 @@ describe('BuildAddFieldsSchema', () => {
   });
 });
 
-// Runtime mirror of the `BuildSelectionSchema` type tests above — the value
-// returned by `buildSelectionSchema` is bridged to the type-level result with
-// an assertion, so these tests are the safety net that the runtime fold
-// actually matches.
+// Runtime mirror of the `BuildSelectionSchema` type tests above. Each case
+// asserts the SAME hand-written oracle on both sides — `toStrictEqual` checks
+// the runtime value and `expectTypeOf(...).toEqualTypeOf(oracle)` checks the
+// type-level computation (the function's return type IS
+// `BuildSelectionSchema<...>`) — so a divergence between the type operators
+// and their runtime counterparts fails one of the two assertions. This is the
+// safety net for the bridging assertion inside `buildSelectionSchema`.
 describe('buildSelectionSchema (runtime)', () => {
   const gender = optional(literal('male', 'female'));
   const profile = map({ age: double(), gender });
@@ -355,49 +358,74 @@ describe('buildSelectionSchema (runtime)', () => {
   } satisfies DocumentSchema;
 
   it('returns {} for an empty selection list', () => {
-    expect(buildSelectionSchema(schema, [])).toStrictEqual({});
+    const oracle = {};
+    const actual = buildSelectionSchema(schema, []);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('picks top-level fields (the exact descriptors)', () => {
-    expect(buildSelectionSchema(schema, ['name', 'rank'])).toStrictEqual({
-      name: schema.name,
-      rank: schema.rank,
-    });
+    const oracle = { name: schema.name, rank: schema.rank };
+    const actual = buildSelectionSchema(schema, ['name', 'rank']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('builds a nested map from a dotted path', () => {
-    expect(buildSelectionSchema(schema, ['profile.age'])).toStrictEqual({
-      profile: map({ age: profile.fields.age }),
-    });
+    const oracle = { profile: map({ age: profile.fields.age }) };
+    const actual = buildSelectionSchema(schema, ['profile.age']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('merges sibling dotted paths into one map', () => {
-    expect(buildSelectionSchema(schema, ['profile.age', 'profile.gender'])).toStrictEqual({
-      profile: map({ age: profile.fields.age, gender }),
-    });
+    const oracle = { profile: map({ age: profile.fields.age, gender }) };
+    const actual = buildSelectionSchema(schema, ['profile.age', 'profile.gender']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('resolves an aliased expression to its expression type at the alias', () => {
-    const selection = field(schema.rank, 'rank').as('points');
-    expect(buildSelectionSchema(schema, ['name', selection])).toStrictEqual({
-      name: schema.name,
-      points: schema.rank,
-    });
+    const oracle = { name: schema.name, points: schema.rank };
+    const actual = buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('points')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('last-wins: the same output name selected twice', () => {
-    expect(
-      buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]),
-    ).toStrictEqual({ name: schema.rank });
+    const oracle = { name: schema.rank };
+    const actual = buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('last-wins: a child path after its parent replaces the parent subtree', () => {
-    expect(buildSelectionSchema(schema, ['profile', 'profile.age'])).toStrictEqual({
-      profile: map({ age: profile.fields.age }),
-    });
+    const oracle = { profile: map({ age: profile.fields.age }) };
+    const actual = buildSelectionSchema(schema, ['profile', 'profile.age']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
   it('last-wins: a parent path after its child replaces with the full subtree', () => {
-    expect(buildSelectionSchema(schema, ['profile.age', 'profile'])).toStrictEqual({ profile });
+    const oracle = { profile };
+    const actual = buildSelectionSchema(schema, ['profile.age', 'profile']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it("drops '__name__' at every path level, like PathToSchema", () => {
+    // A top-level `'__name__'` alias contributes nothing; a nested one keeps
+    // the parent layers but contributes no leaf (`{ a: map({}) }`) — the
+    // runtime check sits inside `pathToSchema`'s recursion, exactly like the
+    // type's per-level `Path extends '__name__'` branch.
+    const topOracle = {};
+    const top = buildSelectionSchema(schema, [field(schema.name, 'name').as('__name__')]);
+    expect(top).toStrictEqual(topOracle);
+    expectTypeOf(top).toEqualTypeOf(topOracle);
+
+    const nestedOracle = { a: map({}) };
+    const nested = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
+    expect(nested).toStrictEqual(nestedOracle);
+    expectTypeOf(nested).toEqualTypeOf(nestedOracle);
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -1,17 +1,26 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import type {
-  ArrayType,
-  DoubleType,
-  LiteralType,
-  MapType,
-  Optional,
-  StringType,
+import {
+  array,
+  type ArrayType,
+  type DocumentSchema,
+  double,
+  type DoubleType,
+  literal,
+  type LiteralType,
+  map,
+  type MapType,
+  optional,
+  type Optional,
+  string,
+  type StringType,
 } from '../schema.js';
-import type {
-  BuildAddFieldsSchema,
-  BuildSelectionSchema,
-  ExpressionWithAlias,
+import { field } from './expression.js';
+import {
+  type BuildAddFieldsSchema,
+  type BuildSelectionSchema,
+  buildSelectionSchema,
+  type ExpressionWithAlias,
 } from './selection.js';
 
 type Schema = {
@@ -328,5 +337,67 @@ describe('BuildAddFieldsSchema', () => {
         tag: ArrayType<StringType, [], []>;
       }>();
     });
+  });
+});
+
+// Runtime mirror of the `BuildSelectionSchema` type tests above — the value
+// returned by `buildSelectionSchema` is bridged to the type-level result with
+// an assertion, so these tests are the safety net that the runtime fold
+// actually matches.
+describe('buildSelectionSchema (runtime)', () => {
+  const gender = optional(literal('male', 'female'));
+  const profile = map({ age: double(), gender });
+  const schema = {
+    name: string(),
+    profile,
+    rank: double(),
+    tag: array(string()),
+  } satisfies DocumentSchema;
+
+  it('returns {} for an empty selection list', () => {
+    expect(buildSelectionSchema(schema, [])).toStrictEqual({});
+  });
+
+  it('picks top-level fields (the exact descriptors)', () => {
+    expect(buildSelectionSchema(schema, ['name', 'rank'])).toStrictEqual({
+      name: schema.name,
+      rank: schema.rank,
+    });
+  });
+
+  it('builds a nested map from a dotted path', () => {
+    expect(buildSelectionSchema(schema, ['profile.age'])).toStrictEqual({
+      profile: map({ age: profile.fields.age }),
+    });
+  });
+
+  it('merges sibling dotted paths into one map', () => {
+    expect(buildSelectionSchema(schema, ['profile.age', 'profile.gender'])).toStrictEqual({
+      profile: map({ age: profile.fields.age, gender }),
+    });
+  });
+
+  it('resolves an aliased expression to its expression type at the alias', () => {
+    const selection = field(schema.rank, 'rank').as('points');
+    expect(buildSelectionSchema(schema, ['name', selection])).toStrictEqual({
+      name: schema.name,
+      points: schema.rank,
+    });
+  });
+
+  it('last-wins: the same output name selected twice', () => {
+    expect(
+      buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]),
+    ).toStrictEqual({ name: schema.rank });
+  });
+
+  it('last-wins: a child path after its parent replaces the parent subtree', () => {
+    expect(buildSelectionSchema(schema, ['profile', 'profile.age'])).toStrictEqual({
+      profile: map({ age: profile.fields.age }),
+    });
+  });
+
+  it('last-wins: a parent path after its child replaces with the full subtree', () => {
+    expect(buildSelectionSchema(schema, ['profile.age', 'profile'])).toStrictEqual({ profile });
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -15,7 +15,7 @@ import {
   string,
   type StringType,
 } from '../schema.js';
-import { alias, field } from './expression.js';
+import { field } from './expression.js';
 import {
   type BuildAddFieldsSchema,
   type BuildSelectionSchema,
@@ -378,7 +378,7 @@ describe('buildSelectionSchema (runtime)', () => {
   });
 
   it('resolves an aliased expression to its expression type at the alias', () => {
-    const selection = alias(field(schema.rank, 'rank'), 'points');
+    const selection = field(schema.rank, 'rank').as('points');
     expect(buildSelectionSchema(schema, ['name', selection])).toStrictEqual({
       name: schema.name,
       points: schema.rank,
@@ -387,7 +387,7 @@ describe('buildSelectionSchema (runtime)', () => {
 
   it('last-wins: the same output name selected twice', () => {
     expect(
-      buildSelectionSchema(schema, ['name', alias(field(schema.rank, 'rank'), 'name')]),
+      buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]),
     ).toStrictEqual({ name: schema.rank });
   });
 

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -15,7 +15,7 @@ import {
   string,
   type StringType,
 } from '../schema.js';
-import { field } from './expression.js';
+import { alias, field } from './expression.js';
 import {
   type BuildAddFieldsSchema,
   type BuildSelectionSchema,
@@ -378,7 +378,7 @@ describe('buildSelectionSchema (runtime)', () => {
   });
 
   it('resolves an aliased expression to its expression type at the alias', () => {
-    const selection = field(schema.rank, 'rank').as('points');
+    const selection = alias(field(schema.rank, 'rank'), 'points');
     expect(buildSelectionSchema(schema, ['name', selection])).toStrictEqual({
       name: schema.name,
       points: schema.rank,
@@ -387,7 +387,7 @@ describe('buildSelectionSchema (runtime)', () => {
 
   it('last-wins: the same output name selected twice', () => {
     expect(
-      buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]),
+      buildSelectionSchema(schema, ['name', alias(field(schema.rank, 'rank'), 'name')]),
     ).toStrictEqual({ name: schema.rank });
   });
 

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -413,19 +413,18 @@ describe('buildSelectionSchema (runtime)', () => {
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
-  it("drops '__name__' at every path level, like PathToSchema", () => {
-    // A top-level `'__name__'` alias contributes nothing; a nested one keeps
-    // the parent layers but contributes no leaf (`{ a: map({}) }`) — the
-    // runtime check sits inside `pathToSchema`'s recursion, exactly like the
-    // type's per-level `Path extends '__name__'` branch.
-    const topOracle = {};
-    const top = buildSelectionSchema(schema, [field(schema.name, 'name').as('__name__')]);
-    expect(top).toStrictEqual(topOracle);
-    expectTypeOf(top).toEqualTypeOf(topOracle);
+  it("rejects '__name__' as an alias; a nested '__name__' is an ordinary key", () => {
+    // The backend refuses aliasing to the reserved top-level `'__name__'`
+    // (`INVALID_ARGUMENT: field name '__name__' is reserved and can not be
+    // overwritten` — verified live), so it is a compile error; a nested
+    // `'__name__'` segment is just a map key and passes through unchanged.
 
-    const nestedOracle = { a: map({}) };
-    const nested = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
-    expect(nested).toStrictEqual(nestedOracle);
-    expectTypeOf(nested).toEqualTypeOf(nestedOracle);
+    // @ts-expect-error -- the reserved '__name__' cannot be used as an alias
+    field(schema.name, 'name').as('__name__');
+
+    const oracle = { a: map({ __name__: schema.name }) };
+    const actual = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -1,11 +1,17 @@
-import type {
-  DocumentSchema,
-  FieldType,
-  FieldTypeOfPath,
-  MapFieldPath,
-  MapType,
+import {
+  type DocumentSchema,
+  type FieldType,
+  type FieldTypeOfPath,
+  fieldTypeOfPath,
+  map,
+  type MapFieldPath,
+  type MapType,
 } from '../schema.js';
-import { Expression } from './expression.js';
+import type { ExpressionWithAlias } from './expression.js';
+
+// Re-exported for consumers of the selection model; the type itself lives in
+// `expression.ts` (it is produced by `Expression.as(...)`).
+export type { ExpressionWithAlias } from './expression.js';
 
 type Fields = DocumentSchema;
 
@@ -22,11 +28,6 @@ type Fields = DocumentSchema;
  * `docs/pipeline-query-identity-research.md`.
  */
 export type Selection<Context extends Fields> = MapFieldPath<Context> | ExpressionWithAlias;
-
-export type ExpressionWithAlias<T extends FieldType = FieldType, Alias extends string = string> = {
-  expression: Expression<T>;
-  alias: Alias;
-};
 
 /**
  * Folds a tuple of selections into a single nested output schema.
@@ -136,4 +137,100 @@ type MergeSchemas<A, B> = {
     : K extends keyof B
       ? B[K]
       : never;
+};
+
+// ---------------------------------------------------------------------------
+// Runtime counterparts. Each helper mirrors the type-level operator of the same
+// name above; `buildSelectionSchema` is the entry point used by
+// `Pipeline.select` to compute the projected runtime schema.
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime counterpart of {@link BuildSelectionSchema}: folds the selections
+ * into the projected output schema (last-wins conflicts, nested deep-merge).
+ * The result feeds the next stage's field resolution and the executors' row
+ * decoding, so it must mirror the type-level result exactly — the type tests
+ * in `selection.test.ts` plus the pipeline spec are the safety net for the
+ * bridging assertion.
+ */
+export const buildSelectionSchema = <
+  Context extends Fields,
+  const Selections extends readonly Selection<Context>[],
+>(
+  schema: Context,
+  selections: Selections,
+): BuildSelectionSchema<Context, Selections> => {
+  let result: Fields = {};
+  // Right-to-left to mirror `FoldSelections`' `MergeSchemas<First, Fold<Rest>>`
+  // associativity (`A` wins in `MergeSchemas`, so earlier selections win over
+  // the accumulated later ones — conflicts are already dropped, this only
+  // affects nothing but keeps the shapes aligned).
+  for (const s of [...dropOverriddenSelections(selections)].reverse()) {
+    const path = selectionPath(s);
+    if (path === '__name__') {
+      continue; // `PathToSchema` drops the reserved key — not a data field.
+    }
+    const type =
+      typeof s === 'string' ? fieldTypeOfPath<Fields, string>(schema, s) : s.expression.type;
+    result = mergeSchemas(pathToSchema(path, type), result);
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `BuildSelectionSchema`, but the compiler cannot connect a runtime schema value to the type-level result
+  return result as BuildSelectionSchema<Context, Selections>;
+};
+
+/**
+ * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection
+ * only if no later selection conflicts with it (last-wins).
+ */
+export const dropOverriddenSelections = <S extends string | ExpressionWithAlias>(
+  selections: readonly S[],
+): S[] =>
+  selections.filter(
+    (s, i) =>
+      !selections
+        .slice(i + 1)
+        .some((later) => pathsConflict(selectionPath(s), selectionPath(later))),
+  );
+
+/** Runtime counterpart of {@link SelectionPath}. */
+const selectionPath = (s: string | ExpressionWithAlias): string =>
+  typeof s === 'string' ? s : s.alias;
+
+/** Runtime counterpart of {@link PathsConflict}. */
+const pathsConflict = (a: string, b: string): boolean =>
+  a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
+
+/** Runtime counterpart of {@link PathToSchema}. */
+const pathToSchema = (path: string, type: FieldType): Fields => {
+  const dot = path.indexOf('.');
+  return dot < 0
+    ? { [path]: type }
+    : { [path.slice(0, dot)]: map(pathToSchema(path.slice(dot + 1), type)) };
+};
+
+/** Runtime counterpart of {@link MergeSchemas} (`a` wins on non-map conflicts). */
+const mergeSchemas = (a: Fields, b: Fields): Fields => {
+  const result: Record<string, FieldType> = { ...b, ...a };
+  for (const key of Object.keys(a)) {
+    const va = a[key];
+    const vb = b[key];
+    if (va !== undefined && vb !== undefined && isMapType(va) && isMapType(vb)) {
+      result[key] = map(mergeSchemas(va.fields, vb.fields));
+    }
+  }
+  return result;
+};
+
+/**
+ * Narrows a `FieldType` descriptor to `MapType`. `FieldType` is an open
+ * structural base (`type: string`), not a closed union, so this is a `switch`
+ * on a plain string with a type-predicate bridge.
+ */
+const isMapType = (t: FieldType): t is MapType => {
+  switch (t.type) {
+    case 'map':
+      return true;
+    default:
+      return false;
+  }
 };

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -10,7 +10,7 @@ import {
 import type { ExpressionWithAlias } from './expression.js';
 
 // Re-exported for consumers of the selection model; the type itself lives in
-// `expression.ts` (it is produced by the `alias(...)` factory).
+// `expression.ts` (it is produced by `Expression.as(...)`).
 export type { ExpressionWithAlias } from './expression.js';
 
 type Fields = DocumentSchema;

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -10,7 +10,7 @@ import {
 import type { ExpressionWithAlias } from './expression.js';
 
 // Re-exported for consumers of the selection model; the type itself lives in
-// `expression.ts` (it is produced by `Expression.as(...)`).
+// `expression.ts` (it is produced by the `alias(...)` factory).
 export type { ExpressionWithAlias } from './expression.js';
 
 type Fields = DocumentSchema;

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -113,13 +113,16 @@ type SelectionToSchema<Context extends Fields, S> =
 /**
  * Builds a single-entry schema where dots in `Path` produce nested `MapType` layers.
  * `PathToSchema<"profile.age", DoubleType>` -> `{ profile: MapType<{ age: DoubleType }> }`.
- * `"__name__"` is dropped (it is not a real document field).
+ * No `'__name__'` special case: the reserved alias is rejected at construction
+ * (`ExpressionBase.as`), and a **nested** `'__name__'` segment is an ordinary
+ * map key on the backend (verified live).
  */
-type PathToSchema<Path extends string, T extends FieldType> = Path extends '__name__'
-  ? {}
-  : Path extends `${infer Head}.${infer Rest}`
-    ? { [K in Head]: MapType<PathToSchema<Rest, T>> }
-    : { [K in Path]: T };
+type PathToSchema<
+  Path extends string,
+  T extends FieldType,
+> = Path extends `${infer Head}.${infer Rest}`
+  ? { [K in Head]: MapType<PathToSchema<Rest, T>> }
+  : { [K in Path]: T };
 
 /**
  * Recursively merges two schemas. When the same key carries a `MapType` on both
@@ -215,15 +218,8 @@ const selectionPath = (s: string | ExpressionWithAlias): string =>
 const pathsConflict = (a: string, b: string): boolean =>
   a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
 
-/**
- * Runtime counterpart of {@link PathToSchema}, including its `'__name__'` →
- * `{}` branch — checked at every recursion level, exactly like the type
- * (so e.g. an alias of `'a.__name__'` yields `{ a: map({}) }` on both sides).
- */
+/** Runtime counterpart of {@link PathToSchema}. */
 const pathToSchema = (path: string, type: FieldType): Fields => {
-  if (path === '__name__') {
-    return {};
-  }
   const dot = path.indexOf('.');
   return dot < 0
     ? { [path]: type }

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -146,12 +146,13 @@ type MergeSchemas<A, B> = {
 // ---------------------------------------------------------------------------
 
 /**
- * Runtime counterpart of {@link BuildSelectionSchema}: folds the selections
- * into the projected output schema (last-wins conflicts, nested deep-merge).
- * The result feeds the next stage's field resolution and the executors' row
- * decoding, so it must mirror the type-level result exactly — the type tests
- * in `selection.test.ts` plus the pipeline spec are the safety net for the
- * bridging assertion.
+ * Runtime counterpart of {@link BuildSelectionSchema}: computed with the same
+ * decomposition as the type — `foldSelections(schema, dropOverriddenSelections(args))`
+ * mirrors `FoldSelections<Context, DropOverriddenSelections<Args>>`, so each
+ * step can be checked against its type-level twin. The result feeds the next
+ * stage's field resolution and the executors' row decoding, so it must mirror
+ * the type-level result exactly — the type tests in `selection.test.ts` plus
+ * the pipeline spec are the safety net for the bridging assertion.
  */
 export const buildSelectionSchema = <
   Context extends Fields,
@@ -159,24 +160,12 @@ export const buildSelectionSchema = <
 >(
   schema: Context,
   selections: Selections,
-): BuildSelectionSchema<Context, Selections> => {
-  let result: Fields = {};
-  // Right-to-left to mirror `FoldSelections`' `MergeSchemas<First, Fold<Rest>>`
-  // associativity (`A` wins in `MergeSchemas`, so earlier selections win over
-  // the accumulated later ones — conflicts are already dropped, this only
-  // affects nothing but keeps the shapes aligned).
-  for (const s of [...dropOverriddenSelections(selections)].reverse()) {
-    const path = selectionPath(s);
-    if (path === '__name__') {
-      continue; // `PathToSchema` drops the reserved key — not a data field.
-    }
-    const type =
-      typeof s === 'string' ? fieldTypeOfPath<Fields, string>(schema, s) : s.expression.type;
-    result = mergeSchemas(pathToSchema(path, type), result);
-  }
+): BuildSelectionSchema<Context, Selections> =>
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `BuildSelectionSchema`, but the compiler cannot connect a runtime schema value to the type-level result
-  return result as BuildSelectionSchema<Context, Selections>;
-};
+  foldSelections(schema, dropOverriddenSelections(selections)) as BuildSelectionSchema<
+    Context,
+    Selections
+  >;
 
 /**
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection
@@ -192,6 +181,32 @@ export const dropOverriddenSelections = <S extends string | ExpressionWithAlias>
         .some((later) => pathsConflict(selectionPath(s), selectionPath(later))),
   );
 
+/**
+ * Runtime counterpart of {@link FoldSelections}: the same
+ * `MergeSchemas<SelectionToSchema<First>, FoldSelections<Rest>>` recursion.
+ */
+const foldSelections = (
+  schema: Fields,
+  selections: readonly (string | ExpressionWithAlias)[],
+): Fields => {
+  const [first, ...rest] = selections;
+  return first === undefined
+    ? {}
+    : mergeSchemas(selectionToSchema(schema, first), foldSelections(schema, rest));
+};
+
+/**
+ * Runtime counterpart of {@link SelectionToSchema}. Where the type resolves a
+ * path's field type via `FieldTypeOfPath`, the runtime uses `fieldTypeOfPath`
+ * (which throws for unknown paths — the type-level `{}` fallback for non-path
+ * strings is unreachable through the typed API, so a throw is the defensive
+ * equivalent).
+ */
+const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fields =>
+  typeof s === 'string'
+    ? pathToSchema(s, fieldTypeOfPath<Fields, string>(schema, s))
+    : pathToSchema(s.alias, s.expression.type);
+
 /** Runtime counterpart of {@link SelectionPath}. */
 const selectionPath = (s: string | ExpressionWithAlias): string =>
   typeof s === 'string' ? s : s.alias;
@@ -200,8 +215,15 @@ const selectionPath = (s: string | ExpressionWithAlias): string =>
 const pathsConflict = (a: string, b: string): boolean =>
   a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
 
-/** Runtime counterpart of {@link PathToSchema}. */
+/**
+ * Runtime counterpart of {@link PathToSchema}, including its `'__name__'` →
+ * `{}` branch — checked at every recursion level, exactly like the type
+ * (so e.g. an alias of `'a.__name__'` yields `{ a: map({}) }` on both sides).
+ */
 const pathToSchema = (path: string, type: FieldType): Fields => {
+  if (path === '__name__') {
+    return {};
+  }
   const dot = path.indexOf('.');
   return dot < 0
     ? { [path]: type }

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../schema.js';
+import type { ExpressionWithAlias } from './expression.js';
 import type { Ordering } from './ordering.js';
 
 /**
@@ -31,7 +32,9 @@ export type InputStage =
 /** Transformation stage: reshapes the rows flowing through the pipeline. */
 export type TransformStage =
   | { kind: 'where' }
-  | { kind: 'select' }
+  // `selections` is already conflict-resolved (last-wins applied by
+  // `Pipeline.select`), so an executor can translate it 1:1.
+  | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }
   | { kind: 'addFields' }
   | { kind: 'removeFields' }
   | { kind: 'sort'; orderings: Ordering[] }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -1,5 +1,10 @@
 import { type Firestore, Pipelines } from '@google-cloud/firestore';
 import { collectionPath } from 'firestore-repository/path';
+import type {
+  Expression,
+  ExpressionWithAlias,
+  FunctionCall,
+} from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
   Pipeline,
@@ -11,6 +16,7 @@ import type { TransformStage } from 'firestore-repository/pipelines/stage';
 import type { Collection, DocumentSchema } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
+import { buildDecodeSchema } from './codec.js';
 import { buildFirestoreUtilities } from './index.js';
 
 /**
@@ -51,9 +57,12 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
     }
 
     const { fromFirestore } = buildFirestoreUtilities(db, collection);
+    // Rows are decoded with the pipeline's FINAL schema (the leaf node's), not
+    // the source collection's — stages like `select` reshape the rows.
+    const decodeRow = buildDecodeSchema(pipeline.node.schema);
     const snapshot = await sdk.execute();
     return snapshot.results.map((r) => {
-      const data = fromFirestore.decode(r.data());
+      const data = decodeRow.parse(r.data());
       const id = r.ref ? fromFirestore.docRef(r.ref) : undefined;
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `data`/`id` are runtime values matching the caller's Schema/Id, which the compiler cannot prove here
       return (id === undefined ? { data } : { data, id }) as PipelineResult<Schema, Id>;
@@ -68,8 +77,14 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       const [first, ...rest] = stage.orderings.map(toSdkOrdering);
       return first === undefined ? sdk : sdk.sort(first, ...rest);
     }
+    case 'select': {
+      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      if (first === undefined) {
+        throw new Error('google-cloud pipeline executor: select requires at least one selection');
+      }
+      return sdk.select(first, ...rest);
+    }
     case 'where':
-    case 'select':
     case 'addFields':
     case 'removeFields':
     case 'limit':
@@ -86,6 +101,43 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       throw new Error(`google-cloud pipeline executor: stage "${stage.kind}" not supported yet`);
     default:
       return assertNever(stage);
+  }
+};
+
+/** Translates a selection (bare path or aliased expression) into an SDK selectable. */
+const toSdkSelectable = (s: string | ExpressionWithAlias): Pipelines.Selectable | string =>
+  typeof s === 'string' ? s : toSdkExpression(s.expression).as(s.alias);
+
+/** Translates the repository expression AST into an SDK expression. */
+const toSdkExpression = (expression: Expression): Pipelines.Expression => {
+  switch (expression.kind) {
+    case 'field':
+      return Pipelines.field(expression.path);
+    case 'constant':
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `Constant.value` is untyped (TODO in expression.ts); the SDK's `constant` overloads want a concrete primitive, but the raw value passes through unchanged at runtime
+      return Pipelines.constant(expression.value as string);
+    case 'functionCall':
+      return toSdkFunctionCall(expression);
+    default:
+      return assertNever(expression);
+  }
+};
+
+// `FunctionCall.name` is an open string (not a union), so `default` is the
+// unsupported-function guard rather than `assertNever`.
+const toSdkFunctionCall = (expression: FunctionCall): Pipelines.Expression => {
+  switch (expression.name) {
+    case 'equal': {
+      const [left, right] = expression.args;
+      if (left === undefined || right === undefined) {
+        throw new Error('google-cloud pipeline executor: equal requires two arguments');
+      }
+      return Pipelines.equal(toSdkExpression(left), toSdkExpression(right));
+    }
+    default:
+      throw new Error(
+        `google-cloud pipeline executor: function "${expression.name}" not supported yet`,
+      );
   }
 };
 

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -128,6 +128,9 @@ const toSdkExpression = (expression: Expression): Pipelines.Expression => {
 const toSdkFunctionCall = (expression: FunctionCall): Pipelines.Expression => {
   switch (expression.name) {
     case 'equal': {
+      // TODO: this runtime arity guard disappears once FunctionCall is
+      // restructured into shape-grouped classes with typed payload fields —
+      // see "Restructure FunctionCall" in docs/plan/pipeline-query.md.
       const [left, right] = expression.args;
       if (left === undefined || right === undefined) {
         throw new Error('google-cloud pipeline executor: equal requires two arguments');


### PR DESCRIPTION
Implements the `select` transformation stage across the pipeline AST, both executors, and the behavioural spec — developed TDD-style (spec cases first) and verified live against a real Enterprise DB (`ikenox-sunrise` / `enterprise-native-playground`, 13/13 passing).

## Spec coverage (new cases)

- single / multiple top-level field projection (row identity dropped — no `id`)
- nested dotted path (`'profile.age'` → `{ profile: { age } }` — **confirmed live that the backend returns the nested shape**, matching `PathToSchema`)
- sibling selections deep-merged under one parent map (optional absent field included)
- `.as()` aliasing: field expressions and a computed `equal(field, constant)` expression
- last-wins conflict resolution ×3, mirroring the `BuildSelectionSchema` type tests (same name twice / parent-then-child / child-then-parent)
- `select` composed with a subsequent `sort` over the projected schema

## Implementation

- **`expression.ts`** — `ExpressionWithAlias` moved here; every expression node now carries SDK-style `.as(alias)`.
- **`selection.ts`** — `buildSelectionSchema` / `dropOverriddenSelections`: runtime mirrors of the type-level fold (last-wins, nested deep-merge), with runtime unit tests mirroring the type tests as the safety net for the bridging assertion.
- **`pipeline.ts`** — `select` builds a real stage node; the stage carries the *conflict-resolved* selection list so it always matches the computed schema and executors translate 1:1.
- **Executors (both SDKs)** — `select` → `sdk.select(...)` via a small expression-AST translator (`field` / `constant` / `equal`; other functions throw "not supported yet"). Result rows are now decoded with the **pipeline's leaf schema** instead of the source collection's — required because `select` reshapes rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)