### PR TITLE
Require at least one selection; pin negative schema threading and __name__ sort

### DIFF
--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -117,6 +117,15 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
           [a3, a2, a1],
         );
       });
+
+      it('sorts by the reserved __name__ key (the document id)', async () => {
+        // `__name__` stays addressable in `sort` / `where` even though it is
+        // not projectable — ids a1 < a2 < a3, so descending reverses them.
+        await expectPipeline(
+          source().sort((field) => [desc(field('__name__'))]),
+          [a3, a2, a1],
+        );
+      });
     });
 
     describe('select', () => {

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   type AuthorsCollection,
@@ -9,6 +9,7 @@ import type { DocRef } from '../repository.js';
 import type { StringType } from '../schema.js';
 import { equal } from './expression.js';
 import { collection, type Pipeline } from './index.js';
+import { asc } from './ordering.js';
 
 describe('pipeline', () => {
   const base = collection(authorsCollection);
@@ -37,6 +38,22 @@ describe('pipeline', () => {
     collection(postsCollection, ['author1']); // parent doc ref: ok
     // @ts-expect-error -- parent doc ref length must match the parent path
     collection(postsCollection, ['author1', 'extra']);
+  });
+
+  it('reshaped schemas reject stale field references downstream', () => {
+    // Schema threading is bidirectional: reshaping stages not only expose new
+    // fields downstream, they revoke the removed ones — at the type level AND
+    // at runtime (the field provider resolves against the reshaped schema).
+
+    expect(() =>
+      // @ts-expect-error -- `rank` is not part of the projected schema
+      base.select(() => ['name']).sort((field) => [asc(field('rank'))]),
+    ).toThrow('schema has no field "rank"');
+
+    expect(() =>
+      // @ts-expect-error -- `tag` was removed by removeFields
+      base.removeFields('tag').where((field) => equal(field('tag'), field('tag'))),
+    ).toThrow('schema has no field "tag"');
   });
 
   it('__name__ is not projectable (keeps `select`/`removeFields` honest)', () => {

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -128,7 +128,9 @@ export class Pipeline<
    * (the fuller "conditionally preserve identity via `__name__`" model, plus
    * `createTime` / `updateTime`, is deferred — see `docs/plan/pipeline-query.md`).
    */
-  select<const Selections extends readonly Selection<Schema>[]>(
+  // At least one selection is required (mirrors the SDK's
+  // `select(selection, ...rest)` signature; an empty projection is meaningless).
+  select<const Selections extends readonly [Selection<Schema>, ...Selection<Schema>[]]>(
     selections: (field: FieldProvider<Schema>) => Selections,
   ): Pipeline<BuildSelectionSchema<Schema, Selections>, undefined> {
     const resolved = selections(fieldProvider(this.node.schema));
@@ -149,7 +151,7 @@ export class Pipeline<
    * Aliased expressions only — bare field paths are rejected at the type
    * level (see {@link BuildAddFieldsSchema} for why they are a foot-gun).
    */
-  addFields<const Selections extends readonly ExpressionWithAlias[]>(
+  addFields<const Selections extends readonly [ExpressionWithAlias, ...ExpressionWithAlias[]]>(
     fields: (field: FieldProvider<Schema>) => Selections,
   ): Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id> {
     const resolved = fields(fieldProvider(this.node.schema));


### PR DESCRIPTION
Edge-case hardening for the projection stages (part 1 of 3).

- **API consistency fix**: `select` / `addFields` now require ≥1 selection at the type level (`[S, ...S[]]`), matching `removeFields`. Previously `select(() => [])` compiled but threw in the executor — a call the types declared valid failing at runtime.
- **Negative schema threading**: new test pinning that reshaping stages *revoke* stale field references downstream, at both layers — a projected-away / removed field is a compile error, and (with the type error suppressed) the field provider throws `schema has no field "…"` at build time.
- **`__name__` sort, live**: the repeated claim that the reserved key stays addressable in `sort` / `where` was compile-tested only; now verified against the real backend (28/28 live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)