### PR TITLE
Add skipped red tests for the optional-map select gap (#202)

### DIFF
--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -10,7 +10,15 @@ import type {
 } from '../pipelines/pipeline.js';
 import { collection as collectionInput } from '../pipelines/source.js';
 import type { Doc, DocRef, FirestoreEnvironment, PlainRepository } from '../repository.js';
-import type { Collection, DocumentSchema } from '../schema.js';
+import {
+  type Collection,
+  type DocumentSchema,
+  double,
+  map,
+  optional,
+  rootCollection,
+  string,
+} from '../schema.js';
 import { type AuthorsCollection, authorsCollection } from './specification.js';
 import { uniqueCollection } from './util.js';
 
@@ -233,6 +241,54 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             { data: { name: 'bob', rank: 2 } },
             { data: { name: 'alice', rank: 1 } },
           ],
+        );
+      });
+    });
+
+    // TODO(#202): un-skip once ancestor optionality propagates to the selected
+    // leaf. Selecting through an optional map currently types the leaf as
+    // required, but the backend materializes the intermediate layers and omits
+    // only the leaf (`{ meta: {} }` for a doc without `meta`) — so decoding
+    // real data throws (confirmed live: both tests fail with a ZodError when
+    // un-skipped). The `@ts-expect-error`s below mark expectations the current
+    // (wrong) types reject; the fix will turn them into unused directives,
+    // forcing this suite to be revisited.
+    describe('select through an optional map (#202)', () => {
+      const optionalMetaCollection = rootCollection({
+        name: 'OptionalMeta',
+        schema: { name: string(), meta: optional(map({ x: double() })) },
+      });
+
+      let coll: typeof optionalMetaCollection;
+      beforeEach(async () => {
+        coll = uniqueCollection(optionalMetaCollection);
+        await createRepository(coll).batchSet([
+          { id: ['m1'], data: { name: 'with-meta', meta: { x: 1 } } },
+          { id: ['m2'], data: { name: 'without-meta' } },
+        ]);
+      });
+
+      it.skip('a dotted path through an optional map yields an optional leaf', async () => {
+        await expectPipeline(
+          collectionInput(coll).select(() => ['meta.x']),
+          [
+            { data: { meta: { x: 1 } } },
+            // @ts-expect-error -- #202: the leaf must become optional; the backend returns `{ meta: {} }` here
+            { data: { meta: {} } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it.skip('an alias of a field under an optional map yields an optional key', async () => {
+        await expectPipeline(
+          collectionInput(coll).select((field) => ['name', field('meta.x').as('mx')]),
+          [
+            { data: { name: 'with-meta', mx: 1 } },
+            // @ts-expect-error -- #202: `mx` must become optional; the backend omits the key here
+            { data: { name: 'without-meta' } },
+          ],
+          { ordered: false },
         );
       });
     });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -413,6 +413,21 @@ describe('buildSelectionSchema (runtime)', () => {
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
+  // TODO(#202): un-skip once ancestor optionality propagates to the selected
+  // leaf. The `@ts-expect-error` marks the type-level expectation the current
+  // (wrong) `BuildSelectionSchema` rejects; the fix will turn it into an
+  // unused directive, forcing this test to be revisited.
+  it.skip('propagates an ancestor Optional marker to the selected leaf (#202)', () => {
+    const s = { name: string(), meta: optional(map({ x: double() })) } satisfies DocumentSchema;
+    // The backend materializes intermediate layers and omits only the leaf, so
+    // the projected `meta` is required while `x` becomes optional.
+    const oracle = { meta: map({ x: optional(double()) }) };
+    const actual = buildSelectionSchema(s, ['meta.x']);
+    expect(actual).toStrictEqual(oracle);
+    // @ts-expect-error -- #202: BuildSelectionSchema does not yet propagate ancestor optionality
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
   it("treats '__name__' in an alias like any other key (no special-casing)", () => {
     // The reserved-name rule is deliberately not modelled client-side:
     // aliasing to top-level `'__name__'` is rejected by the backend itself


### PR DESCRIPTION
Adds the failing test cases for #202 as skipped tests, so the expected behavior is pinned in code ahead of the fix.

- **pipeline-spec**: `select through an optional map (#202)` — two `it.skip` cases (a bare dotted path and a `Field` alias through an optional map), seeded with a document lacking the map. **Confirmed genuinely red**: un-skipping them fails live with a `ZodError` (the decode schema types the leaf as required while the backend returns `{ meta: {} }` / omits the alias key).
- **selection.test.ts**: a skipped oracle-both-sides unit test for `buildSelectionSchema` with the corrected leaf-optional oracle.

Expectations the current (wrong) types reject are marked `@ts-expect-error` — when the fix lands they become *unused* directives, so tsc itself forces these tests to be revisited and un-skipped.

Refs #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)