### PR TITLE
Pin sort semantics: missing-field placement and multi-key precedence

### DIFF
--- a/docs/pipeline-query-ordering-research.md
+++ b/docs/pipeline-query-ordering-research.md
@@ -1,0 +1,36 @@
+# Pipeline Query — `sort` ordering semantics
+
+> Empirical notes on how the pipeline `sort` stage orders rows, focusing on
+> where it diverges from core-query `orderBy`. Probed 2026-07 against a real
+> Firestore Enterprise database (`ikenox-sunrise` /
+> `enterprise-native-playground`) via `@google-cloud/firestore@8.6.0`
+> (`probe-sort-missing.mjs` under gitignored `./.ikenox/`).
+
+## Rows missing the sort field are kept, not excluded
+
+The core-query `orderBy` **excludes** documents that lack the ordered field
+(an artifact of index-based execution). Pipeline `sort` — index-optional —
+**keeps** them and gives absence a position in the total order.
+
+## The total order around absence
+
+Seeded `v: 1`, `v: 3`, `v: null`, and a document without `v`:
+
+```
+sort(v ascending):   null  <  (absent)  <  1  <  3
+sort(v descending):  3  >  1  >  (absent)  >  null   (exact mirror)
+```
+
+- `null` and _absent_ are **distinct positions**: `null` orders before an
+  absent field ascending.
+- Both order before every present value; descending is the exact reverse
+  (absence is not pinned to one end).
+
+Covered by the pipeline spec: sorting the authors seed by the optional
+`profile.gender` keeps the document lacking it (first ascending, last
+descending).
+
+## Multiple sort keys
+
+Standard lexicographic behavior — the earlier ordering takes precedence and
+later orderings break its ties (covered by the spec's composite-keys case).

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -21,6 +21,7 @@ such); only the final `pipeline` → `main` merge needs to be release-ready.
 Related research / decisions:
 
 - [`../pipeline-query-identity-research.md`](../pipeline-query-identity-research.md) — which stages preserve `id` / `ref` / `createTime` / `updateTime`.
+- [`../pipeline-query-ordering-research.md`](../pipeline-query-ordering-research.md) — `sort` keeps rows missing the field (unlike core `orderBy`); `null` < absent < values.
 - [`../pipeline-query-projection-research.md`](../pipeline-query-projection-research.md) — `select` / `add_fields` output shaping (dotted-name materialization, conflict rejection vs the library's last-wins, add_fields merge rules).
 
 ## Current status (snapshot — read this first)

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -117,6 +117,48 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
           [a3, a2, a1],
         );
       });
+
+      it('keeps rows missing the sort field, ordering them before all values', async () => {
+        // Unlike core-query `orderBy` (which EXCLUDES documents lacking the
+        // field), pipeline `sort` keeps them: absent orders before every
+        // present value (and after `null`) ascending, and mirrored descending.
+        // a2 has no `profile.gender`; 'female' (a1) < 'male' (a3).
+        await expectPipeline(
+          source().sort((field) => [asc(field('profile.gender'))]),
+          [a2, a1, a3],
+        );
+        await expectPipeline(
+          source().sort((field) => [desc(field('profile.gender'))]),
+          [a3, a1, a2],
+        );
+      });
+
+      describe('multiple sort keys', () => {
+        const compositeCollection = rootCollection({
+          name: 'SortComposite',
+          schema: { group: string(), n: double() },
+        });
+        type CompositeDoc = Doc<typeof compositeCollection>;
+        const compositeItems: [CompositeDoc, CompositeDoc, CompositeDoc] = [
+          { id: ['s1'], data: { group: 'x', n: 1 } },
+          { id: ['s2'], data: { group: 'x', n: 2 } },
+          { id: ['s3'], data: { group: 'y', n: 3 } },
+        ];
+
+        let composite: typeof compositeCollection;
+        beforeEach(async () => {
+          composite = uniqueCollection(compositeCollection);
+          await createRepository(composite).batchSet(compositeItems);
+        });
+
+        it('the earlier key takes precedence; later keys break its ties', async () => {
+          const [x1, x2, y3] = compositeItems;
+          await expectPipeline(
+            collectionInput(composite).sort((field) => [asc(field('group')), desc(field('n'))]),
+            [x2, x1, y3],
+          );
+        });
+      });
     });
 
     describe('select', () => {


### PR DESCRIPTION
Edge-case hardening part 3 of 3: `sort` ordering semantics, probed live first.

## Findings (new `docs/pipeline-query-ordering-research.md`)

- **Rows missing the sort field are kept** — a sharp divergence from core-query `orderBy`, which excludes documents lacking the field (index artifact). Pipeline sort is index-optional and gives absence a position.
- **Total order around absence**: `null` < *absent* < every present value (ascending); descending is the exact mirror. `null` and absent are distinct positions.

## New spec cases (29/29 live)

- sorting the authors seed by the optional `profile.gender`: the document lacking it orders first ascending / last descending (asserted both directions)
- composite sort keys over a dedicated seeded collection with a tie: the earlier ordering takes precedence, later orderings break its ties

🤖 Generated with [Claude Code](https://claude.com/claude-code)