### PR TITLE
Propagate ancestor optionality to the selected leaf

### DIFF
--- a/docs/pipeline-query-projection-research.md
+++ b/docs/pipeline-query-projection-research.md
@@ -53,10 +53,11 @@ Implications for the schema model:
   (`{ meta?: { x } }` --select('meta.x')--> `{ meta: { x?} }`).
 - Selecting a whole optional map by key keeps the key optional (absent when
   the source lacks it).
-- As of this writing the library does **not** yet propagate ancestor
-  optionality to the leaf — tracked in
-  [#202](https://github.com/ikenox/firestore-repository/issues/202) with
-  skipped red tests.
+- The library models this via `IsConditionalPath` / `WithConditionality` in
+  `selection.ts`: a selection reading a source field path (bare, or a
+  `Field`-expression alias) marks the projected leaf `Optional` when the path
+  crosses an optional ancestor
+  ([#202](https://github.com/ikenox/firestore-repository/issues/202)).
 - The backend output erases the distinction between "parent missing" and
   "parent present but leaf missing" — both yield materialized-empty parents.
   The library deliberately models the wire shape as-is (source-modal

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -385,15 +385,12 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
     });
 
-    // TODO(#202): un-skip once ancestor optionality propagates to the selected
-    // leaf. Selecting through an optional map currently types the leaf as
-    // required, but the backend materializes the intermediate layers and omits
-    // only the leaf (`{ meta: {} }` for a doc without `meta`) — so decoding
-    // real data throws (confirmed live: both tests fail with a ZodError when
-    // un-skipped). The `@ts-expect-error`s below mark expectations the current
-    // (wrong) types reject; the fix will turn them into unused directives,
-    // forcing this suite to be revisited.
-    describe('select through an optional map (#202)', () => {
+    // Ancestor optionality moves onto the projected leaf: the backend
+    // materializes a dotted selection's intermediate layers and omits only the
+    // leaf, so a path through an optional map yields an optional leaf (and an
+    // aliased read of it an optional key). See
+    // docs/pipeline-query-projection-research.md.
+    describe('select through an optional map', () => {
       const optionalMetaCollection = rootCollection({
         name: 'OptionalMeta',
         schema: { name: string(), meta: optional(map({ x: double() })) },
@@ -408,26 +405,18 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         ]);
       });
 
-      it.skip('a dotted path through an optional map yields an optional leaf', async () => {
+      it('a dotted path through an optional map yields an optional leaf', async () => {
         await expectPipeline(
           collectionInput(coll).select(() => ['meta.x']),
-          [
-            { data: { meta: { x: 1 } } },
-            // @ts-expect-error -- #202: the leaf must become optional; the backend returns `{ meta: {} }` here
-            { data: { meta: {} } },
-          ],
+          [{ data: { meta: { x: 1 } } }, { data: { meta: {} } }],
           { ordered: false },
         );
       });
 
-      it.skip('an alias of a field under an optional map yields an optional key', async () => {
+      it('an alias of a field under an optional map yields an optional key', async () => {
         await expectPipeline(
           collectionInput(coll).select((field) => ['name', field('meta.x').as('mx')]),
-          [
-            { data: { name: 'with-meta', mx: 1 } },
-            // @ts-expect-error -- #202: `mx` must become optional; the backend omits the key here
-            { data: { name: 'without-meta' } },
-          ],
+          [{ data: { name: 'with-meta', mx: 1 } }, { data: { name: 'without-meta' } }],
           { ordered: false },
         );
       });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   array,
   type ArrayType,
+  bool,
   type DocumentSchema,
   double,
   type DoubleType,
@@ -15,7 +16,7 @@ import {
   string,
   type StringType,
 } from '../schema.js';
-import { field } from './expression.js';
+import { constant, equal, field } from './expression.js';
 import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
@@ -442,18 +443,50 @@ describe('buildSelectionSchema (runtime)', () => {
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
-  // TODO(#202): un-skip once ancestor optionality propagates to the selected
-  // leaf. The `@ts-expect-error` marks the type-level expectation the current
-  // (wrong) `BuildSelectionSchema` rejects; the fix will turn it into an
-  // unused directive, forcing this test to be revisited.
-  it.skip('propagates an ancestor Optional marker to the selected leaf (#202)', () => {
+  it('propagates an ancestor Optional marker to the selected leaf', () => {
     const s = { name: string(), meta: optional(map({ x: double() })) } satisfies DocumentSchema;
     // The backend materializes intermediate layers and omits only the leaf, so
     // the projected `meta` is required while `x` becomes optional.
     const oracle = { meta: map({ x: optional(double()) }) };
     const actual = buildSelectionSchema(s, ['meta.x']);
     expect(actual).toStrictEqual(oracle);
-    // @ts-expect-error -- #202: BuildSelectionSchema does not yet propagate ancestor optionality
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('propagates a mid-path Optional marker from deeper nesting', () => {
+    const s = { a: map({ b: optional(map({ c: double() })) }) } satisfies DocumentSchema;
+    // The optional segment is in the middle: output layers are required maps,
+    // only the leaf carries the conditionality.
+    const oracle = { a: map({ b: map({ c: optional(double()) }) }) };
+    const actual = buildSelectionSchema(s, ['a.b.c']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('marks an aliased Field of a conditional path optional; computed expressions stay required', () => {
+    const s = { name: string(), meta: optional(map({ x: double() })) } satisfies DocumentSchema;
+
+    const aliased = buildSelectionSchema(s, [field(s.meta.fields.x, 'meta.x').as('mx')]);
+    const aliasedOracle = { mx: optional(double()) };
+    expect(aliased).toStrictEqual(aliasedOracle);
+    expectTypeOf(aliased).toEqualTypeOf(aliasedOracle);
+
+    // A computed expression always produces a value — no conditionality.
+    const computed = buildSelectionSchema(s, [
+      equal(field(s.meta.fields.x, 'meta.x'), constant(1)).as('isOne'),
+    ]);
+    const computedOracle = { isOne: bool() };
+    expect(computed).toStrictEqual(computedOracle);
+    expectTypeOf(computed).toEqualTypeOf(computedOracle);
+  });
+
+  it('selecting a whole optional map keeps the key itself optional', () => {
+    const s = { name: string(), meta: optional(map({ x: double() })) } satisfies DocumentSchema;
+    // Whole-key selection: absence stays on the key (the backend omits it),
+    // not on the leaves inside.
+    const oracle = { meta: s.meta };
+    const actual = buildSelectionSchema(s, ['meta']);
+    expect(actual).toStrictEqual(oracle);
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -7,8 +7,11 @@ import {
   map,
   type MapFieldPath,
   type MapType,
+  type Optional,
+  optional,
 } from '../schema.js';
-import type { ExpressionWithAlias } from './expression.js';
+import { assertNever } from '../util.js';
+import type { ExpressionWithAlias, Field } from './expression.js';
 
 // Re-exported for consumers of the selection model; the type itself lives in
 // `expression.ts` (it is produced by `Expression.as(...)`).
@@ -108,15 +111,54 @@ export type BuildAddFieldsSchema<
   ? MergeSchemas<BuildSelectionSchema<Context, Args>, Context>
   : never;
 
-/** Resolves one selection into the partial schema it contributes to the output. */
-type SelectionToSchema<Context extends Fields, S> =
-  S extends ExpressionWithAlias<infer T, infer P>
+/**
+ * Resolves one selection into the partial schema it contributes to the output.
+ * Selections that read a source **field path** (bare paths, and aliases whose
+ * expression is a `Field`) mark the projected leaf `Optional` when the path
+ * crosses an optional ancestor ({@link WithConditionality}); computed
+ * expressions always produce a value and stay as-is.
+ */
+type SelectionToSchema<Context extends Fields, S> = S extends {
+  expression: Field<infer T, infer P>;
+  alias: infer A extends string;
+}
+  ? PathToSchema<A, WithConditionality<Context, P, T>>
+  : S extends ExpressionWithAlias<infer T, infer P>
     ? PathToSchema<P, T>
     : S extends string
       ? S extends MapFieldPath<Context>
-        ? PathToSchema<S, FieldTypeOfPath<Context, S>>
+        ? PathToSchema<S, WithConditionality<Context, S, FieldTypeOfPath<Context, S>>>
         : {}
       : {};
+
+/**
+ * Marks the resolved leaf type `Optional` when its source path is conditional
+ * ({@link IsConditionalPath}). The backend materializes the intermediate
+ * output layers of a dotted selection and omits only the leaf, so the
+ * projection moves ancestor optionality onto the leaf — see
+ * `docs/pipeline-query-projection-research.md`.
+ */
+type WithConditionality<Context extends Fields, P extends string, T extends FieldType> =
+  IsConditionalPath<Context, P> extends true ? T & Optional : T;
+
+/**
+ * Whether the value at `P` can be absent even though the path is well-typed:
+ * true when any **ancestor** segment carries the `Optional` marker. The leaf's
+ * own marker is not this type's concern — it already survives through
+ * `FieldTypeOfPath`.
+ */
+type IsConditionalPath<
+  Context extends Fields,
+  P extends string,
+> = P extends `${infer Head}.${infer Rest}`
+  ? Head extends keyof Context
+    ? Context[Head] extends Optional
+      ? true
+      : Context[Head] extends MapType<infer F>
+        ? IsConditionalPath<F, Rest>
+        : false
+    : false
+  : false;
 
 /**
  * Builds a single-entry schema where dots in `Path` produce nested `MapType` layers.
@@ -232,10 +274,46 @@ const foldSelections = (
  * strings is unreachable through the typed API, so a throw is the defensive
  * equivalent).
  */
-const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fields =>
-  typeof s === 'string'
-    ? pathToSchema(s, fieldTypeOfPath<Fields, string>(schema, s))
-    : pathToSchema(s.alias, s.expression.type);
+const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fields => {
+  if (typeof s === 'string') {
+    return pathToSchema(
+      s,
+      withConditionality(schema, s, fieldTypeOfPath<Fields, string>(schema, s)),
+    );
+  }
+  const { expression, alias } = s;
+  switch (expression.kind) {
+    case 'field':
+      return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
+    case 'constant':
+    case 'functionCall':
+      return pathToSchema(alias, expression.type);
+    default:
+      return assertNever(expression);
+  }
+};
+
+/** Runtime counterpart of {@link WithConditionality}. */
+const withConditionality = (schema: Fields, path: string, type: FieldType): FieldType =>
+  isConditionalPath(schema, path) ? optional(type) : type;
+
+/** Runtime counterpart of {@link IsConditionalPath}. */
+const isConditionalPath = (schema: Fields, path: string): boolean => {
+  const dot = path.indexOf('.');
+  if (dot < 0) {
+    return false;
+  }
+  const head = schema[path.slice(0, dot)];
+  if (head === undefined) {
+    return false;
+  }
+  // Read the marker before `isMapType` narrows the descriptor to `MapType`
+  // (narrowing drops the `optional?` part of the `MapFields` intersection).
+  if (head.optional === true) {
+    return true;
+  }
+  return isMapType(head) ? isConditionalPath(head.fields, path.slice(dot + 1)) : false;
+};
 
 /** Runtime counterpart of {@link SelectionPath}. */
 const selectionPath = (s: string | ExpressionWithAlias): string =>


### PR DESCRIPTION
Fixes #202.

Selecting through an optional map typed the leaf as required, while the backend materializes a dotted selection's intermediate layers and omits **only the leaf** (`{ meta: {} }` for a document without `meta`) — so decoding real data threw a ZodError. The projection now moves ancestor optionality onto the leaf:

```
source:            { meta?: { x: number } }
select('meta.x') → { meta: { x?: number } }   // parent materialized-required, leaf optional
```

## Implementation (`selection.ts` only, per the type/runtime mirroring guideline)

- **`IsConditionalPath<Context, P>`** — true when any *ancestor* segment of the path carries the `Optional` marker (the leaf's own marker already survives via `FieldTypeOfPath`).
- **`WithConditionality`** — intersects the resolved leaf type with `Optional` when conditional.
- **`SelectionToSchema`** applies it to selections that *read a source field path*: bare paths, and aliases whose expression is a `Field` (probed first: an `addFields`/`select` alias of a missing field omits the output key). Computed expressions always produce a value and stay required.
- Runtime mirrors 1:1 (`isConditionalPath` / `withConditionality`).
- `addFields` inherits the rule through `BuildSelectionSchema`.

## Tests

- The three #202 **red tests un-skipped** — their `@ts-expect-error` directives went unused exactly as designed, with tsc forcing the revisit. Both live spec cases now pass (41/41).
- New oracle-both-sides unit cases: mid-path optional in deeper nesting, aliased-`Field` vs computed-expression conditionality, and whole-key optional-map selection keeping absence on the key itself.
- Research doc updated to reflect the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)