### PR TITLE
Implement the removeFields stage end-to-end

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -262,7 +262,10 @@ Transformation stages already stubbed:
       back **nested**, matching `PathToSchema`; last-wins matches the type
       tests; `.as()` field + computed `equal` expressions work).
 - [ ] `addFields(...)` — Context augmentation + identity preserve.
-- [ ] `removeFields(...)` — Context shrinkage + identity preserve.
+- [x] `removeFields(...)` — runtime schema shrink (`omitPaths`, the runtime
+      mirror of `OmitPaths`, incl. the Optional marker and the empty-map cascade),
+      stage carries the field paths, executors translate to `sdk.removeFields(...)`,
+      identity preserved (`Id` threads through). Verified live.
 - [ ] `distinct(...)` — Context shrinkage + identity break.
 - [ ] `limit(N)` / `offset(N)` — Context unchanged + identity preserve.
 - [ ] `unnest(...)` — Context augmentation + identity preserve.

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -93,9 +93,15 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       }
       return sdk.select(first, ...rest);
     }
+    case 'removeFields': {
+      const [first, ...rest] = stage.fields;
+      if (first === undefined) {
+        throw new Error('firebase pipeline executor: removeFields requires at least one field');
+      }
+      return sdk.removeFields(first, ...rest);
+    }
     case 'where':
     case 'addFields':
-    case 'removeFields':
     case 'limit':
     case 'offset':
     case 'unnest':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -236,5 +236,79 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
     });
+
+    describe('removeFields', () => {
+      it('removes a top-level field, keeping row identity', async () => {
+        // `removeFields` is identity-preserving: rows keep their `id`.
+        await expectPipeline(
+          source().removeFields('rank'),
+          [
+            {
+              id: ['a1'],
+              data: { name: 'alice', profile: { age: 20, gender: 'female' }, tag: ['x'] },
+            },
+            { id: ['a2'], data: { name: 'bob', profile: { age: 30 }, tag: [] } },
+            {
+              id: ['a3'],
+              data: { name: 'carol', profile: { age: 40, gender: 'male' }, tag: ['y', 'z'] },
+            },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('removes a nested (dotted) field', async () => {
+        // Removing an optional field that is absent on a document (a2's
+        // `gender`) is a no-op for that document.
+        await expectPipeline(
+          source().removeFields('profile.gender'),
+          [
+            { id: ['a1'], data: { name: 'alice', profile: { age: 20 }, rank: 1, tag: ['x'] } },
+            { id: ['a2'], data: { name: 'bob', profile: { age: 30 }, rank: 2, tag: [] } },
+            { id: ['a3'], data: { name: 'carol', profile: { age: 40 }, rank: 3, tag: ['y', 'z'] } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('removes multiple fields at once', async () => {
+        await expectPipeline(
+          source().removeFields('rank', 'tag', 'profile.gender'),
+          [
+            { id: ['a1'], data: { name: 'alice', profile: { age: 20 } } },
+            { id: ['a2'], data: { name: 'bob', profile: { age: 30 } } },
+            { id: ['a3'], data: { name: 'carol', profile: { age: 40 } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('drops a map emptied by removing all of its fields', async () => {
+        // Mirrors `OmitPaths`' empty-map cascade: removing every field of
+        // `profile` drops the `profile` key from the schema itself.
+        await expectPipeline(
+          source().removeFields('profile.age', 'profile.gender'),
+          [
+            { id: ['a1'], data: { name: 'alice', rank: 1, tag: ['x'] } },
+            { id: ['a2'], data: { name: 'bob', rank: 2, tag: [] } },
+            { id: ['a3'], data: { name: 'carol', rank: 3, tag: ['y', 'z'] } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('composes with a subsequent sort over the narrowed schema', async () => {
+        await expectPipeline(
+          source()
+            .removeFields('profile', 'tag')
+            .sort((field) => [desc(field('rank'))]),
+          [
+            { id: ['a3'], data: { name: 'carol', rank: 3 } },
+            { id: ['a2'], data: { name: 'bob', rank: 2 } },
+            { id: ['a1'], data: { name: 'alice', rank: 1 } },
+          ],
+        );
+      });
+    });
   });
 };

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -11,6 +11,7 @@ import {
   type MapFields,
   type MapType,
   type OmitPaths,
+  omitPaths,
 } from '../schema.js';
 import { AggregateWithAlias } from './aggregate.js';
 import { field, type Expression, type Field } from './expression.js';
@@ -133,11 +134,16 @@ export class Pipeline<
     return unimplemented();
   }
   // `MapFieldPath` (data fields only), not `DocFieldPath`: the reserved
-  // `'__name__'` key is not a removable data field.
-  removeFields<const U extends MapFieldPath<Schema>[]>(
-    ..._fields: U
+  // `'__name__'` key is not a removable data field. At least one field is
+  // required (mirrors the SDK's `removeFields(field, ...rest)` signature).
+  removeFields<const U extends [MapFieldPath<Schema>, ...MapFieldPath<Schema>[]]>(
+    ...fields: U
   ): Pipeline<OmitPaths<Schema, U[number]>, Id> {
-    return unimplemented();
+    return new Pipeline<OmitPaths<Schema, U[number]>, Id>({
+      schema: omitPaths(this.node.schema, fields),
+      stage: { kind: 'removeFields', fields },
+      parent: this.node,
+    });
   }
   sort(orderings: (field: FieldProvider<Schema>) => Ordering[]): Pipeline<Schema, Id> {
     return new Pipeline<Schema, Id>({

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -3,6 +3,7 @@ import {
   type FieldType,
   type FieldTypeOfPath,
   fieldTypeOfPath,
+  isMapType,
   map,
   type MapFieldPath,
   type MapType,
@@ -237,18 +238,4 @@ const mergeSchemas = (a: Fields, b: Fields): Fields => {
     }
   }
   return result;
-};
-
-/**
- * Narrows a `FieldType` descriptor to `MapType`. `FieldType` is an open
- * structural base (`type: string`), not a closed union, so this is a `switch`
- * on a plain string with a type-predicate bridge.
- */
-const isMapType = (t: FieldType): t is MapType => {
-  switch (t.type) {
-    case 'map':
-      return true;
-    default:
-      return false;
-  }
 };

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -36,7 +36,7 @@ export type TransformStage =
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }
   | { kind: 'addFields' }
-  | { kind: 'removeFields' }
+  | { kind: 'removeFields'; fields: readonly string[] }
   | { kind: 'sort'; orderings: Ordering[] }
   | { kind: 'limit' }
   | { kind: 'offset' }

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -26,7 +26,9 @@ import {
   map,
   type MapType,
   type OmitPaths,
+  omitPaths,
   optional,
+  _optional,
   type Optional,
   type PickPaths,
   rootCollection,
@@ -522,6 +524,89 @@ describe('document', () => {
         type S = { name: StringType; a: MapType<{ b: MapType<{ c: DoubleType }> }> };
         // Removing the only leaf empties `a.b`, which empties `a`, dropping both.
         expectTypeOf<OmitPaths<S, 'a.b.c'>>().toEqualTypeOf<{ name: StringType }>();
+      });
+    });
+
+    // Runtime mirror of the `OmitPaths` type tests above. Each case asserts one
+    // hand-written oracle on both sides (`toStrictEqual` for the runtime value,
+    // `expectTypeOf` for the type-level computation) — see "Type-level /
+    // runtime mirroring" in docs/coding-guideline.md.
+    describe('omitPaths (runtime)', () => {
+      const gender = optional(literal('male', 'female'));
+      const profile = map({ age: double(), gender });
+      const schema = {
+        name: string(),
+        profile,
+        rank: double(),
+        tag: array(string()),
+      } satisfies DocumentSchema;
+
+      it('removes a single top-level field', () => {
+        const oracle = { profile, rank: schema.rank, tag: schema.tag };
+        const actual = omitPaths(schema, ['name']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+      });
+
+      it('removes a nested field while preserving the rest of the MapType', () => {
+        const oracle = {
+          name: schema.name,
+          profile: map({ age: profile.fields.age }),
+          rank: schema.rank,
+          tag: schema.tag,
+        };
+        const actual = omitPaths(schema, ['profile.gender']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+      });
+
+      it('preserves the Optional marker when removing a nested field', () => {
+        const s = { profile: optional(map({ age: double(), gender: string() })) };
+        const oracle = { profile: optional(map({ age: s.profile.fields.age })) };
+        const actual = omitPaths(s, ['profile.gender']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+        // `toStrictEqual` does not compare symbol keys, so pin the marker explicitly.
+        expect(_optional in actual.profile).toBe(true);
+      });
+
+      it('drops the whole subtree when a top-level key matches exactly', () => {
+        const oracle = { name: schema.name, rank: schema.rank, tag: schema.tag };
+        const actual = omitPaths(schema, ['profile']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+      });
+
+      it('returns the original schema entries when no path matches', () => {
+        const actual = omitPaths(schema, ['nonexistent']);
+        expect(actual).toStrictEqual(schema);
+        expectTypeOf(actual).toEqualTypeOf(schema);
+      });
+
+      it('removes both top-level and nested fields at once', () => {
+        const oracle = {
+          profile: map({ age: profile.fields.age }),
+          rank: schema.rank,
+          tag: schema.tag,
+        };
+        const actual = omitPaths(schema, ['name', 'profile.gender']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+      });
+
+      it('drops a map when all of its fields are removed at once', () => {
+        const oracle = { name: schema.name, rank: schema.rank, tag: schema.tag };
+        const actual = omitPaths(schema, ['profile.age', 'profile.gender']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
+      });
+
+      it('cascades the empty-map drop up through multiple levels', () => {
+        const s = { name: string(), a: map({ b: map({ c: double() }) }) };
+        const oracle = { name: s.name };
+        const actual = omitPaths(s, ['a.b.c']);
+        expect(actual).toStrictEqual(oracle);
+        expectTypeOf(actual).toEqualTypeOf(oracle);
       });
     });
   });

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -312,3 +312,55 @@ export type OmitPaths<T extends DocumentSchema, P extends string> = MapType['fie
             : MapType<OmitPaths<F, TailPath<K, P>>>
         : T[K];
     };
+
+/**
+ * Runtime counterpart of {@link OmitPaths} (the type's `P` union of paths is
+ * the `paths` array), decomposed the same way — `tailPath` mirrors
+ * {@link TailPath}, and the branch structure follows the mapped type
+ * branch-for-branch: an exact key match drops the subtree, a nested removal
+ * recurses into the map (preserving an `Optional` marker), and a map emptied
+ * by the removal is dropped too. The `buildOmitPathsSchema`-style oracle tests
+ * in `schema.test.ts` assert value and type against one oracle.
+ */
+export const omitPaths = <T extends DocumentSchema, const P extends readonly string[]>(
+  schema: T,
+  paths: P,
+): OmitPaths<T, P[number]> => {
+  const result: Record<string, FieldType> = {};
+  for (const [key, fieldType] of Object.entries(schema)) {
+    if (paths.includes(key)) {
+      continue; // exact match drops the whole subtree
+    }
+    const tail = tailPath(key, paths);
+    if (!isMapType(fieldType) || tail.length === 0) {
+      result[key] = fieldType;
+      continue;
+    }
+    const nested = omitPaths(fieldType.fields, tail);
+    if (Object.keys(nested).length === 0) {
+      continue; // nested removal emptied this map -> drop the key
+    }
+    const nestedMap = map(nested);
+    result[key] = _optional in fieldType ? optional(nestedMap) : nestedMap;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime walk mirrors the type-level `OmitPaths`, but the compiler cannot connect a runtime schema value to the type-level result
+  return result as OmitPaths<T, P[number]>;
+};
+
+/** Runtime counterpart of {@link TailPath}: the sub-paths of `paths` nested under `key`. */
+const tailPath = (key: string, paths: readonly string[]): string[] =>
+  paths.filter((p) => p.startsWith(`${key}.`)).map((p) => p.slice(key.length + 1));
+
+/**
+ * Narrows a `FieldType` descriptor to `MapType`. `FieldType` is an open
+ * structural base (`type: string`), not a closed union, so this is a `switch`
+ * on a plain string with a type-predicate bridge.
+ */
+export const isMapType = (t: FieldType): t is MapType => {
+  switch (t.type) {
+    case 'map':
+      return true;
+    default:
+      return false;
+  }
+};

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -84,9 +84,15 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       }
       return sdk.select(first, ...rest);
     }
+    case 'removeFields': {
+      const [first, ...rest] = stage.fields;
+      if (first === undefined) {
+        throw new Error('google-cloud pipeline executor: removeFields requires at least one field');
+      }
+      return sdk.removeFields(first, ...rest);
+    }
     case 'where':
     case 'addFields':
-    case 'removeFields':
     case 'limit':
     case 'offset':
     case 'unnest':


### PR DESCRIPTION
Implements the `removeFields` transformation stage across the pipeline AST, both executors, and the behavioural spec — TDD-style (spec cases first), verified live against a real Enterprise DB (18/18 passing, 5 new).

## Spec coverage (new cases)

- top-level field removal — **row identity preserved** (`Id` threads through; rows keep `id`)
- nested dotted removal (`'profile.gender'`), including a document where the optional field is absent (no-op)
- multiple fields at once
- **empty-map cascade**: removing every field of `profile` drops the `profile` key itself, mirroring `OmitPaths`
- composition with a subsequent `sort` over the narrowed schema

## Implementation

- **`schema.ts`** — `omitPaths`: runtime mirror of `OmitPaths`, decomposed branch-for-branch per the type/runtime mirroring guideline (`tailPath` ↔ `TailPath`; exact-match subtree drop, `Optional`-marker preservation, empty-map cascade). Runtime tests assert each case's single oracle on both sides (`toStrictEqual` + `expectTypeOf`), mirroring the `OmitPaths` type tests. `isMapType` moved here from `selection.ts` and shared.
- **`pipeline.ts`** — `removeFields` builds a real stage node; the signature requires at least one field (`[MapFieldPath, ...MapFieldPath[]]`), mirroring the SDK's `removeFields(field, ...rest)`.
- **Executors (both SDKs)** — translate via `sdk.removeFields(first, ...rest)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)