### PR TITLE
Implement the where stage end-to-end

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -255,7 +255,11 @@ Input stages (the `input` stage now carries an `InputSource` payload — see
 
 Transformation stages already stubbed:
 
-- [ ] `where(condition)` — real runtime + AST node + tests.
+- [x] `where(condition)` — stage carries the `Expression<BoolType>` condition,
+      executors translate via `sdk.where(expr.asBoolean())` (a type-tag wrap, no
+      wire change), identity preserved. Verified live incl. chained-where
+      conjunction (AND) and the truthy-only row-drop semantics (missing operand
+      fields drop the row silently).
 - [x] `select(...)` — runtime schema fold (`buildSelectionSchema`, the runtime
       mirror of `BuildSelectionSchema`), stage AST carries conflict-resolved
       selections, executors translate to `sdk.select(...)`, rows decode with

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -108,6 +108,9 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       return sdk.addFields(first, ...rest);
     }
     case 'where':
+      // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
+      // parameter — it does not change the wire proto.
+      return sdk.where(toSdkExpression(stage.condition).asBoolean());
     case 'limit':
     case 'offset':
     case 'unnest':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -293,6 +293,70 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
     });
 
+    describe('where', () => {
+      // items are seeded with rank 1 / 2 / 3 for a1 / a2 / a3.
+      const [a1, _a2, a3] = items;
+
+      it('filters rows by an equality condition, keeping row identity', async () => {
+        await expectPipeline(
+          source().where((field) => equal(field('rank'), constant(1))),
+          [a1],
+          { ordered: false },
+        );
+      });
+
+      it('filters by a nested (dotted) field', async () => {
+        await expectPipeline(
+          source().where((field) => equal(field('profile.age'), constant(40))),
+          [a3],
+          { ordered: false },
+        );
+      });
+
+      it('silently drops rows where the condition does not evaluate to true', async () => {
+        // a2 has no `profile.gender`, so the comparison does not evaluate to
+        // `true` for it — the row is dropped rather than erroring (Firestore's
+        // truthy-only `where` semantics; mixed/missing fields are tolerated).
+        await expectPipeline(
+          source().where((field) => equal(field('profile.gender'), constant('male'))),
+          [a3],
+          { ordered: false },
+        );
+      });
+
+      it('chained where stages conjoin (AND)', async () => {
+        // Each condition matches a row on its own (gender=female -> a1,
+        // rank=3 -> a3), but no row satisfies both — a disjunction would
+        // return two rows, a conjunction none.
+        await expectPipeline(
+          source()
+            .where((field) => equal(field('profile.gender'), constant('female')))
+            .where((field) => equal(field('rank'), constant(3))),
+          [],
+          { ordered: false },
+        );
+
+        // A row satisfying both conditions passes through the chain.
+        await expectPipeline(
+          source()
+            .where((field) => equal(field('profile.gender'), constant('male')))
+            .where((field) => equal(field('rank'), constant(3))),
+          [a3],
+          { ordered: false },
+        );
+      });
+
+      it('composes with a subsequent select over the filtered rows', async () => {
+        await expectPipeline(
+          source()
+            .where((field) => equal(field('rank'), constant(2)))
+            .select(() => ['name']),
+          [{ data: { name: 'bob' } }],
+          { ordered: false },
+        );
+      });
+    });
+
     describe('removeFields', () => {
       it('removes a top-level field, keeping row identity', async () => {
         // `removeFields` is identity-preserving: rows keep their `id`.

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -102,8 +102,18 @@ export class Pipeline<
     return { input: node.stage, transforms };
   }
 
-  where(_condition: (field: FieldProvider<Schema>) => Expression<BoolType>): Pipeline<Schema, Id> {
-    return unimplemented();
+  /**
+   * Filters rows to those where `condition` evaluates to exactly `true`.
+   * Identity-preserving; chained `where` stages conjoin (AND). Rows where the
+   * condition evaluates to anything else — `false`, `null`, a missing field,
+   * a non-boolean — are silently dropped (Firestore's truthy-only semantics).
+   */
+  where(condition: (field: FieldProvider<Schema>) => Expression<BoolType>): Pipeline<Schema, Id> {
+    return new Pipeline<Schema, Id>({
+      schema: this.node.schema,
+      stage: { kind: 'where', condition: condition(fieldProvider(this.node.schema)) },
+      parent: this.node,
+    });
   }
   /**
    * Projects the selections into a new document shape, dropping read-identity

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,5 +1,5 @@
-import type { Collection } from '../schema.js';
-import type { ExpressionWithAlias } from './expression.js';
+import type { BoolType, Collection } from '../schema.js';
+import type { Expression, ExpressionWithAlias } from './expression.js';
 import type { Ordering } from './ordering.js';
 
 /**
@@ -31,7 +31,7 @@ export type InputStage =
 
 /** Transformation stage: reshapes the rows flowing through the pipeline. */
 export type TransformStage =
-  | { kind: 'where' }
+  | { kind: 'where'; condition: Expression<BoolType> }
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -99,6 +99,9 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       return sdk.addFields(first, ...rest);
     }
     case 'where':
+      // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
+      // parameter — it does not change the wire proto.
+      return sdk.where(toSdkExpression(stage.condition).asBoolean());
     case 'limit':
     case 'offset':
     case 'unnest':


### PR DESCRIPTION
Implements the `where` transformation stage across the pipeline AST, both executors, and the behavioural spec — TDD-style, verified live against a real Enterprise DB (27/27 passing, 5 new).

## Spec coverage (new cases)

- equality filter — **row identity preserved** (rows keep `id`)
- nested dotted field condition
- **truthy-only semantics**: a condition over a missing operand field (`profile.gender` absent on a2) silently drops the row instead of erroring
- **chained `where` stages conjoin (AND)** — asserted distinguishably: two individually-matching but disjoint conditions yield no rows (a disjunction would yield two), and a row satisfying both passes through
- composition with a subsequent `select`

## Implementation

- **`stage.ts`** — `{ kind: 'where'; condition: Expression<BoolType> }`
- **`pipeline.ts`** — `where` builds a real node; schema unchanged, `Id` threads through
- **Executors (both SDKs)** — `sdk.where(toSdkExpression(condition).asBoolean())`; `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression` parameter and does not change the wire proto

🤖 Generated with [Claude Code](https://claude.com/claude-code)