### PR TITLE
Implement the addFields stage end-to-end

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -261,7 +261,12 @@ Transformation stages already stubbed:
       the pipeline's leaf schema. Verified live (nested dotted selects come
       back **nested**, matching `PathToSchema`; last-wins matches the type
       tests; `.as()` field + computed `equal` expressions work).
-- [ ] `addFields(...)` — Context augmentation + identity preserve.
+- [x] `addFields(...)` — runtime schema merge (`buildAddFieldsSchema`, the
+      runtime mirror of `BuildAddFieldsSchema`), stage carries conflict-resolved
+      selections, executors translate to `sdk.addFields(...)` (bare paths become
+      `field(p).as(p)`), identity preserved. Backend semantics probed: added
+      fields win on overlap, dotted aliases deep-merge into existing maps, a
+      scalar added under a map's name replaces the map. Verified live.
 - [x] `removeFields(...)` — runtime schema shrink (`omitPaths`, the runtime
       mirror of `OmitPaths`, incl. the Optional marker and the empty-map cascade),
       stage carries the field paths, executors translate to `sdk.removeFields(...)`,

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -127,12 +127,12 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
 
 /**
  * Translates a selection (bare path or aliased expression) into an SDK
- * selectable. A bare path becomes `field(path).as(path)` — exactly what the
- * SDK's own string handling does for `select`, and the only form `addFields`
- * accepts.
+ * selectable. A bare path becomes a `Field`, which implements `Selectable`
+ * with its own path as the alias — the same wire proto as the SDK's string
+ * handling for `select`, in the form `addFields` also accepts.
  */
 const toSdkSelectable = (s: string | ExpressionWithAlias): SdkSelectable =>
-  typeof s === 'string' ? field(s).as(s) : toSdkExpression(s.expression).as(s.alias);
+  typeof s === 'string' ? field(s) : toSdkExpression(s.expression).as(s.alias);
 
 /** Translates the repository expression AST into an SDK expression. */
 const toSdkExpression = (expression: Expression): SdkExpression => {

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -100,8 +100,14 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       }
       return sdk.removeFields(first, ...rest);
     }
+    case 'addFields': {
+      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      if (first === undefined) {
+        throw new Error('firebase pipeline executor: addFields requires at least one field');
+      }
+      return sdk.addFields(first, ...rest);
+    }
     case 'where':
-    case 'addFields':
     case 'limit':
     case 'offset':
     case 'unnest':
@@ -119,9 +125,14 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
   }
 };
 
-/** Translates a selection (bare path or aliased expression) into an SDK selectable. */
-const toSdkSelectable = (s: string | ExpressionWithAlias): SdkSelectable | string =>
-  typeof s === 'string' ? s : toSdkExpression(s.expression).as(s.alias);
+/**
+ * Translates a selection (bare path or aliased expression) into an SDK
+ * selectable. A bare path becomes `field(path).as(path)` — exactly what the
+ * SDK's own string handling does for `select`, and the only form `addFields`
+ * accepts.
+ */
+const toSdkSelectable = (s: string | ExpressionWithAlias): SdkSelectable =>
+  typeof s === 'string' ? field(s).as(s) : toSdkExpression(s.expression).as(s.alias);
 
 /** Translates the repository expression AST into an SDK expression. */
 const toSdkExpression = (expression: Expression): SdkExpression => {

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -310,5 +310,74 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
     });
+
+    describe('addFields', () => {
+      it('adds an aliased computed field, keeping identity and existing fields', async () => {
+        // `addFields` is identity-preserving and keeps every existing field.
+        await expectPipeline(
+          source()
+            .removeFields('profile', 'tag') // narrow the rows to keep the expectations readable
+            .addFields((field) => [equal(field('rank'), constant(2)).as('isSecond')]),
+          [
+            { id: ['a1'], data: { name: 'alice', rank: 1, isSecond: false } },
+            { id: ['a2'], data: { name: 'bob', rank: 2, isSecond: true } },
+            { id: ['a3'], data: { name: 'carol', rank: 3, isSecond: false } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('deep-merges a dotted alias into an existing map', async () => {
+        // Adding under an existing map merges with its fields (verified against
+        // the backend), mirroring `MergeSchemas`.
+        await expectPipeline(
+          source()
+            .removeFields('rank', 'tag')
+            .addFields((field) => [field('name').as('profile.author')]),
+          [
+            {
+              id: ['a1'],
+              data: { name: 'alice', profile: { age: 20, gender: 'female', author: 'alice' } },
+            },
+            { id: ['a2'], data: { name: 'bob', profile: { age: 30, author: 'bob' } } },
+            {
+              id: ['a3'],
+              data: { name: 'carol', profile: { age: 40, gender: 'male', author: 'carol' } },
+            },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('an added field overwrites an existing one on name overlap', async () => {
+        // The added field wins (the SDK's "overwrite existing ones" behavior);
+        // `rank` becomes a string here, which `BuildAddFieldsSchema` tracks.
+        await expectPipeline(
+          source()
+            .removeFields('profile', 'tag')
+            .addFields((field) => [field('name').as('rank')]),
+          [
+            { id: ['a1'], data: { name: 'alice', rank: 'alice' } },
+            { id: ['a2'], data: { name: 'bob', rank: 'bob' } },
+            { id: ['a3'], data: { name: 'carol', rank: 'carol' } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('composes with a subsequent sort over the added field', async () => {
+        await expectPipeline(
+          source()
+            .removeFields('profile', 'tag')
+            .addFields((field) => [field('rank').as('score')])
+            .sort((field) => [desc(field('score'))]),
+          [
+            { id: ['a3'], data: { name: 'carol', rank: 3, score: 3 } },
+            { id: ['a2'], data: { name: 'bob', rank: 2, score: 2 } },
+            { id: ['a1'], data: { name: 'alice', rank: 1, score: 1 } },
+          ],
+        );
+      });
+    });
   });
 };

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -39,14 +39,6 @@ describe('pipeline', () => {
     collection(postsCollection, ['author1', 'extra']);
   });
 
-  it('addFields accepts aliased expressions only (no bare paths)', () => {
-    // A bare path would be a schema no-op while the backend materializes
-    // missing intermediate layers — see `BuildAddFieldsSchema`.
-    // @ts-expect-error -- bare string paths are not valid addFields selections
-    base.addFields(() => ['name']);
-    base.addFields((field) => [field('name').as('name2')]); // aliased: ok
-  });
-
   it('__name__ is not projectable (keeps `select`/`removeFields` honest)', () => {
     // `select` / `removeFields` operate on data field paths only (`Selection` /
     // `MapFieldPath`), so the reserved `__name__` key cannot be projected or

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -39,6 +39,14 @@ describe('pipeline', () => {
     collection(postsCollection, ['author1', 'extra']);
   });
 
+  it('addFields accepts aliased expressions only (no bare paths)', () => {
+    // A bare path would be a schema no-op while the backend materializes
+    // missing intermediate layers — see `BuildAddFieldsSchema`.
+    // @ts-expect-error -- bare string paths are not valid addFields selections
+    base.addFields(() => ['name']);
+    base.addFields((field) => [field('name').as('name2')]); // aliased: ok
+  });
+
   it('__name__ is not projectable (keeps `select`/`removeFields` honest)', () => {
     // `select` / `removeFields` operate on data field paths only (`Selection` /
     // `MapFieldPath`), so the reserved `__name__` key cannot be projected or

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -18,6 +18,7 @@ import { field, type Expression, type Field } from './expression.js';
 import { Ordering } from './ordering.js';
 import {
   type BuildAddFieldsSchema,
+  buildAddFieldsSchema,
   type BuildSelectionSchema,
   buildSelectionSchema,
   dropOverriddenSelections,
@@ -128,10 +129,23 @@ export class Pipeline<
       parent: this.node,
     });
   }
+  /**
+   * Adds the selections on top of the existing fields, keeping read-identity.
+   * On name overlap the added field wins; a dotted alias deep-merges into the
+   * existing map (both verified against the backend — see
+   * {@link BuildAddFieldsSchema}).
+   */
   addFields<const Selections extends readonly Selection<Schema>[]>(
-    _fields: (field: FieldProvider<Schema>) => Selections,
+    fields: (field: FieldProvider<Schema>) => Selections,
   ): Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id> {
-    return unimplemented();
+    const resolved = fields(fieldProvider(this.node.schema));
+    return new Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id>({
+      schema: buildAddFieldsSchema(this.node.schema, resolved),
+      // Resolve last-wins here so the stage carries a conflict-free list that
+      // matches the schema (and executors translate it 1:1).
+      stage: { kind: 'addFields', selections: dropOverriddenSelections(resolved) },
+      parent: this.node,
+    });
   }
   // `MapFieldPath` (data fields only), not `DocFieldPath`: the reserved
   // `'__name__'` key is not a removable data field. At least one field is

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -22,6 +22,7 @@ import {
   type BuildSelectionSchema,
   buildSelectionSchema,
   dropOverriddenSelections,
+  type ExpressionWithAlias,
   type Selection,
 } from './selection.js';
 import type { InputStage, TransformStage } from './stage.js';
@@ -134,8 +135,11 @@ export class Pipeline<
    * On name overlap the added field wins; a dotted alias deep-merges into the
    * existing map (both verified against the backend — see
    * {@link BuildAddFieldsSchema}).
+   *
+   * Aliased expressions only — bare field paths are rejected at the type
+   * level (see {@link BuildAddFieldsSchema} for why they are a foot-gun).
    */
-  addFields<const Selections extends readonly Selection<Schema>[]>(
+  addFields<const Selections extends readonly ExpressionWithAlias[]>(
     fields: (field: FieldProvider<Schema>) => Selections,
   ): Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id> {
     const resolved = fields(fieldProvider(this.node.schema));

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -204,17 +204,9 @@ describe('BuildSelectionSchema', () => {
 });
 
 describe('BuildAddFieldsSchema', () => {
-  describe('empty / no-op', () => {
+  describe('empty', () => {
     it('returns the context unchanged for an empty list', () => {
       expectTypeOf<BuildAddFieldsSchema<Schema, []>>().toEqualTypeOf<Schema>();
-    });
-
-    it('rejects bare field paths (aliased expressions only)', () => {
-      // A bare path would be a schema no-op while the backend materializes
-      // missing intermediate layers (mutating rows the schema says are
-      // untouched) — so it is a type error. See `BuildAddFieldsSchema`.
-      // @ts-expect-error -- bare string paths are not valid addFields selections
-      expectTypeOf<BuildAddFieldsSchema<Schema, ['name']>>().toEqualTypeOf<Schema>();
     });
   });
 

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -18,6 +18,7 @@ import {
 import { field } from './expression.js';
 import {
   type BuildAddFieldsSchema,
+  buildAddFieldsSchema,
   type BuildSelectionSchema,
   buildSelectionSchema,
   type ExpressionWithAlias,
@@ -411,6 +412,44 @@ describe('buildSelectionSchema (runtime)', () => {
     const actual = buildSelectionSchema(schema, ['profile.age', 'profile']);
     expect(actual).toStrictEqual(oracle);
     expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('addFields: keeps the context and adds the selection schema on top', () => {
+    const oracle = {
+      name: schema.name,
+      profile,
+      rank: schema.rank,
+      tag: schema.tag,
+      points: schema.rank,
+    };
+    const actual = buildAddFieldsSchema(schema, [field(schema.rank, 'rank').as('points')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('addFields: an added field wins over an existing one on name overlap', () => {
+    const oracle = { name: schema.name, profile, rank: schema.name, tag: schema.tag };
+    const actual = buildAddFieldsSchema(schema, [field(schema.name, 'name').as('rank')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('addFields: a dotted alias deep-merges into the existing map', () => {
+    const oracle = {
+      name: schema.name,
+      profile: map({ author: schema.name, age: profile.fields.age, gender }),
+      rank: schema.rank,
+      tag: schema.tag,
+    };
+    const actual = buildAddFieldsSchema(schema, [field(schema.name, 'name').as('profile.author')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('addFields: a bare path selection is a schema no-op', () => {
+    const actual = buildAddFieldsSchema(schema, ['profile.age']);
+    expect(actual).toStrictEqual(schema);
+    expectTypeOf(actual).toEqualTypeOf(schema);
   });
 
   it("treats '__name__' in an alias like any other key (no special-casing)", () => {

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -209,15 +209,13 @@ describe('BuildAddFieldsSchema', () => {
       expectTypeOf<BuildAddFieldsSchema<Schema, []>>().toEqualTypeOf<Schema>();
     });
 
-    it('adding an existing top-level field by string path is a no-op', () => {
+    it('rejects bare field paths (aliased expressions only)', () => {
+      // A bare path would be a schema no-op while the backend materializes
+      // missing intermediate layers (mutating rows the schema says are
+      // untouched) — so it is a type error. See `BuildAddFieldsSchema`.
+      // @ts-expect-error -- bare string paths are not valid addFields selections
       expectTypeOf<BuildAddFieldsSchema<Schema, ['name']>>().toEqualTypeOf<Schema>();
     });
-
-    it('adding an existing nested field by dotted path keeps siblings (no-op)', () => {
-      expectTypeOf<BuildAddFieldsSchema<Schema, ['profile.age']>>().toEqualTypeOf<Schema>();
-    });
-    // `__name__` is not a valid `Selection`, so `addFields(['__name__'])` is a
-    // type error rather than a no-op (see `Selection`'s doc comment).
   });
 
   describe('adding new fields (existing fields preserved)', () => {
@@ -301,10 +299,11 @@ describe('BuildAddFieldsSchema', () => {
 
   describe('properties (additions merge into the existing context)', () => {
     it('same field name twice among additions: the later one wins', () => {
+      type NameString = ExpressionWithAlias<StringType, 'name'>;
       type NameDouble = ExpressionWithAlias<DoubleType, 'name'>;
       // The later addition (DoubleType) wins over both the earlier addition and
       // the existing context field (StringType).
-      expectTypeOf<BuildAddFieldsSchema<Schema, ['name', NameDouble]>>().toEqualTypeOf<{
+      expectTypeOf<BuildAddFieldsSchema<Schema, [NameString, NameDouble]>>().toEqualTypeOf<{
         name: DoubleType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
@@ -329,9 +328,14 @@ describe('BuildAddFieldsSchema', () => {
     });
 
     it('parent/child conflict among additions still keeps existing siblings', () => {
+      type ProfileAlias = ExpressionWithAlias<
+        MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>,
+        'profile'
+      >;
+      type AgeAlias = ExpressionWithAlias<DoubleType, 'profile.age'>;
       // Within the args `profile.age` wins over `profile`; but addFields also
       // preserves existing context fields, so `gender` remains.
-      expectTypeOf<BuildAddFieldsSchema<Schema, ['profile', 'profile.age']>>().toEqualTypeOf<{
+      expectTypeOf<BuildAddFieldsSchema<Schema, [ProfileAlias, AgeAlias]>>().toEqualTypeOf<{
         name: StringType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
@@ -444,12 +448,6 @@ describe('buildSelectionSchema (runtime)', () => {
     const actual = buildAddFieldsSchema(schema, [field(schema.name, 'name').as('profile.author')]);
     expect(actual).toStrictEqual(oracle);
     expectTypeOf(actual).toEqualTypeOf(oracle);
-  });
-
-  it('addFields: a bare path selection is a schema no-op', () => {
-    const actual = buildAddFieldsSchema(schema, ['profile.age']);
-    expect(actual).toStrictEqual(schema);
-    expectTypeOf(actual).toEqualTypeOf(schema);
   });
 
   it("treats '__name__' in an alias like any other key (no special-casing)", () => {

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -91,13 +91,20 @@ type DropOverriddenSelections<Args extends readonly unknown[]> = Args extends re
  * fields. Unlike `select` (which keeps only the selections), `addFields` keeps
  * all existing fields; on name overlap the added field wins, matching the
  * official SDK's "overwrite existing ones" behavior.
+ *
+ * Accepts **aliased expressions only** — no bare field paths (unlike
+ * `select`). A bare path would be a schema no-op at best, and for a path
+ * through an optional map it would silently mutate rows (the backend
+ * materializes the missing intermediate layers as empty maps — verified
+ * live), so the schema would lie. The official SDK's `addFields` accepts only
+ * `Selectable`s too.
  */
 export type BuildAddFieldsSchema<
   Context extends Fields,
-  Args extends readonly Selection<Context>[],
+  Args extends readonly ExpressionWithAlias[],
   // The `Args extends ...` guard is always true; it defers evaluation so the
   // result is accepted as a `DocumentSchema` (same trick as BuildSelectionSchema).
-> = Args extends readonly Selection<Context>[]
+> = Args extends readonly ExpressionWithAlias[]
   ? MergeSchemas<BuildSelectionSchema<Context, Args>, Context>
   : never;
 
@@ -179,7 +186,7 @@ export const buildSelectionSchema = <
  */
 export const buildAddFieldsSchema = <
   Context extends Fields,
-  const Selections extends readonly Selection<Context>[],
+  const Selections extends readonly ExpressionWithAlias[],
 >(
   schema: Context,
   selections: Selections,

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -172,6 +172,25 @@ export const buildSelectionSchema = <
   >;
 
 /**
+ * Runtime counterpart of {@link BuildAddFieldsSchema}: the same
+ * `MergeSchemas<BuildSelectionSchema<Context, Args>, Context>` composition
+ * (the added fields' schema wins on overlap, deep-merging nested maps —
+ * verified against the backend).
+ */
+export const buildAddFieldsSchema = <
+  Context extends Fields,
+  const Selections extends readonly Selection<Context>[],
+>(
+  schema: Context,
+  selections: Selections,
+): BuildAddFieldsSchema<Context, Selections> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `BuildAddFieldsSchema`, but the compiler cannot connect a runtime schema value to the type-level result
+  mergeSchemas(
+    foldSelections(schema, dropOverriddenSelections(selections)),
+    schema,
+  ) as BuildAddFieldsSchema<Context, Selections>;
+
+/**
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection
  * only if no later selection conflicts with it (last-wins).
  */

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -35,7 +35,9 @@ export type TransformStage =
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }
-  | { kind: 'addFields' }
+  // `selections` is already conflict-resolved (last-wins applied by
+  // `Pipeline.addFields`), so an executor can translate it 1:1.
+  | { kind: 'addFields'; selections: readonly (string | ExpressionWithAlias)[] }
   | { kind: 'removeFields'; fields: readonly string[] }
   | { kind: 'sort'; orderings: Ordering[] }
   | { kind: 'limit' }

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -36,8 +36,9 @@ export type TransformStage =
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }
   // `selections` is already conflict-resolved (last-wins applied by
-  // `Pipeline.addFields`), so an executor can translate it 1:1.
-  | { kind: 'addFields'; selections: readonly (string | ExpressionWithAlias)[] }
+  // `Pipeline.addFields`), so an executor can translate it 1:1. Aliased
+  // expressions only — see `BuildAddFieldsSchema`.
+  | { kind: 'addFields'; selections: readonly ExpressionWithAlias[] }
   | { kind: 'removeFields'; fields: readonly string[] }
   | { kind: 'sort'; orderings: Ordering[] }
   | { kind: 'limit' }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -118,12 +118,12 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
 
 /**
  * Translates a selection (bare path or aliased expression) into an SDK
- * selectable. A bare path becomes `field(path).as(path)` — exactly what the
- * SDK's own string handling does for `select`, and the only form `addFields`
- * accepts.
+ * selectable. A bare path becomes a `Field`, which implements `Selectable`
+ * with its own path as the alias — the same wire proto as the SDK's string
+ * handling for `select`, in the form `addFields` also accepts.
  */
 const toSdkSelectable = (s: string | ExpressionWithAlias): Pipelines.Selectable =>
-  typeof s === 'string' ? Pipelines.field(s).as(s) : toSdkExpression(s.expression).as(s.alias);
+  typeof s === 'string' ? Pipelines.field(s) : toSdkExpression(s.expression).as(s.alias);
 
 /** Translates the repository expression AST into an SDK expression. */
 const toSdkExpression = (expression: Expression): Pipelines.Expression => {

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -91,8 +91,14 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       }
       return sdk.removeFields(first, ...rest);
     }
+    case 'addFields': {
+      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      if (first === undefined) {
+        throw new Error('google-cloud pipeline executor: addFields requires at least one field');
+      }
+      return sdk.addFields(first, ...rest);
+    }
     case 'where':
-    case 'addFields':
     case 'limit':
     case 'offset':
     case 'unnest':
@@ -110,9 +116,14 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
   }
 };
 
-/** Translates a selection (bare path or aliased expression) into an SDK selectable. */
-const toSdkSelectable = (s: string | ExpressionWithAlias): Pipelines.Selectable | string =>
-  typeof s === 'string' ? s : toSdkExpression(s.expression).as(s.alias);
+/**
+ * Translates a selection (bare path or aliased expression) into an SDK
+ * selectable. A bare path becomes `field(path).as(path)` — exactly what the
+ * SDK's own string handling does for `select`, and the only form `addFields`
+ * accepts.
+ */
+const toSdkSelectable = (s: string | ExpressionWithAlias): Pipelines.Selectable =>
+  typeof s === 'string' ? Pipelines.field(s).as(s) : toSdkExpression(s.expression).as(s.alias);
 
 /** Translates the repository expression AST into an SDK expression. */
 const toSdkExpression = (expression: Expression): Pipelines.Expression => {


### PR DESCRIPTION
Implements the `addFields` transformation stage across the pipeline AST, both executors, and the behavioural spec — TDD-style with the backend semantics **probed first**, then verified live against a real Enterprise DB (22/22 passing, 4 new).

## Probed backend semantics (all match `BuildAddFieldsSchema`'s existing model)

| case | result |
|---|---|
| new top-level alias | added alongside existing fields |
| dotted alias into an existing map | **deep merge** (`profile` keeps `age`/`gender`, gains the new key) |
| same name as an existing leaf | added field wins (overwrite) |
| scalar added under an existing map's name | replaces the whole map |

## Spec coverage (new cases)

- aliased computed field (`equal(...).as('isSecond')`) — identity preserved, existing fields kept
- dotted alias deep-merge into an existing map (incl. a doc where the optional sibling is absent)
- added-field-wins on name overlap — `rank` becomes a **string**, which the projected type tracks
- composition with a subsequent `sort` over the added field

## Implementation

- **`selection.ts`** — `buildAddFieldsSchema`: runtime mirror of `BuildAddFieldsSchema` (`mergeSchemas(foldSelections(dropOverridden(args)), context)` — same decomposition), with oracle-both-sides runtime tests.
- **`pipeline.ts`** — `addFields` builds a real node; the stage carries the conflict-resolved selection list matching the computed schema; `Id` threads through (identity-preserving).
- **Executors (both SDKs)** — `sdk.addFields(...)`; `toSdkSelectable` now always returns a `Selectable` (a bare path becomes `field(p).as(p)`, exactly what the SDK's own string handling does for `select`), shared by `select` and `addFields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)