### PR TITLE
Add live spec coverage for the subcollection and collectionGroup inputs

### DIFF
--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -112,14 +112,18 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       // `postsCollection` is a subcollection under `Authors`. `uniqueCollection`
       // renames only the collection itself, so instances land under
       // `Authors/<parent id>/<unique name>` and the group id is unique per run.
-      const postItems: [Doc<PostsCollection>, Doc<PostsCollection>] = [
+      const postItems: [Doc<PostsCollection>, Doc<PostsCollection>, Doc<PostsCollection>] = [
         {
           id: ['author1', 'p1'],
           data: { title: 'first', postedAt: new Date('2024-01-01T00:00:00Z') },
         },
         {
-          id: ['author2', 'p2'],
+          id: ['author1', 'p2'],
           data: { title: 'second', postedAt: new Date('2024-02-01T00:00:00Z') },
+        },
+        {
+          id: ['author2', 'p3'],
+          data: { title: 'third', postedAt: new Date('2024-03-01T00:00:00Z') },
         },
       ];
 
@@ -130,8 +134,9 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
 
       it('reads a specific subcollection instance located by its parent doc ref', async () => {
-        // Only author1's posts; the row ids are full (parent-inclusive) refs.
-        await expectPipeline(collectionInput(posts, ['author1']), [postItems[0]], {
+        // All of author1's posts (and only those); the row ids are full
+        // (parent-inclusive) refs.
+        await expectPipeline(collectionInput(posts, ['author1']), [postItems[0], postItems[1]], {
           ordered: false,
         });
       });

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -8,7 +8,10 @@ import type {
   PipelineResult,
   PipelineRowIdentity,
 } from '../pipelines/pipeline.js';
-import { collection as collectionInput } from '../pipelines/source.js';
+import {
+  collection as collectionInput,
+  collectionGroup as collectionGroupInput,
+} from '../pipelines/source.js';
 import type { Doc, DocRef, FirestoreEnvironment, PlainRepository } from '../repository.js';
 import {
   type Collection,
@@ -19,7 +22,12 @@ import {
   rootCollection,
   string,
 } from '../schema.js';
-import { type AuthorsCollection, authorsCollection } from './specification.js';
+import {
+  type AuthorsCollection,
+  authorsCollection,
+  type PostsCollection,
+  postsCollection,
+} from './specification.js';
 import { uniqueCollection } from './util.js';
 
 /**
@@ -97,6 +105,39 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       it('fetches all documents of a collection with their ids', async () => {
         // A bare collection input has no defined order, so compare as a set.
         await expectPipeline(source(), items, { ordered: false });
+      });
+    });
+
+    describe('input stages (subcollection / collection group)', () => {
+      // `postsCollection` is a subcollection under `Authors`. `uniqueCollection`
+      // renames only the collection itself, so instances land under
+      // `Authors/<parent id>/<unique name>` and the group id is unique per run.
+      const postItems: [Doc<PostsCollection>, Doc<PostsCollection>] = [
+        {
+          id: ['author1', 'p1'],
+          data: { title: 'first', postedAt: new Date('2024-01-01T00:00:00Z') },
+        },
+        {
+          id: ['author2', 'p2'],
+          data: { title: 'second', postedAt: new Date('2024-02-01T00:00:00Z') },
+        },
+      ];
+
+      let posts: PostsCollection;
+      beforeEach(async () => {
+        posts = uniqueCollection(postsCollection);
+        await createRepository(posts).batchSet(postItems);
+      });
+
+      it('reads a specific subcollection instance located by its parent doc ref', async () => {
+        // Only author1's posts; the row ids are full (parent-inclusive) refs.
+        await expectPipeline(collectionInput(posts, ['author1']), [postItems[0]], {
+          ordered: false,
+        });
+      });
+
+      it('reads every instance of a subcollection via a collection group', async () => {
+        await expectPipeline(collectionGroupInput(posts), postItems, { ordered: false });
       });
     });
 


### PR DESCRIPTION
Edge-case hardening part 2 of 3: the `collection(def, parent)` (subcollection instance) and `collectionGroup` input stages were implemented earlier but had **zero live coverage** — the spec only ever used a root collection input.

New spec describe seeds a posts subcollection under two different parents:

- **subcollection instance** — `collection(posts, ['author1'])` returns only that parent's rows, with full parent-inclusive `DocRef`s (exercises `collectionPath` resolution)
- **collection group** — `collectionGroup(posts)` returns rows from every instance, with full ids (exercises the executor's nested `DocRef` reconstruction)

Both passing live against the Enterprise DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)