### PR TITLE
Implement the limit and offset stages end-to-end

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -278,7 +278,9 @@ Transformation stages already stubbed:
       stage carries the field paths, executors translate to `sdk.removeFields(...)`,
       identity preserved (`Id` threads through). Verified live.
 - [ ] `distinct(...)` — Context shrinkage + identity break.
-- [ ] `limit(N)` / `offset(N)` — Context unchanged + identity preserve.
+- [x] `limit(N)` / `offset(N)` — stages carry the count, executors translate
+      to `sdk.limit/offset`, schema unchanged, identity preserved. Verified live
+      incl. offset+limit paging and an over-sized limit.
 - [ ] `unnest(...)` — Context augmentation + identity preserve.
 - [ ] `replaceWith(...)` — Context replacement + identity break.
 - [ ] `union(other)` — combine sources; identity break (conservative).

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -112,7 +112,9 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       // parameter — it does not change the wire proto.
       return sdk.where(toSdkExpression(stage.condition).asBoolean());
     case 'limit':
+      return sdk.limit(stage.limit);
     case 'offset':
+      return sdk.offset(stage.offset);
     case 'unnest':
     case 'aggregate':
     case 'distinct':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -216,6 +216,49 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
     });
 
+    describe('limit / offset', () => {
+      // items are seeded with rank 1 / 2 / 3 for a1 / a2 / a3; sort first so
+      // the truncation point is deterministic.
+      const [a1, a2, a3] = items;
+
+      it('limit truncates the sorted rows, keeping row identity', async () => {
+        await expectPipeline(
+          source()
+            .sort((field) => [asc(field('rank'))])
+            .limit(2),
+          [a1, a2],
+        );
+      });
+
+      it('offset skips the leading sorted rows', async () => {
+        await expectPipeline(
+          source()
+            .sort((field) => [asc(field('rank'))])
+            .offset(1),
+          [a2, a3],
+        );
+      });
+
+      it('offset then limit pages through the rows', async () => {
+        await expectPipeline(
+          source()
+            .sort((field) => [asc(field('rank'))])
+            .offset(1)
+            .limit(1),
+          [a2],
+        );
+      });
+
+      it('a limit larger than the row count returns everything', async () => {
+        await expectPipeline(
+          source()
+            .sort((field) => [asc(field('rank'))])
+            .limit(100),
+          [a1, a2, a3],
+        );
+      });
+    });
+
     describe('select', () => {
       it('projects a single top-level field, dropping row identity', async () => {
         // `select` breaks read-identity: the result rows carry no `id`.

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -182,11 +182,21 @@ export class Pipeline<
       parent: this.node,
     });
   }
-  limit(_limit: number): Pipeline<Schema, Id> {
-    return unimplemented();
+  /** Truncates to the first `limit` rows. Identity-preserving; schema unchanged. */
+  limit(limit: number): Pipeline<Schema, Id> {
+    return new Pipeline<Schema, Id>({
+      schema: this.node.schema,
+      stage: { kind: 'limit', limit },
+      parent: this.node,
+    });
   }
-  offset(_offset: number): Pipeline<Schema, Id> {
-    return unimplemented();
+  /** Skips the first `offset` rows. Identity-preserving; schema unchanged. */
+  offset(offset: number): Pipeline<Schema, Id> {
+    return new Pipeline<Schema, Id>({
+      schema: this.node.schema,
+      stage: { kind: 'offset', offset },
+      parent: this.node,
+    });
   }
   // TODO
   unnest(..._args: unknown[]): Pipeline<Fields, Id> {

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -41,8 +41,8 @@ export type TransformStage =
   | { kind: 'addFields'; selections: readonly ExpressionWithAlias[] }
   | { kind: 'removeFields'; fields: readonly string[] }
   | { kind: 'sort'; orderings: Ordering[] }
-  | { kind: 'limit' }
-  | { kind: 'offset' }
+  | { kind: 'limit'; limit: number }
+  | { kind: 'offset'; offset: number }
   | { kind: 'unnest' }
   | { kind: 'aggregate' }
   | { kind: 'distinct' }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -103,7 +103,9 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       // parameter — it does not change the wire proto.
       return sdk.where(toSdkExpression(stage.condition).asBoolean());
     case 'limit':
+      return sdk.limit(stage.limit);
     case 'offset':
+      return sdk.offset(stage.offset);
     case 'unnest':
     case 'aggregate':
     case 'distinct':


### PR DESCRIPTION
Implements the `limit` / `offset` transformation stages across the pipeline AST, both executors, and the behavioural spec — TDD-style, verified live against a real Enterprise DB (39/39 passing, 4 new).

## Spec coverage (new cases)

- `limit` truncates the sorted rows — **row identity preserved**
- `offset` skips the leading sorted rows
- `offset` + `limit` paging composition
- an over-sized `limit` returns everything

## Implementation

- **`stage.ts`** — `{ kind: 'limit'; limit: number }` / `{ kind: 'offset'; offset: number }`
- **`pipeline.ts`** — real nodes; schema unchanged, `Id` threads through
- **Executors (both SDKs)** — `sdk.limit(n)` / `sdk.offset(n)`

Validation of the count (negative / non-integer) is deliberately left to the backend's own loud validation, per the established rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)