### PR TITLE
Close FieldType into a discriminated union

### DIFF
--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -14,16 +14,7 @@ import {
 } from '@firebase/firestore';
 import { documentPath } from 'firestore-repository/path';
 import type { DocRef } from 'firestore-repository/repository';
-import type {
-  ArrayType,
-  Collection,
-  DocRefType,
-  DocumentSchema,
-  FieldType,
-  LiteralType,
-  MapType,
-  UnionType,
-} from 'firestore-repository/schema';
+import type { Collection, DocumentSchema, FieldType } from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -90,11 +81,9 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
           return ids.reverse() as DocRef<Collection>;
         });
     case 'map': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as MapType;
       return z.object(
         Object.fromEntries(
-          Object.entries(ft.fields).map(([k, v]) => {
+          Object.entries(fieldType.fields).map(([k, v]) => {
             const s = buildDecodeField(v);
             return [k, v.optional ? s.optional() : s];
           }),
@@ -102,23 +91,16 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
       );
     }
     case 'array': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as ArrayType;
-      return z.array(buildDecodeField(ft.dynamicPart));
+      return z.array(buildDecodeField(fieldType.dynamicPart));
     }
     case 'union': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as UnionType;
-      return zodUnion(ft.elements.map(buildDecodeField));
+      return zodUnion(fieldType.elements.map(buildDecodeField));
     }
     case 'const': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as LiteralType<(string | number | boolean | null)[]>;
-      return zodUnion(ft.values.map((v) => z.literal(v)));
+      return zodUnion(fieldType.values.map((v) => z.literal(v)));
     }
     default:
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      return assertNever(fieldType as never);
+      return assertNever(fieldType);
   }
 }
 
@@ -170,19 +152,15 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
           .transform(() => firestoreServerTimestamp()),
       ]);
     case 'docRef': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as DocRefType<Collection>;
       return z.array(z.string()).transform((ref) =>
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        doc(db, documentPath(ft.collection, ref as DocRef<Collection>)),
+        doc(db, documentPath(fieldType.collection, ref as DocRef<Collection>)),
       );
     }
     case 'map': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as MapType;
       return z.object(
         Object.fromEntries(
-          Object.entries(ft.fields).map(([k, v]) => {
+          Object.entries(fieldType.fields).map(([k, v]) => {
             const s = buildEncodeField(v, db);
             return [k, v.optional ? s.optional() : s];
           }),
@@ -190,10 +168,8 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
       );
     }
     case 'array': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as ArrayType;
       return zodUnion([
-        z.array(buildEncodeField(ft.dynamicPart, db)),
+        z.array(buildEncodeField(fieldType.dynamicPart, db)),
         z
           .unknown()
           .refine(isArrayRemove)
@@ -205,18 +181,13 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
       ]);
     }
     case 'union': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as UnionType;
-      return zodUnion(ft.elements.map((e) => buildEncodeField(e, db)));
+      return zodUnion(fieldType.elements.map((e) => buildEncodeField(e, db)));
     }
     case 'const': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as LiteralType<(string | number | boolean | null)[]>;
-      return zodUnion(ft.values.map((v) => z.literal(v)));
+      return zodUnion(fieldType.values.map((v) => z.literal(v)));
     }
     default:
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      return assertNever(fieldType as never);
+      return assertNever(fieldType);
   }
 }
 

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -224,9 +224,9 @@ export type ConstantTypeOf<V extends ConstantValue> = ConstantValue extends V
 type ArrayConstantTypeOf<V extends ConstantArray> =
   DedupDescriptors<{ readonly [K in keyof V]: ConstantTypeOf<V[K]> }> extends infer D
     ? D extends readonly [infer Only extends FieldType]
-      ? ArrayType<Only, [], []>
+      ? ArrayType<Only>
       : D extends readonly FieldType[]
-        ? ArrayType<UnionType<[...D]>, [], []>
+        ? ArrayType<UnionType<[...D]>>
         : never
     : never;
 

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -29,7 +29,7 @@ type Schema = {
   name: StringType;
   profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
   rank: DoubleType;
-  tag: ArrayType<StringType, [], []>;
+  tag: ArrayType<StringType>;
 };
 
 describe('BuildSelectionSchema', () => {
@@ -65,7 +65,7 @@ describe('BuildSelectionSchema', () => {
     it('merges disjoint top-level selections', () => {
       expectTypeOf<BuildSelectionSchema<Schema, ['name', 'tag']>>().toEqualTypeOf<{
         name: StringType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
 
@@ -219,7 +219,7 @@ describe('BuildAddFieldsSchema', () => {
         name: StringType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
         score: DoubleType;
       }>();
     });
@@ -230,7 +230,7 @@ describe('BuildAddFieldsSchema', () => {
         name: StringType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
         stats: MapType<{ score: DoubleType }>;
       }>();
     });
@@ -245,7 +245,7 @@ describe('BuildAddFieldsSchema', () => {
           computed: StringType;
         }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
   });
@@ -257,7 +257,7 @@ describe('BuildAddFieldsSchema', () => {
         name: DoubleType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
 
@@ -267,7 +267,7 @@ describe('BuildAddFieldsSchema', () => {
         name: StringType;
         profile: MapType<{ age: StringType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
   });
@@ -284,7 +284,7 @@ describe('BuildAddFieldsSchema', () => {
           computed: StringType;
         }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
         score: DoubleType;
       }>();
     });
@@ -300,7 +300,7 @@ describe('BuildAddFieldsSchema', () => {
         name: DoubleType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
 
@@ -316,7 +316,7 @@ describe('BuildAddFieldsSchema', () => {
           baz: StringType;
         }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
 
@@ -332,7 +332,7 @@ describe('BuildAddFieldsSchema', () => {
         name: StringType;
         profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
         rank: DoubleType;
-        tag: ArrayType<StringType, [], []>;
+        tag: ArrayType<StringType>;
       }>();
     });
   });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -311,7 +311,7 @@ const isConditionalPath = (schema: Fields, path: string): boolean => {
   if (head === undefined) {
     return false;
   }
-  // Read the marker before `isMapType` narrows the descriptor to `MapType`
+  // Read the marker before `isMapType` narrows the descriptor to `AnyMapType`
   // (narrowing drops the `optional?` part of the `MapFields` intersection).
   if (head.optional === true) {
     return true;

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -155,7 +155,7 @@ describe('schema', () => {
         >();
       });
 
-      // TODO: support tuple
+      // TODO: support tuple (https://github.com/ikenox/firestore-repository/issues/218)
     });
 
     it('union', () => {

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -13,6 +13,7 @@ import {
   type DocumentSchema,
   type DocFieldPath,
   fieldTypeOfPath,
+  type FieldType,
   type FieldTypeOfPath,
   type FieldValue,
   type FieldValueOfPath,
@@ -20,6 +21,7 @@ import {
   geoPoint,
   Increment,
   int64,
+  isMapType,
   Int64Type,
   LiteralType,
   literal,
@@ -31,6 +33,7 @@ import {
   type Optional,
   type PickPaths,
   rootCollection,
+  subCollection,
   ServerTimestamp,
   string,
   StringType,
@@ -188,29 +191,90 @@ describe('schema', () => {
         expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<'a' | 1 | true>();
       });
     });
+  });
 
-    // describe('array (compound)', () => {
-    //   it('tuple', () => {
-    //     type T = {
-    //       type: 'array';
-    //       headFixedPart: [StringType, BoolType];
-    //       dynamicPart: never;
-    //       tailFixedPart: [];
-    //     };
-    //     expectTypeOf<FieldValue<T, 'read'>>().toEqualTypeOf<[string, boolean]>();
-    //   });
-    //
-    //   it('non-empty array', () => {
-    //     type T = {
-    //       type: 'array';
-    //       headFixedPart: [StringType];
-    //       dynamicPart: Int64Type;
-    //       tailFixedPart: [];
-    //     };
-    //     expectTypeOf<FieldValue<T, 'read'>>().toEqualTypeOf<[string, ...number[]]>();
-    //   });
-    // });
-    //
+  describe('FieldType (closed union)', () => {
+    const authors = rootCollection({ name: 'authors', schema: { name: string() } });
+
+    it('every factory-built descriptor is a member of the union', () => {
+      // The `FieldType[]` annotation is the assertion: this fails to compile
+      // if any factory's return type falls outside the closed union.
+      const descriptors: FieldType[] = [
+        bool(),
+        string(),
+        int64(),
+        double(),
+        timestamp(),
+        docRef(authors),
+        bytes(),
+        geoPoint(),
+        vector(),
+        nullType(),
+        map({ a: string() }),
+        array(string()),
+        union(string(), nullType()),
+        literal('a', 1, true, null),
+        optional(string()),
+        nullable(map({ deep: array(union(literal(true), double())) })),
+      ];
+      expect(descriptors).toHaveLength(16);
+    });
+
+    it('isMapType narrows exactly the map descriptor', () => {
+      expect(isMapType(map({ a: string() }))).toBe(true);
+      const nonMaps: FieldType[] = [
+        bool(),
+        string(),
+        int64(),
+        double(),
+        timestamp(),
+        docRef(authors),
+        bytes(),
+        geoPoint(),
+        vector(),
+        nullType(),
+        array(string()),
+        union(string(), nullType()),
+        literal('a'),
+      ];
+      expect(nonMaps.map(isMapType)).toEqual(nonMaps.map(() => false));
+    });
+  });
+
+  describe('dotted field names are rejected', () => {
+    // Rejected at both layers: the type level (the field's descriptor type
+    // becomes `never` via `WithoutDottedFieldNames`) and the runtime level
+    // (the factory throws) — hence @ts-expect-error wrapped in toThrow.
+    it('map', () => {
+      expect(() =>
+        // @ts-expect-error a field name containing "." is rejected
+        map({ 'a.b': string() }),
+      ).toThrow('must not contain "."');
+    });
+
+    it('rootCollection', () => {
+      expect(() =>
+        // @ts-expect-error a field name containing "." is rejected
+        rootCollection({ name: 'authors', schema: { 'a.b': string() } }),
+      ).toThrow('must not contain "."');
+    });
+
+    it('subCollection', () => {
+      expect(() =>
+        // @ts-expect-error a field name containing "." is rejected
+        subCollection({ name: 'posts', schema: { 'a.b': string() }, parent: ['authors'] }),
+      ).toThrow('must not contain "."');
+    });
+
+    it('a nested map inside a collection schema is covered by the map factory', () => {
+      expect(() =>
+        rootCollection({
+          name: 'authors',
+          // @ts-expect-error a nested field name containing "." is rejected
+          schema: { profile: map({ 'a.b': string() }) },
+        }),
+      ).toThrow('must not contain "."');
+    });
   });
 });
 
@@ -311,7 +375,7 @@ describe('document', () => {
       expectTypeOf(fieldTypeOfPath(schema, 'i')).toEqualTypeOf<Int64Type>();
       expectTypeOf(fieldTypeOfPath(schema, 'b')).toEqualTypeOf<BoolType>();
       expectTypeOf(fieldTypeOfPath(schema, 't')).toEqualTypeOf<TimestampType>();
-      expectTypeOf(fieldTypeOfPath(schema, 'arr')).toEqualTypeOf<ArrayType<StringType, [], []>>();
+      expectTypeOf(fieldTypeOfPath(schema, 'arr')).toEqualTypeOf<ArrayType<StringType>>();
     });
 
     it('resolves nested (dotted) fields', () => {
@@ -370,7 +434,7 @@ describe('document', () => {
       name: StringType;
       profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
       rank: DoubleType;
-      tag: ArrayType<StringType, [], []>;
+      tag: ArrayType<StringType>;
     };
 
     describe('TailPath', () => {
@@ -459,7 +523,7 @@ describe('document', () => {
         expectTypeOf<OmitPaths<Schema, 'name'>>().toEqualTypeOf<{
           profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
           rank: DoubleType;
-          tag: ArrayType<StringType, [], []>;
+          tag: ArrayType<StringType>;
         }>();
       });
 
@@ -468,7 +532,7 @@ describe('document', () => {
           name: StringType;
           profile: MapType<{ age: DoubleType }>;
           rank: DoubleType;
-          tag: ArrayType<StringType, [], []>;
+          tag: ArrayType<StringType>;
         }>();
       });
 
@@ -483,7 +547,7 @@ describe('document', () => {
         expectTypeOf<OmitPaths<Schema, 'profile'>>().toEqualTypeOf<{
           name: StringType;
           rank: DoubleType;
-          tag: ArrayType<StringType, [], []>;
+          tag: ArrayType<StringType>;
         }>();
       });
 
@@ -495,7 +559,7 @@ describe('document', () => {
         expectTypeOf<OmitPaths<Schema, 'name' | 'profile.gender'>>().toEqualTypeOf<{
           profile: MapType<{ age: DoubleType }>;
           rank: DoubleType;
-          tag: ArrayType<StringType, [], []>;
+          tag: ArrayType<StringType>;
         }>();
       });
 
@@ -508,7 +572,7 @@ describe('document', () => {
         expectTypeOf<OmitPaths<Schema, 'profile.age' | 'profile.gender'>>().toEqualTypeOf<{
           name: StringType;
           rank: DoubleType;
-          tag: ArrayType<StringType, [], []>;
+          tag: ArrayType<StringType>;
         }>();
       });
 

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -1,4 +1,5 @@
 import { DocRef } from './repository.js';
+import { assertNever } from './util.js';
 
 /**
  * A definition of a Firestore collection
@@ -18,27 +19,58 @@ export type SubCollection<
 > = Collection<Schema, Parent>;
 
 /** Creates a root collection definition */
-export const rootCollection = <Schema extends DocumentSchema>(params: {
+export const rootCollection = <
+  Schema extends DocumentSchema & WithoutDottedFieldNames<Schema>,
+>(params: {
   name: string;
   schema: Schema;
-}): Collection<Schema, []> => ({ ...params, parent: [] });
+}): Collection<Schema, []> => {
+  assertNoDottedFieldNames(params.schema);
+  return { ...params, parent: [] };
+};
 
 /** Creates a subcollection definition */
 export const subCollection = <
-  Schema extends DocumentSchema,
+  Schema extends DocumentSchema & WithoutDottedFieldNames<Schema>,
   const Parent extends [...string[], string],
 >(params: {
   name: string;
   schema: Schema;
   parent: Parent;
 }): SubCollection<Schema, Parent> => {
+  assertNoDottedFieldNames(params.schema);
   return params;
 };
 
 /** A validation schema for document data */
 export type DocumentSchema = MapType['fields'];
 
-export type FieldType = { type: string; input: unknown; output: unknown };
+/**
+ * The closed discriminated union of every field descriptor, discriminated by
+ * `type`. Being closed (rather than an open `{ type: string }` base) lets
+ * `switch (fieldType.type)` narrow each arm to its concrete descriptor and
+ * makes `default: assertNever(fieldType)` a real exhaustiveness check —
+ * adding a new descriptor surfaces every handling site as a compile error.
+ *
+ * The recursive members are the widest `Any*` interfaces, not the generic
+ * `MapType`/`ArrayType`/`UnionType` aliases — see the comment on those
+ * interfaces for why.
+ */
+export type FieldType =
+  | BoolType
+  | StringType
+  | Int64Type
+  | DoubleType
+  | TimestampType
+  | DocRefType<Collection>
+  | BytesType
+  | GeoPointType
+  | VectorType
+  | NullType
+  | AnyMapType
+  | AnyArrayType
+  | AnyUnionType
+  | LiteralType<(string | number | boolean | null)[]>;
 
 export type BoolType = { type: 'bool'; input: boolean; output: boolean };
 export type StringType = { type: 'string'; input: string; output: string };
@@ -55,13 +87,59 @@ export type BytesType = { type: 'bytes'; input: Uint8Array; output: Uint8Array }
 export type GeoPointType = { type: 'geoPoint'; input: GeoPoint; output: GeoPoint };
 export type VectorType = { type: 'vector'; input: number[]; output: number[] };
 export type NullType = { type: 'null'; input: null; output: null };
+/**
+ * The widest map/array/union descriptors — the recursive members of the
+ * closed {@link FieldType} union. Each concrete `MapType<T>` /
+ * `ArrayType<T>` / `UnionType<T>` is a structural subtype of its `Any*`
+ * counterpart.
+ *
+ * Two deliberate choices make the recursion work:
+ *
+ * - They are `interface`s, not type aliases: their members resolve lazily,
+ *   so `FieldType -> AnyMapType -> MapFields -> FieldType` is legal. Spelling
+ *   the union with the (eagerly resolved) generic aliases instead is a TS2456
+ *   circular reference. Making the generic aliases themselves interfaces does
+ *   not work either: TS compares two instantiations of one generic interface
+ *   by measured variance, the computed `input`/`output` members measure as
+ *   invariant, and e.g. `UnionType<[StringType, NullType]>` would no longer
+ *   be accepted where the widest union descriptor is expected.
+ * - `input`/`output` are `unknown` at this widest level (exactly the width
+ *   the old open `{ type: string; input: unknown; output: unknown }` base
+ *   had), which also terminates the type recursion when resolving the wide
+ *   union's value types.
+ */
+export interface AnyMapType {
+  type: 'map';
+  fields: MapFields;
+  input: unknown;
+  output: unknown;
+}
+export interface AnyArrayType {
+  type: 'array';
+  dynamicPart: FieldType;
+  input: unknown;
+  output: unknown;
+}
+export interface AnyUnionType {
+  type: 'union';
+  elements: FieldType[];
+  input: unknown;
+  output: unknown;
+}
+/**
+ * An `interface` (with an index signature) rather than a `Record` alias for
+ * the same laziness reason as the `Any*` descriptors above.
+ */
+export interface MapFields {
+  [field: string]: FieldType & { optional?: boolean };
+}
+
 export type MapType<T extends MapFields = MapFields> = {
   type: 'map';
   fields: T;
   input: ResolveMapValue<T, 'write'>;
   output: ResolveMapValue<T, 'read'>;
 };
-export type MapFields = Record<string, FieldType & { optional?: boolean }>;
 /**
  * Marks a field descriptor as optional. A plain (string-keyed) property, not a
  * symbol: descriptors are a library-controlled closed structure with no
@@ -71,15 +149,9 @@ export type MapFields = Record<string, FieldType & { optional?: boolean }>;
  * that mix with user data, where a symbol is the right call.)
  */
 export type Optional = { optional: true };
-export type ArrayType<
-  DynamicPart extends FieldType = FieldType,
-  HeadFixedPart extends FieldType[] = FieldType[],
-  TailFixedPart extends FieldType[] = FieldType[],
-> = {
+export type ArrayType<DynamicPart extends FieldType = FieldType> = {
   type: 'array';
   dynamicPart: DynamicPart;
-  headFixedPart: HeadFixedPart;
-  tailFixedPart: TailFixedPart;
   input: ResolveArrayValue<DynamicPart, 'write'>;
   output: ResolveArrayValue<DynamicPart, 'read'>;
 };
@@ -108,10 +180,8 @@ export type ResolveMapValue<
   { [K in keyof T]: T[K]['optional'] extends true ? K : never }[keyof T]
 >;
 
-// TODO: support tuple
 export type ResolveArrayValue<T extends FieldType, Mode extends 'read' | 'write'> =
   | FieldValue<T, Mode>[]
-  // TODO: disallow this operations when the array has a fixed part
   | (Mode extends 'write'
       ? ArrayRemove<FieldValue<T, 'read'>> | ArrayUnion<FieldValue<T, 'read'>>
       : never);
@@ -134,6 +204,27 @@ type Merge<T> = { [K in keyof T]: T[K] };
 export const serverOperation: unique symbol = Symbol();
 
 /**
+ * Rejects schema field names containing `.` (the offending field's type
+ * becomes `never`, so the schema literal fails to type-check). Dots are the
+ * path separator of {@link MapFieldPath} / {@link FieldTypeOfPath}, so a
+ * dotted field name would be unaddressable (or ambiguous with a nested
+ * path). Enforced by every factory that accepts a field map (`map`,
+ * `rootCollection`, `subCollection`).
+ */
+type WithoutDottedFieldNames<T> = {
+  [K in keyof T]: K extends `${string}.${string}` ? never : T[K];
+};
+
+/** Runtime counterpart of {@link WithoutDottedFieldNames}. */
+const assertNoDottedFieldNames = (fields: DocumentSchema): void => {
+  for (const field of Object.keys(fields)) {
+    if (field.includes('.')) {
+      throw new Error(`schema field name "${field}" must not contain "."`);
+    }
+  }
+};
+
+/**
  * Constructs a schema type value without specifying the phantom `input`/`output` fields.
  * Those fields exist only at the type level to carry value type information (valibot-style),
  * so they must not appear in runtime objects. The `as T` cast attaches the phantom types
@@ -152,10 +243,12 @@ export const docRef = <T extends Collection>(collection: T): DocRefType<T> =>
 export const bytes = (): BytesType => buildType({ type: 'bytes' });
 export const geoPoint = (): GeoPointType => buildType({ type: 'geoPoint' });
 export const vector = (): VectorType => buildType({ type: 'vector' });
-export const map = <T extends MapType['fields']>(fields: T): MapType<T> =>
-  buildType({ type: 'map', fields });
-export const array = <T extends FieldType>(elementType: T): ArrayType<T, [], []> =>
-  buildType({ type: 'array', dynamicPart: elementType, headFixedPart: [], tailFixedPart: [] });
+export const map = <T extends MapFields & WithoutDottedFieldNames<T>>(fields: T): MapType<T> => {
+  assertNoDottedFieldNames(fields);
+  return buildType({ type: 'map', fields });
+};
+export const array = <T extends FieldType>(elementType: T): ArrayType<T> =>
+  buildType({ type: 'array', dynamicPart: elementType });
 export const union = <T extends FieldType[]>(...elements: T): UnionType<T> =>
   buildType({ type: 'union', elements });
 export const nullType = (): NullType => buildType({ type: 'null' });
@@ -207,8 +300,9 @@ export type MapFieldPath<T extends MapType['fields']> = MapType['fields'] extend
     }[keyof T & string];
 
 /**
- * Resolves field value type at the specified path
- * TODO: Field names containing dots are not handled correctly because dots are used as path separators.
+ * Resolves field value type at the specified path.
+ * (Field names containing dots would collide with the path separator, but the
+ * schema factories reject them — see {@link WithoutDottedFieldNames}.)
  */
 export type FieldTypeOfPath<T extends DocumentSchema, U extends DocFieldPath<T>> = U extends keyof T
   ? // root field
@@ -241,8 +335,10 @@ export const fieldTypeOfPath = <T extends DocumentSchema, U extends DocFieldPath
     resolved = requireField(schema, path);
   } else {
     // A dotted path's head is a map (enforced by `DocFieldPath`).
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `FieldType` is the base type; narrowing it to `MapType` for the nested walk cannot be expressed structurally
-    const head = requireField(schema, path.slice(0, dot)) as MapType;
+    const head = requireField(schema, path.slice(0, dot));
+    if (!isMapType(head)) {
+      throw new Error(`field "${path.slice(0, dot)}" is not a map`);
+    }
     resolved = fieldTypeOfPath(head.fields, path.slice(dot + 1));
   }
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime walk mirrors `FieldTypeOfPath`, but the compiler cannot connect a runtime schema value to the type-level result
@@ -338,7 +434,7 @@ export const omitPaths = <T extends DocumentSchema, const P extends readonly str
       continue; // exact match drops the whole subtree
     }
     const tail = tailPath(key, paths);
-    // Read the marker before `isMapType` narrows the descriptor to `MapType`
+    // Read the marker before `isMapType` narrows the descriptor to `AnyMapType`
     // (narrowing drops the `optional?` part of the `MapFields` intersection).
     const markedOptional = fieldType.optional === true;
     if (!isMapType(fieldType) || tail.length === 0) {
@@ -360,16 +456,26 @@ export const omitPaths = <T extends DocumentSchema, const P extends readonly str
 const tailPath = (key: string, paths: readonly string[]): string[] =>
   paths.filter((p) => p.startsWith(`${key}.`)).map((p) => p.slice(key.length + 1));
 
-/**
- * Narrows a `FieldType` descriptor to `MapType`. `FieldType` is an open
- * structural base (`type: string`), not a closed union, so this is a `switch`
- * on a plain string with a type-predicate bridge.
- */
-export const isMapType = (t: FieldType): t is MapType => {
+/** Narrows a `FieldType` descriptor to the widest map descriptor. */
+export const isMapType = (t: FieldType): t is AnyMapType => {
   switch (t.type) {
     case 'map':
       return true;
-    default:
+    case 'bool':
+    case 'string':
+    case 'int64':
+    case 'double':
+    case 'timestamp':
+    case 'docRef':
+    case 'bytes':
+    case 'geoPoint':
+    case 'vector':
+    case 'null':
+    case 'array':
+    case 'union':
+    case 'const':
       return false;
+    default:
+      return assertNever(t);
   }
 };

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -8,16 +8,7 @@ import {
 } from '@google-cloud/firestore';
 import { documentPath } from 'firestore-repository/path';
 import type { DocRef } from 'firestore-repository/repository';
-import type {
-  ArrayType,
-  Collection,
-  DocRefType,
-  DocumentSchema,
-  FieldType,
-  LiteralType,
-  MapType,
-  UnionType,
-} from 'firestore-repository/schema';
+import type { Collection, DocumentSchema, FieldType } from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -85,11 +76,9 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
           return ids.reverse() as DocRef<Collection>;
         });
     case 'map': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as MapType;
       return z.object(
         Object.fromEntries(
-          Object.entries(ft.fields).map(([k, v]) => {
+          Object.entries(fieldType.fields).map(([k, v]) => {
             const s = buildDecodeField(v);
             return [k, v.optional ? s.optional() : s];
           }),
@@ -97,23 +86,16 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
       );
     }
     case 'array': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as ArrayType;
-      return z.array(buildDecodeField(ft.dynamicPart));
+      return z.array(buildDecodeField(fieldType.dynamicPart));
     }
     case 'union': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as UnionType;
-      return zodUnion(ft.elements.map(buildDecodeField));
+      return zodUnion(fieldType.elements.map(buildDecodeField));
     }
     case 'const': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as LiteralType<(string | number | boolean | null)[]>;
-      return zodUnion(ft.values.map((v) => z.literal(v)));
+      return zodUnion(fieldType.values.map((v) => z.literal(v)));
     }
     default:
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      return assertNever(fieldType as never);
+      return assertNever(fieldType);
   }
 }
 
@@ -165,19 +147,15 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
           .transform(() => FieldValue.serverTimestamp()),
       ]);
     case 'docRef': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as DocRefType<Collection>;
       return z.array(z.string()).transform((ref) =>
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        db.doc(documentPath(ft.collection, ref as DocRef<Collection>)),
+        db.doc(documentPath(fieldType.collection, ref as DocRef<Collection>)),
       );
     }
     case 'map': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as MapType;
       return z.object(
         Object.fromEntries(
-          Object.entries(ft.fields).map(([k, v]) => {
+          Object.entries(fieldType.fields).map(([k, v]) => {
             const s = buildEncodeField(v, db);
             return [k, v.optional ? s.optional() : s];
           }),
@@ -185,10 +163,8 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
       );
     }
     case 'array': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as ArrayType;
       return zodUnion([
-        z.array(buildEncodeField(ft.dynamicPart, db)),
+        z.array(buildEncodeField(fieldType.dynamicPart, db)),
         z
           .unknown()
           .refine(isArrayRemove)
@@ -200,18 +176,13 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
       ]);
     }
     case 'union': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as UnionType;
-      return zodUnion(ft.elements.map((e) => buildEncodeField(e, db)));
+      return zodUnion(fieldType.elements.map((e) => buildEncodeField(e, db)));
     }
     case 'const': {
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      const ft = fieldType as LiteralType<(string | number | boolean | null)[]>;
-      return zodUnion(ft.values.map((v) => z.literal(v)));
+      return zodUnion(fieldType.values.map((v) => z.literal(v)));
     }
     default:
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-      return assertNever(fieldType as never);
+      return assertNever(fieldType);
   }
 }
 


### PR DESCRIPTION
## Summary

`FieldType` was an open structural base (`{ type: string; input: unknown; output: unknown }`), so every switch over descriptors needed an unsafe cast per arm and a fake `assertNever(fieldType as never)` default. This PR closes it into a discriminated union keyed on `type` (soundness item S2-PR1, with S3/S5 riding along).

- Both codecs (`google-cloud-firestore`, `firebase-js-sdk`) lose all 9 per-arm casts each; their `default` clauses are now real exhaustiveness checks. Adding a new descriptor will surface every handling site as a compile error.
- `isMapType` is a genuinely verified type predicate, and `fieldTypeOfPath`'s nested walk narrows through it instead of an unsafe `as MapType`.

## Design note: the `Any*` widest interfaces

The recursive members join the union as new non-generic `AnyMapType` / `AnyArrayType` / `AnyUnionType` interfaces (plus `MapFields` becoming an interface), not the generic aliases:

- Spelling the union with the aliases is an eager-resolution TS2456 circular reference.
- Making the generic aliases interfaces instead breaks assignability: TS compares two instantiations of one generic interface by measured variance, the computed `input`/`output` members measure as invariant, and e.g. `UnionType<[StringType, NullType]>` stops being accepted where the widest union descriptor is expected.

The `Any*` interfaces keep `input`/`output` at `unknown` — exactly the width the old open base had — which also terminates the wide union's value-type recursion. Every concrete `MapType<T>` / `ArrayType<T>` / `UnionType<T>` is a structural subtype of its `Any*` counterpart, so all existing narrow-descriptor behavior is unchanged.

## Ride-alongs

- **S3**: drop `ArrayType`'s `headFixedPart` / `tailFixedPart` — dead type surface for unimplemented tuple support, unbuildable from factories and inconsistent with the phantom `output`.
- **S5**: reject schema field names containing `"."` at both layers (`WithoutDottedFieldNames` as an F-bounded constraint on `map` / `rootCollection` / `subCollection`, plus a runtime assert twin). Dots are the `MapFieldPath` separator, so such fields were unaddressable; this retires the `FieldTypeOfPath` caveat.

## Tests

- New closed-union membership test (every factory output annotated as `FieldType[]`) and a table-driven `isMapType` test.
- Dotted-field-name rejection pinned at both layers (`@ts-expect-error` + `toThrow`) for all three factories, including a nested `map`.
- 205 unit tests pass; `tsc --noEmit` clean across all packages; lint/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)