### PR TITLE
Cover addFields-then-select composition and the identity ratchet

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -434,7 +434,7 @@ Query API (admin has `query.stream()`, web only `getDocs()`):
   Covers `fetch all` + `sort` asc/desc; add a case per new stage.
 - [x] `fieldTypeOfPath` runtime resolver unit tests
       (`schema.field-type-of-path.test.ts`).
-- [ ] Identity ratchet integration test — confirm a `select` result lacks `id`
+- [x] Identity ratchet integration test — confirm a `select` result lacks `id`
       at runtime (type side is covered by `pipeline.test.ts`).
 - [ ] DML stage tests (`update` / `delete`).
 - [ ] Sub-pipeline / join behavior tests once that's implemented.

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -421,6 +421,48 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
+      it('a subsequent select projects an added field', async () => {
+        // The added field participates in the reshaped schema: `select` can
+        // reference it by path, and the rows decode with it.
+        await expectPipeline(
+          source()
+            .addFields((field) => [equal(field('rank'), constant(2)).as('isSecond')])
+            .select(() => ['name', 'isSecond']),
+          [
+            { data: { name: 'alice', isSecond: false } },
+            { data: { name: 'bob', isSecond: true } },
+            { data: { name: 'carol', isSecond: false } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('a subsequent select projects a field deep-merged into an existing map', async () => {
+        await expectPipeline(
+          source()
+            .addFields((field) => [field('name').as('profile.author')])
+            .select(() => ['profile.author']),
+          [
+            { data: { profile: { author: 'alice' } } },
+            { data: { profile: { author: 'bob' } } },
+            { data: { profile: { author: 'carol' } } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('a subsequent select sees the overwritten field type', async () => {
+        // `rank` was overwritten by a string-typed field; the projected rows
+        // (and their static type) carry the string.
+        await expectPipeline(
+          source()
+            .addFields((field) => [field('name').as('rank')])
+            .select(() => ['rank']),
+          [{ data: { rank: 'alice' } }, { data: { rank: 'bob' } }, { data: { rank: 'carol' } }],
+          { ordered: false },
+        );
+      });
+
       it('composes with a subsequent sort over the added field', async () => {
         await expectPipeline(
           source()

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 
 import {
   type AuthorsCollection,
@@ -8,7 +8,8 @@ import {
 import type { DocRef } from '../repository.js';
 import type { StringType } from '../schema.js';
 import { equal } from './expression.js';
-import { collection, type Pipeline } from './index.js';
+import { collection, type Pipeline, type PipelineResult } from './index.js';
+import { asc } from './ordering.js';
 
 describe('pipeline', () => {
   const base = collection(authorsCollection);
@@ -37,6 +38,23 @@ describe('pipeline', () => {
     collection(postsCollection, ['author1']); // parent doc ref: ok
     // @ts-expect-error -- parent doc ref length must match the parent path
     collection(postsCollection, ['author1', 'extra']);
+  });
+
+  it('identity ratchet: preserving stages keep `id`, select drops it for good', () => {
+    // The result-row type of a pipeline: `id` present iff `Id` is a `DocRef`.
+    type RowOf<P> = P extends Pipeline<infer S, infer I> ? PipelineResult<S, I> : never;
+
+    // A chain of identity-preserving stages keeps `id` on the result rows.
+    const preserved = base.removeFields('tag').addFields((field) => [field('rank').as('score')]);
+    expectTypeOf<RowOf<typeof preserved>>().toHaveProperty('id');
+
+    // `select` drops it...
+    const projected = preserved.select(() => ['name']);
+    expectTypeOf<RowOf<typeof projected>>().not.toHaveProperty('id');
+
+    // ...and a downstream preserving stage never brings it back.
+    const after = projected.sort((field) => [asc(field('name'))]);
+    expectTypeOf<RowOf<typeof after>>().not.toHaveProperty('id');
   });
 
   it('__name__ is not projectable (keeps `select`/`removeFields` honest)', () => {


### PR DESCRIPTION
Test-only PR: composition coverage between the projection stages, plus the explicit identity-ratchet type test.

## New live spec cases (30/30 passing incl. these)

- `addFields` computed field → `select` projects it (`['name', 'isSecond']`)
- `addFields` deep-merged into an existing map → `select(['profile.author'])` resolves the dotted path over the merged schema
- `addFields` overwriting `rank` with a string → `select(['rank'])` rows (and their static type) carry the string

These exercise the runtime schema threading end-to-end: field resolution and row decoding both run over `buildAddFieldsSchema`'s output. The expected rows also assert identity loss at runtime (no `id` after `select`; strict deep equality fails on extra keys).

## Identity ratchet type test

`pipeline.test.ts` now pins the ratchet the plan doc listed as an open item: a preserving chain (`removeFields` → `addFields`) has `id` on its result-row type, `select` drops it, and a downstream preserving `sort` never brings it back (`expectTypeOf(...).not.toHaveProperty('id')`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)