### PR TITLE
Make the optional marker a plain property instead of a symbol

### DIFF
--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -24,7 +24,6 @@ import type {
   MapType,
   UnionType,
 } from 'firestore-repository/schema';
-import { _optional } from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -46,7 +45,7 @@ export function buildDecodeSchema(schema: DocumentSchema): z.ZodObject<z.ZodRawS
     Object.fromEntries(
       Object.entries(schema).map(([k, v]) => {
         const s = buildDecodeField(v);
-        return [k, v[_optional] ? s.optional() : s];
+        return [k, v.optional ? s.optional() : s];
       }),
     ),
   );
@@ -97,7 +96,7 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
         Object.fromEntries(
           Object.entries(ft.fields).map(([k, v]) => {
             const s = buildDecodeField(v);
-            return [k, v[_optional] ? s.optional() : s];
+            return [k, v.optional ? s.optional() : s];
           }),
         ),
       );
@@ -131,7 +130,7 @@ export function buildEncodeSchema(
     Object.fromEntries(
       Object.entries(schema).map(([k, v]) => {
         const s = buildEncodeField(v, db);
-        return [k, v[_optional] ? s.optional() : s];
+        return [k, v.optional ? s.optional() : s];
       }),
     ),
   );
@@ -185,7 +184,7 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
         Object.fromEntries(
           Object.entries(ft.fields).map(([k, v]) => {
             const s = buildEncodeField(v, db);
-            return [k, v[_optional] ? s.optional() : s];
+            return [k, v.optional ? s.optional() : s];
           }),
         ),
       );

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -565,8 +565,6 @@ describe('document', () => {
         const actual = omitPaths(s, ['profile.gender']);
         expect(actual).toStrictEqual(oracle);
         expectTypeOf(actual).toEqualTypeOf(oracle);
-        // The plain-property marker is covered by `toStrictEqual` itself (a
-        // symbol key would be invisible to it).
       });
 
       it('drops the whole subtree when a top-level key matches exactly', () => {

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -28,7 +28,6 @@ import {
   type OmitPaths,
   omitPaths,
   optional,
-  _optional,
   type Optional,
   type PickPaths,
   rootCollection,
@@ -566,8 +565,8 @@ describe('document', () => {
         const actual = omitPaths(s, ['profile.gender']);
         expect(actual).toStrictEqual(oracle);
         expectTypeOf(actual).toEqualTypeOf(oracle);
-        // `toStrictEqual` does not compare symbol keys, so pin the marker explicitly.
-        expect(_optional in actual.profile).toBe(true);
+        // The plain-property marker is covered by `toStrictEqual` itself (a
+        // symbol key would be invisible to it).
       });
 
       it('drops the whole subtree when a top-level key matches exactly', () => {

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -61,8 +61,16 @@ export type MapType<T extends MapFields = MapFields> = {
   input: ResolveMapValue<T, 'write'>;
   output: ResolveMapValue<T, 'read'>;
 };
-export type MapFields = Record<string, FieldType & { [_optional]?: boolean }>;
-export type Optional = { [_optional]: true };
+export type MapFields = Record<string, FieldType & { optional?: boolean }>;
+/**
+ * Marks a field descriptor as optional. A plain (string-keyed) property, not a
+ * symbol: descriptors are a library-controlled closed structure with no
+ * collision risk, and a plain key stays visible to deep-equality assertions
+ * (`toStrictEqual`) and survives `structuredClone` — a symbol key does
+ * neither. (Contrast with `serverOperation`, which marks *document values*
+ * that mix with user data, where a symbol is the right call.)
+ */
+export type Optional = { optional: true };
 export type ArrayType<
   DynamicPart extends FieldType = FieldType,
   HeadFixedPart extends FieldType[] = FieldType[],
@@ -97,7 +105,7 @@ export type ResolveMapValue<
   Mode extends 'read' | 'write',
 > = MakeSomeFieldsOptional<
   { [K in keyof T]: FieldValue<T[K], Mode> },
-  { [K in keyof T]: T[K][typeof _optional] extends true ? K : never }[keyof T]
+  { [K in keyof T]: T[K]['optional'] extends true ? K : never }[keyof T]
 >;
 
 // TODO: support tuple
@@ -122,8 +130,6 @@ type MakeSomeFieldsOptional<T extends Record<string, unknown>, OptFields extends
   Pick<{ [K in keyof T]?: T[K] }, OptFields> & Omit<T, OptFields>
 >;
 type Merge<T> = { [K in keyof T]: T[K] };
-
-export const _optional: unique symbol = Symbol();
 
 export const serverOperation: unique symbol = Symbol();
 
@@ -162,7 +168,7 @@ export const nullable = <T extends FieldType>(t: T): UnionType<[T, NullType]> =>
   union(t, nullType());
 
 export const optional = <T extends FieldType>(type: T): T & Optional =>
-  buildType({ ...type, [_optional]: true });
+  buildType({ ...type, optional: true });
 
 /**
  * A type-safe path to anything addressable on a **document**: either one of its
@@ -332,6 +338,9 @@ export const omitPaths = <T extends DocumentSchema, const P extends readonly str
       continue; // exact match drops the whole subtree
     }
     const tail = tailPath(key, paths);
+    // Read the marker before `isMapType` narrows the descriptor to `MapType`
+    // (narrowing drops the `optional?` part of the `MapFields` intersection).
+    const markedOptional = fieldType.optional === true;
     if (!isMapType(fieldType) || tail.length === 0) {
       result[key] = fieldType;
       continue;
@@ -341,7 +350,7 @@ export const omitPaths = <T extends DocumentSchema, const P extends readonly str
       continue; // nested removal emptied this map -> drop the key
     }
     const nestedMap = map(nested);
-    result[key] = _optional in fieldType ? optional(nestedMap) : nestedMap;
+    result[key] = markedOptional ? optional(nestedMap) : nestedMap;
   }
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime walk mirrors the type-level `OmitPaths`, but the compiler cannot connect a runtime schema value to the type-level result
   return result as OmitPaths<T, P[number]>;

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -18,7 +18,6 @@ import type {
   MapType,
   UnionType,
 } from 'firestore-repository/schema';
-import { _optional } from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -41,7 +40,7 @@ export function buildDecodeSchema(schema: DocumentSchema): z.ZodObject<z.ZodRawS
     Object.fromEntries(
       Object.entries(schema).map(([k, v]) => {
         const s = buildDecodeField(v);
-        return [k, v[_optional] ? s.optional() : s];
+        return [k, v.optional ? s.optional() : s];
       }),
     ),
   );
@@ -92,7 +91,7 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
         Object.fromEntries(
           Object.entries(ft.fields).map(([k, v]) => {
             const s = buildDecodeField(v);
-            return [k, v[_optional] ? s.optional() : s];
+            return [k, v.optional ? s.optional() : s];
           }),
         ),
       );
@@ -126,7 +125,7 @@ export function buildEncodeSchema(
     Object.fromEntries(
       Object.entries(schema).map(([k, v]) => {
         const s = buildEncodeField(v, db);
-        return [k, v[_optional] ? s.optional() : s];
+        return [k, v.optional ? s.optional() : s];
       }),
     ),
   );
@@ -180,7 +179,7 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
         Object.fromEntries(
           Object.entries(ft.fields).map(([k, v]) => {
             const s = buildEncodeField(v, db);
-            return [k, v[_optional] ? s.optional() : s];
+            return [k, v.optional ? s.optional() : s];
           }),
         ),
       );


### PR DESCRIPTION
Replaces the `_optional` unique-symbol marker on field descriptors with a plain `optional: true` property.

## Why

- **Deep-equality visibility**: `toStrictEqual` does not compare symbol-keyed properties, so descriptor-comparison tests (now central to the type/runtime mirroring strategy) could not see the marker — the `omitPaths` test needed an explicit `_optional in ...` pin assertion to close the blind spot. With a plain property the oracle-both-sides assertions cover it naturally.
- **`structuredClone` safety**: symbol-keyed properties are silently dropped by `structuredClone`; a plain key survives.
- Field descriptors are a library-controlled closed structure (`type` / `fields` / `input` / `output` / …), so the symbol's collision-proofing bought nothing there.

`serverOperation` deliberately **stays a symbol** — it marks document *values* that mix with user data, where collision-proofing is exactly the point. The distinction is documented on the `Optional` type.

Verified: tsc / 170 unit tests / lint / fmt clean, plus the live Enterprise pipeline spec (18/18) exercising the codec's optional-field decode path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)