### PR TITLE
Shape-grouped function calls; comparison and logical operators

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -331,25 +331,30 @@ Deferred to a later iteration (still tracked here, not currently in scope):
 
 ## Expressions — remaining gaps
 
-- [ ] **Restructure `FunctionCall` into shape-grouped classes when the ~85
-      factories return.** Decided design (2026-07): don't do one class per
-      function (SDK-style, ~85 classes, giant `Expression` union) and don't
-      keep the current single `FunctionCall` with untyped `args: Expression[]`
-      (forces runtime arity guards in every executor — see
-      `toSdkFunctionCall`'s `left === undefined` checks). Instead, one class
-      per **shape** (`UnaryFunction` / `BinaryFunction` / `VariadicFunction` /
-      individual classes for irregulars like `findNearest` / `cond`), each
-      with typed payload fields (`left` / `right` / `operands`) and a
-      per-shape `name: <Shape>FunctionName` string-literal union. - Executors then translate each shape with a
-      `Record<BinaryFunctionName, (l, r) => SdkExpr>` lookup table — the
-      `Record` requires every key, giving the same exhaustiveness guarantee
-      as `assertNever` without per-function `case`s, and the arity guards
-      disappear into the types. - Rationale: a Visitor and a `name` string-union switch are the same
-      case-analysis over a closed sum (same side of the expression problem);
-      the only substantive win available is typed payloads, and shape
-      granularity gets it with ~5 classes instead of ~85. Per-function
-      individuality (operand/return typing like `equal`'s overloads) stays
-      in the factory signatures.
+- [~] **Restructure `FunctionCall` into shape-grouped classes when the ~85
+  factories return.** DONE for the structure plus the comparison
+  (`equal` / `notEqual` / `lessThan` / `lessThanOrEqual` / `greaterThan` /
+  `greaterThanOrEqual`) and logical (`and` / `or` / `not`) factories;
+  remaining categories (arithmetic / string / array / map / timestamp /
+  vector / ...) slot into the same shapes as they return. Decided design
+  (2026-07): don't do one class per
+  function (SDK-style, ~85 classes, giant `Expression` union) and don't
+  keep the current single `FunctionCall` with untyped `args: Expression[]`
+  (forces runtime arity guards in every executor — see
+  `toSdkFunctionCall`'s `left === undefined` checks). Instead, one class
+  per **shape** (`UnaryFunction` / `BinaryFunction` / `VariadicFunction` /
+  individual classes for irregulars like `findNearest` / `cond`), each
+  with typed payload fields (`left` / `right` / `operands`) and a
+  per-shape `name: <Shape>FunctionName` string-literal union. - Executors then translate each shape with a
+  `Record<BinaryFunctionName, (l, r) => SdkExpr>` lookup table — the
+  `Record` requires every key, giving the same exhaustiveness guarantee
+  as `assertNever` without per-function `case`s, and the arity guards
+  disappear into the types. - Rationale: a Visitor and a `name` string-union switch are the same
+  case-analysis over a closed sum (same side of the expression problem);
+  the only substantive win available is typed payloads, and shape
+  granularity gets it with ~5 classes instead of ~85. Per-function
+  individuality (operand/return typing like `equal`'s overloads) stays
+  in the factory signatures.
 - [ ] Per-op numeric return type refinement (Int64-pair → Int64 vs
       auto-widen to Double) — TODO comments already in `expression.ts`.
 - [ ] Improve `constant(value)` type inference from runtime value

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -1,18 +1,28 @@
 import type { Firestore } from '@firebase/firestore';
 import {
+  and as sdkAnd,
   constant as sdkConstant,
   equal as sdkEqual,
   execute as executePipeline,
   field,
+  greaterThan as sdkGreaterThan,
+  greaterThanOrEqual as sdkGreaterThanOrEqual,
+  lessThan as sdkLessThan,
+  lessThanOrEqual as sdkLessThanOrEqual,
+  not as sdkNot,
+  notEqual as sdkNotEqual,
+  or as sdkOr,
   type Expression as SdkExpression,
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
 } from '@firebase/firestore/pipelines';
 import { collectionPath } from 'firestore-repository/path';
 import type {
+  BinaryFunctionName,
   Expression,
   ExpressionWithAlias,
-  FunctionCall,
+  UnaryFunctionName,
+  VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
@@ -147,32 +157,51 @@ const toSdkExpression = (expression: Expression): SdkExpression => {
     case 'constant':
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `Constant.value` is untyped (TODO in expression.ts); the SDK's `constant` overloads want a concrete primitive, but the raw value passes through unchanged at runtime
       return sdkConstant(expression.value as string);
-    case 'functionCall':
-      return toSdkFunctionCall(expression);
+    case 'unaryFunction':
+      return unaryFns[expression.name](toSdkExpression(expression.operand));
+    case 'binaryFunction':
+      return binaryFns[expression.name](
+        toSdkExpression(expression.left),
+        toSdkExpression(expression.right),
+      );
+    case 'variadicFunction': {
+      const [first, second, ...rest] = expression.operands;
+      return variadicFns[expression.name](
+        toSdkExpression(first),
+        toSdkExpression(second),
+        ...rest.map(toSdkExpression),
+      );
+    }
     default:
       return assertNever(expression);
   }
 };
 
-// `FunctionCall.name` is an open string (not a union), so `default` is the
-// unsupported-function guard rather than `assertNever`.
-const toSdkFunctionCall = (expression: FunctionCall): SdkExpression => {
-  switch (expression.name) {
-    case 'equal': {
-      // TODO: this runtime arity guard disappears once FunctionCall is
-      // restructured into shape-grouped classes with typed payload fields —
-      // see "Restructure FunctionCall" in docs/plan/pipeline-query.md.
-      const [left, right] = expression.args;
-      if (left === undefined || right === undefined) {
-        throw new Error('firebase pipeline executor: equal requires two arguments');
-      }
-      return sdkEqual(toSdkExpression(left), toSdkExpression(right));
-    }
-    default:
-      throw new Error(
-        `firebase pipeline executor: function "${expression.name}" not supported yet`,
-      );
-  }
+// Per-shape translation tables: `Record` over the name union requires every
+// key, so a newly added function name fails to compile here until translated.
+// (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
+// type-tag only, no wire change.)
+
+const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> = {
+  not: (o) => sdkNot(o.asBoolean()),
+};
+
+const binaryFns: Record<BinaryFunctionName, (l: SdkExpression, r: SdkExpression) => SdkExpression> =
+  {
+    equal: sdkEqual,
+    notEqual: sdkNotEqual,
+    lessThan: sdkLessThan,
+    lessThanOrEqual: sdkLessThanOrEqual,
+    greaterThan: sdkGreaterThan,
+    greaterThanOrEqual: sdkGreaterThanOrEqual,
+  };
+
+const variadicFns: Record<
+  VariadicFunctionName,
+  (first: SdkExpression, second: SdkExpression, ...rest: SdkExpression[]) => SdkExpression
+> = {
+  and: (f, s, ...r) => sdkAnd(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
+  or: (f, s, ...r) => sdkOr(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
 };
 
 const toSdkOrdering = (ordering: Ordering) => {
@@ -181,7 +210,9 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'functionCall':
+    case 'unaryFunction':
+    case 'binaryFunction':
+    case 'variadicFunction':
       throw new Error('firebase pipeline executor: only field orderings are supported in sort yet');
     default:
       return assertNever(expression);

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,6 +1,15 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
-import { constant, equal } from '../pipelines/expression.js';
+import {
+  and,
+  constant,
+  equal,
+  greaterThanOrEqual,
+  lessThan,
+  not,
+  notEqual,
+  or,
+} from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
   Pipeline,
@@ -424,7 +433,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
 
     describe('where', () => {
       // items are seeded with rank 1 / 2 / 3 for a1 / a2 / a3.
-      const [a1, _a2, a3] = items;
+      const [a1, a2, a3] = items;
 
       it('filters rows by an equality condition, keeping row identity', async () => {
         await expectPipeline(
@@ -449,6 +458,47 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         await expectPipeline(
           source().where((field) => equal(field('profile.gender'), constant('male'))),
           [a3],
+          { ordered: false },
+        );
+      });
+
+      it('filters with ordering comparisons', async () => {
+        await expectPipeline(
+          source().where((field) => greaterThanOrEqual(field('rank'), constant(2))),
+          [a2, a3],
+          { ordered: false },
+        );
+      });
+
+      it('combines conditions with and / or', async () => {
+        await expectPipeline(
+          source().where((field) =>
+            and(
+              equal(field('profile.gender'), constant('female')),
+              lessThan(field('rank'), constant(2)),
+            ),
+          ),
+          [a1],
+          { ordered: false },
+        );
+        await expectPipeline(
+          source().where((field) =>
+            or(equal(field('rank'), constant(1)), equal(field('rank'), constant(3))),
+          ),
+          [a1, a3],
+          { ordered: false },
+        );
+      });
+
+      it('negates conditions with not / notEqual', async () => {
+        await expectPipeline(
+          source().where((field) => not(equal(field('rank'), constant(2)))),
+          [a1, a3],
+          { ordered: false },
+        );
+        await expectPipeline(
+          source().where((field) => notEqual(field('rank'), constant(2))),
+          [a1, a3],
           { ordered: false },
         );
       });

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { bool, type BoolType, double, int64, string } from '../schema.js';
+import {
+  and,
+  BinaryFunction,
+  equal,
+  field,
+  greaterThan,
+  greaterThanOrEqual,
+  lessThan,
+  not,
+  notEqual,
+  or,
+  UnaryFunction,
+  VariadicFunction,
+} from './expression.js';
+
+describe('expression factories', () => {
+  const name = field(string(), 'name');
+  const rank = field(double(), 'rank');
+  const count = field(int64(), 'count');
+  const flag = field(bool(), 'flag');
+
+  it('comparisons accept same-typed operands and mixed numerics', () => {
+    equal(name, name);
+    notEqual(rank, count); // Int64 and Double mix
+    lessThan(count, rank);
+    greaterThanOrEqual(rank, rank);
+    expectTypeOf(greaterThan(rank, count)).toEqualTypeOf<BinaryFunction<BoolType>>();
+  });
+
+  it('comparisons reject cross-group operands', () => {
+    // @ts-expect-error -- string vs double
+    equal(name, rank);
+    // @ts-expect-error -- bool vs double
+    lessThan(flag, rank);
+  });
+
+  it('and / or / not compose boolean expressions only', () => {
+    and(flag, equal(name, name));
+    or(equal(rank, count), flag, not(flag));
+
+    // @ts-expect-error -- a string expression is not a condition
+    and(flag, name);
+    // @ts-expect-error -- a double expression is not a condition
+    not(rank);
+    // @ts-expect-error -- `and` requires at least two conditions
+    and(flag);
+  });
+
+  it('builds shape-grouped nodes with typed payloads', () => {
+    const cmp = lessThan(rank, count);
+    expect(cmp.kind).toBe('binaryFunction');
+    expect(cmp.name).toBe('lessThan');
+    expect(cmp.left).toBe(rank);
+    expect(cmp.right).toBe(count);
+
+    const neg = not(flag);
+    expect(neg.kind).toBe('unaryFunction');
+    expect(neg.operand).toBe(flag);
+    expectTypeOf(neg).toEqualTypeOf<UnaryFunction<BoolType>>();
+
+    const both = and(flag, cmp, neg);
+    expect(both.kind).toBe('variadicFunction');
+    expect(both.operands).toStrictEqual([flag, cmp, neg]);
+    expectTypeOf(both).toEqualTypeOf<VariadicFunction<BoolType>>();
+  });
+});

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -11,7 +11,12 @@ import { bool, type BoolType, type DoubleType, type FieldType, type Int64Type } 
  * public type, so `switch (expr.kind)` narrowing and `assertNever`
  * exhaustiveness keep working (a base-class-typed value would not narrow).
  */
-export type Expression<T extends FieldType = FieldType> = FunctionCall<T> | Constant<T> | Field<T>;
+export type Expression<T extends FieldType = FieldType> =
+  | Field<T>
+  | Constant<T>
+  | UnaryFunction<T>
+  | BinaryFunction<T>
+  | VariadicFunction<T>;
 
 /**
  * An expression bound to an output name — the aliased form of a `select` /
@@ -91,37 +96,153 @@ export const constant = <T extends FieldType>(value: unknown): Constant<T> =>
     value,
   );
 
-export class FunctionCall<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'functionCall';
+// Function-call nodes are grouped by SHAPE (arity), not one class per
+// function: each shape carries typed payload fields (no untyped `args` array,
+// so executors need no runtime arity guards), and its `name` is a
+// string-literal union so an executor can translate a whole shape with an
+// exhaustive `Record<Name, ...>` lookup. Per-function individuality (operand
+// compatibility, return types) lives in the factory signatures. See
+// "Restructure FunctionCall" in docs/plan/pipeline-query.md.
+
+/** A function call with a single operand. */
+export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'unaryFunction';
   constructor(
-    readonly name: string,
+    readonly name: UnaryFunctionName,
     readonly type: T,
-    readonly args: readonly Expression[],
+    readonly operand: Expression,
   ) {
     super();
   }
 }
+export type UnaryFunctionName = 'not';
+
+/** A function call with exactly two operands. */
+export class BinaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'binaryFunction';
+  constructor(
+    readonly name: BinaryFunctionName,
+    readonly type: T,
+    readonly left: Expression,
+    readonly right: Expression,
+  ) {
+    super();
+  }
+}
+export type BinaryFunctionName =
+  | 'equal'
+  | 'notEqual'
+  | 'lessThan'
+  | 'lessThanOrEqual'
+  | 'greaterThan'
+  | 'greaterThanOrEqual';
+
+/** A function call with two or more uniform operands. */
+export class VariadicFunction<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'variadicFunction';
+  constructor(
+    readonly name: VariadicFunctionName,
+    readonly type: T,
+    readonly operands: readonly [Expression, Expression, ...Expression[]],
+  ) {
+    super();
+  }
+}
+export type VariadicFunctionName = 'and' | 'or';
 
 /** Convenience union for numeric expression inputs. */
 type NumericType = Int64Type | DoubleType;
 
-const fn = <T extends FieldType>(
-  name: string,
-  type: T,
-  args: readonly Expression[],
-): FunctionCall<T> => new FunctionCall(name, type, args);
-
 // A comparison op has two overloads:
 //   1) numeric-pair — lets Int64 and Double mix while rejecting numeric-vs-other.
 //   2) generic same-`T` — every other group plus union-vs-narrow widening.
+
 export function equal(
   left: Expression<NumericType>,
   right: Expression<NumericType>,
-): FunctionCall<BoolType>;
+): BinaryFunction<BoolType>;
 export function equal<T extends FieldType>(
   left: Expression<T>,
   right: Expression<T>,
-): FunctionCall<BoolType>;
-export function equal(left: Expression, right: Expression): FunctionCall<BoolType> {
-  return fn('equal', bool(), [left, right]);
+): BinaryFunction<BoolType>;
+export function equal(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('equal', bool(), left, right);
 }
+
+export function notEqual(
+  left: Expression<NumericType>,
+  right: Expression<NumericType>,
+): BinaryFunction<BoolType>;
+export function notEqual<T extends FieldType>(
+  left: Expression<T>,
+  right: Expression<T>,
+): BinaryFunction<BoolType>;
+export function notEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('notEqual', bool(), left, right);
+}
+
+export function lessThan(
+  left: Expression<NumericType>,
+  right: Expression<NumericType>,
+): BinaryFunction<BoolType>;
+export function lessThan<T extends FieldType>(
+  left: Expression<T>,
+  right: Expression<T>,
+): BinaryFunction<BoolType>;
+export function lessThan(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('lessThan', bool(), left, right);
+}
+
+export function lessThanOrEqual(
+  left: Expression<NumericType>,
+  right: Expression<NumericType>,
+): BinaryFunction<BoolType>;
+export function lessThanOrEqual<T extends FieldType>(
+  left: Expression<T>,
+  right: Expression<T>,
+): BinaryFunction<BoolType>;
+export function lessThanOrEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('lessThanOrEqual', bool(), left, right);
+}
+
+export function greaterThan(
+  left: Expression<NumericType>,
+  right: Expression<NumericType>,
+): BinaryFunction<BoolType>;
+export function greaterThan<T extends FieldType>(
+  left: Expression<T>,
+  right: Expression<T>,
+): BinaryFunction<BoolType>;
+export function greaterThan(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('greaterThan', bool(), left, right);
+}
+
+export function greaterThanOrEqual(
+  left: Expression<NumericType>,
+  right: Expression<NumericType>,
+): BinaryFunction<BoolType>;
+export function greaterThanOrEqual<T extends FieldType>(
+  left: Expression<T>,
+  right: Expression<T>,
+): BinaryFunction<BoolType>;
+export function greaterThanOrEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
+  return new BinaryFunction('greaterThanOrEqual', bool(), left, right);
+}
+
+/** Logical conjunction of two or more boolean expressions. */
+export const and = (
+  first: Expression<BoolType>,
+  second: Expression<BoolType>,
+  ...rest: Expression<BoolType>[]
+): VariadicFunction<BoolType> => new VariadicFunction('and', bool(), [first, second, ...rest]);
+
+/** Logical disjunction of two or more boolean expressions. */
+export const or = (
+  first: Expression<BoolType>,
+  second: Expression<BoolType>,
+  ...rest: Expression<BoolType>[]
+): VariadicFunction<BoolType> => new VariadicFunction('or', bool(), [first, second, ...rest]);
+
+/** Logical negation of a boolean expression. */
+export const not = (condition: Expression<BoolType>): UnaryFunction<BoolType> =>
+  new UnaryFunction('not', bool(), condition);

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -286,7 +286,9 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'field':
       return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
     case 'constant':
-    case 'functionCall':
+    case 'unaryFunction':
+    case 'binaryFunction':
+    case 'variadicFunction':
       return pathToSchema(alias, expression.type);
     default:
       return assertNever(expression);

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -1,9 +1,11 @@
 import { type Firestore, Pipelines } from '@google-cloud/firestore';
 import { collectionPath } from 'firestore-repository/path';
 import type {
+  BinaryFunctionName,
   Expression,
   ExpressionWithAlias,
-  FunctionCall,
+  UnaryFunctionName,
+  VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
@@ -138,32 +140,57 @@ const toSdkExpression = (expression: Expression): Pipelines.Expression => {
     case 'constant':
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `Constant.value` is untyped (TODO in expression.ts); the SDK's `constant` overloads want a concrete primitive, but the raw value passes through unchanged at runtime
       return Pipelines.constant(expression.value as string);
-    case 'functionCall':
-      return toSdkFunctionCall(expression);
+    case 'unaryFunction':
+      return unaryFns[expression.name](toSdkExpression(expression.operand));
+    case 'binaryFunction':
+      return binaryFns[expression.name](
+        toSdkExpression(expression.left),
+        toSdkExpression(expression.right),
+      );
+    case 'variadicFunction': {
+      const [first, second, ...rest] = expression.operands;
+      return variadicFns[expression.name](
+        toSdkExpression(first),
+        toSdkExpression(second),
+        ...rest.map(toSdkExpression),
+      );
+    }
     default:
       return assertNever(expression);
   }
 };
 
-// `FunctionCall.name` is an open string (not a union), so `default` is the
-// unsupported-function guard rather than `assertNever`.
-const toSdkFunctionCall = (expression: FunctionCall): Pipelines.Expression => {
-  switch (expression.name) {
-    case 'equal': {
-      // TODO: this runtime arity guard disappears once FunctionCall is
-      // restructured into shape-grouped classes with typed payload fields —
-      // see "Restructure FunctionCall" in docs/plan/pipeline-query.md.
-      const [left, right] = expression.args;
-      if (left === undefined || right === undefined) {
-        throw new Error('google-cloud pipeline executor: equal requires two arguments');
-      }
-      return Pipelines.equal(toSdkExpression(left), toSdkExpression(right));
-    }
-    default:
-      throw new Error(
-        `google-cloud pipeline executor: function "${expression.name}" not supported yet`,
-      );
-  }
+// Per-shape translation tables: `Record` over the name union requires every
+// key, so a newly added function name fails to compile here until translated.
+// (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
+// type-tag only, no wire change.)
+
+const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines.Expression> = {
+  not: (o) => Pipelines.not(o.asBoolean()),
+};
+
+const binaryFns: Record<
+  BinaryFunctionName,
+  (l: Pipelines.Expression, r: Pipelines.Expression) => Pipelines.Expression
+> = {
+  equal: Pipelines.equal,
+  notEqual: Pipelines.notEqual,
+  lessThan: Pipelines.lessThan,
+  lessThanOrEqual: Pipelines.lessThanOrEqual,
+  greaterThan: Pipelines.greaterThan,
+  greaterThanOrEqual: Pipelines.greaterThanOrEqual,
+};
+
+const variadicFns: Record<
+  VariadicFunctionName,
+  (
+    first: Pipelines.Expression,
+    second: Pipelines.Expression,
+    ...rest: Pipelines.Expression[]
+  ) => Pipelines.Expression
+> = {
+  and: (f, s, ...r) => Pipelines.and(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
+  or: (f, s, ...r) => Pipelines.or(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
 };
 
 const toSdkOrdering = (ordering: Ordering) => {
@@ -172,7 +199,9 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'functionCall':
+    case 'unaryFunction':
+    case 'binaryFunction':
+    case 'variadicFunction':
       throw new Error(
         'google-cloud pipeline executor: only field orderings are supported in sort yet',
       );


### PR DESCRIPTION
First slice of the expression-factory restoration, executing the shape-grouped design recorded in the plan doc.

## Restructure

`FunctionCall` (untyped `args: Expression[]`, open string `name`) is replaced by three shape classes:

- `UnaryFunction` (`operand`), `BinaryFunction` (`left` / `right`), `VariadicFunction` (`operands: [E, E, ...E[]]` — min-2 in the type)
- each with a per-shape string-literal `name` union
- executors translate each shape via an **exhaustive `Record<Name, ...>` table** — adding a name to a union fails compilation in both executors until translated
- the runtime arity guards (`left === undefined` etc.) disappear into the types, as designed

## Restored operators (where becomes actually usable)

- comparisons: `notEqual` / `lessThan` / `lessThanOrEqual` / `greaterThan` / `greaterThanOrEqual` — same two-overload pattern as `equal` (numeric Int64↔Double mixing, cross-group rejection)
- logical: `and` / `or` (min-2 boolean operands) and `not`

## Tests

- 3 new live spec cases: ordering comparisons, `and`/`or` composition, `not`/`notEqual` negation (44/44 live)
- new `expression.test.ts`: operand group compatibility (incl. cross-group `@ts-expect-error`s), boolean-only logical composition, min-2 arity, and the shaped payload wiring

Remaining factory categories (arithmetic / string / array / map / timestamp / vector / …) slot into the same shapes in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)