### PR TITLE
Let the compiler infer type predicates instead of hand-annotating

### DIFF
--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -35,26 +35,29 @@ typescript/no-unsafe-type-assertion` comment stating the specific compiler
 - **The `default` clause may contain nothing but `assertNever(...)`** (from
   `firestore-repository/util`). Never use `default` as a catch-all for "the
   rest of the members"; a non-exhaustive `switch` is forbidden.
-- **Do not branch on union/enum-like values with `if` / ternary equality
-  comparisons** (e.g. `if (x.kind !== 'field')`, `dir === 'asc' ? a : b`).
-  Use an exhaustive `switch` instead. Comparisons that are not union-member
+- **Do not use equality comparison on a union/enum-like value as a proxy for
+  deciding behavior** (e.g. `if (x.kind !== 'field')`, `dir === 'asc' ? a : b`).
+  The question such code actually asks is not "is it this member?" but "which
+  behavior does this value get?" — and the `else` / non-matching side becomes
+  an implicit catch-all for _every other member_, so a member added later
+  silently falls into it. Use an exhaustive `switch` instead, which forces
+  each member's behavior to be stated. Comparisons that are not union-member
   discrimination (e.g. `=== undefined` on an optional, numeric comparisons)
   are fine.
-- **Exception — type-predicate helpers.** A narrowing helper whose whole body
-  is a single boolean expression (e.g.
-  `const isMapType = (t: FieldType) => t.type === 'map'`) should be written
-  exactly like that, **without** a hand-written `t is X` annotation: since
-  TS 5.5 the compiler infers the type predicate from the expression and
-  _verifies_ it, whereas an explicit annotation is trusted unchecked. The
-  exhaustive-`switch` rule does not apply here — there is no per-member
-  behavior to keep in sync, and the inferred predicate stays correct when the
-  union gains members. Keep an explicit annotation only where inference is
-  impossible (the check is delegated to a boolean-returning function, as in
-  `server-value.ts`) or where the built-in narrowing is wrong and the
-  annotation deliberately overrides it (e.g. `Array.isArray` against
-  `readonly` array unions — `isConstantArray` in `pipelines/expression.ts`);
-  say why in a comment, and pin inferred predicates in a type test via
-  `expectTypeOf(fn).guards`.
+- **Membership tests themselves are not proxies and are allowed.** When the
+  question genuinely is "is this value that member?" (a type-predicate
+  helper), `===` is the direct expression of it and stays correct as the
+  union grows — every new member correctly answers "no". Write such a helper
+  as a single boolean expression **without** a hand-written `t is X`
+  annotation (e.g. `const isMapType = (t: FieldType) => t.type === 'map'`):
+  since TS 5.5 the compiler infers the type predicate from the expression and
+  _verifies_ it, whereas an explicit annotation is trusted unchecked. Keep an
+  explicit annotation only where inference is impossible (the check is
+  delegated to a boolean-returning function, as in `server-value.ts`) or
+  where the built-in narrowing is wrong and the annotation deliberately
+  overrides it (e.g. `Array.isArray` against `readonly` array unions —
+  `isConstantArray` in `pipelines/expression.ts`); say why in a comment, and
+  pin inferred predicates in a type test via `expectTypeOf(fn).guards`.
 - Enforcement: `typescript/switch-exhaustiveness-check` (with
   `considerDefaultExhaustiveForUnions: false`, `requireDefaultForNonUnion: true`)
   in `.oxlintrc.json` enforces the `switch` rules. The `if`/ternary ban is

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -36,11 +36,13 @@ typescript/no-unsafe-type-assertion` comment stating the specific compiler
   `firestore-repository/util`). Never use `default` as a catch-all for "the
   rest of the members"; a non-exhaustive `switch` is forbidden.
 - **Do not use equality comparison on a union/enum-like value as a proxy for
-  deciding behavior** (e.g. `if (x.kind !== 'field')`, `dir === 'asc' ? a : b`).
-  The question such code actually asks is not "is it this member?" but "which
-  behavior does this value get?" — and the `else` / non-matching side becomes
-  an implicit catch-all for _every other member_, so a member added later
-  silently falls into it. Use an exhaustive `switch` instead, which forces
+  deciding behavior** (e.g. `if (x.kind !== 'field')`, or
+  `expr.kind === 'constant' ? inlineValue(expr) : compileFunction(expr)` —
+  where `Expression` gains a new kind every rollout slice). The question such
+  code actually asks is not "is it this member?" but "which behavior does
+  this value get?" — and the `else` / non-matching side becomes an implicit
+  catch-all for _every other member_, so a member added later silently falls
+  into it. Use an exhaustive `switch` instead, which forces
   each member's behavior to be stated. Comparisons that are not union-member
   discrimination (e.g. `=== undefined` on an optional, numeric comparisons)
   are fine.

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -40,6 +40,21 @@ typescript/no-unsafe-type-assertion` comment stating the specific compiler
   Use an exhaustive `switch` instead. Comparisons that are not union-member
   discrimination (e.g. `=== undefined` on an optional, numeric comparisons)
   are fine.
+- **Exception — type-predicate helpers.** A narrowing helper whose whole body
+  is a single boolean expression (e.g.
+  `const isMapType = (t: FieldType) => t.type === 'map'`) should be written
+  exactly like that, **without** a hand-written `t is X` annotation: since
+  TS 5.5 the compiler infers the type predicate from the expression and
+  _verifies_ it, whereas an explicit annotation is trusted unchecked. The
+  exhaustive-`switch` rule does not apply here — there is no per-member
+  behavior to keep in sync, and the inferred predicate stays correct when the
+  union gains members. Keep an explicit annotation only where inference is
+  impossible (the check is delegated to a boolean-returning function, as in
+  `server-value.ts`) or where the built-in narrowing is wrong and the
+  annotation deliberately overrides it (e.g. `Array.isArray` against
+  `readonly` array unions — `isConstantArray` in `pipelines/expression.ts`);
+  say why in a comment, and pin inferred predicates in a type test via
+  `expectTypeOf(fn).guards`.
 - Enforcement: `typescript/switch-exhaustiveness-check` (with
   `considerDefaultExhaustiveForUnions: false`, `requireDefaultForNonUnion: true`)
   in `.oxlintrc.json` enforces the `switch` rules. The `if`/ternary ban is

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -27,9 +27,8 @@ import * as z from 'zod';
 // oxlint-disable-next-line typescript/no-explicit-any
 type ZodAny = z.ZodType<any, any>;
 
-export const isBytes = (v: unknown): v is FirestoreBytes => v instanceof FirestoreBytes;
-export const isDocumentReference = (v: unknown): v is FirestoreDocumentReference =>
-  v instanceof FirestoreDocumentReference;
+export const isBytes = (v: unknown) => v instanceof FirestoreBytes;
+export const isDocumentReference = (v: unknown) => v instanceof FirestoreDocumentReference;
 
 export function buildDecodeSchema(schema: DocumentSchema): z.ZodObject<z.ZodRawShape> {
   return z.object(

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { DocRef } from './repository.js';
 import {
+  type AnyMapType,
   array,
   type ArrayType,
   bool,
@@ -238,6 +239,8 @@ describe('schema', () => {
         literal('a'),
       ];
       expect(nonMaps.map(isMapType)).toEqual(nonMaps.map(() => false));
+      // Pins the compiler-inferred (checked, not asserted) type predicate.
+      expectTypeOf(isMapType).guards.toEqualTypeOf<AnyMapType>();
     });
   });
 

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -1,5 +1,4 @@
 import { DocRef } from './repository.js';
-import { assertNever } from './util.js';
 
 /**
  * A definition of a Firestore collection
@@ -456,26 +455,9 @@ export const omitPaths = <T extends DocumentSchema, const P extends readonly str
 const tailPath = (key: string, paths: readonly string[]): string[] =>
   paths.filter((p) => p.startsWith(`${key}.`)).map((p) => p.slice(key.length + 1));
 
-/** Narrows a `FieldType` descriptor to the widest map descriptor. */
-export const isMapType = (t: FieldType): t is AnyMapType => {
-  switch (t.type) {
-    case 'map':
-      return true;
-    case 'bool':
-    case 'string':
-    case 'int64':
-    case 'double':
-    case 'timestamp':
-    case 'docRef':
-    case 'bytes':
-    case 'geoPoint':
-    case 'vector':
-    case 'null':
-    case 'array':
-    case 'union':
-    case 'const':
-      return false;
-    default:
-      return assertNever(t);
-  }
-};
+/**
+ * Narrows a `FieldType` descriptor to the widest map descriptor. The
+ * `t is AnyMapType` predicate is inferred (and therefore checked) by the
+ * compiler — pinned in `schema.test.ts`.
+ */
+export const isMapType = (t: FieldType) => t.type === 'map';

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -21,10 +21,8 @@ import * as z from 'zod';
 // oxlint-disable-next-line typescript/no-explicit-any
 type ZodAny = z.ZodType<any, any>;
 
-export const isVectorValue = (v: unknown): v is FirestoreVectorValue =>
-  v instanceof FirestoreVectorValue;
-export const isDocumentReference = (v: unknown): v is FirestoreDocumentReference =>
-  v instanceof FirestoreDocumentReference;
+export const isVectorValue = (v: unknown) => v instanceof FirestoreVectorValue;
+export const isDocumentReference = (v: unknown) => v instanceof FirestoreDocumentReference;
 
 export function buildDecodeSchema(schema: DocumentSchema): z.ZodObject<z.ZodRawShape> {
   return z.object(


### PR DESCRIPTION
## Summary

Since TS 5.5, a narrowing helper whose body is a single boolean expression gets its type predicate **inferred and verified** by the compiler, while an explicit `v is X` annotation is trusted unchecked. This PR switches the codebase to the inferred style wherever inference covers the helper.

## Changes

- **`isMapType`** (`schema.ts`): the exhaustive-switch form (14 arms + assertNever) collapses to `(t: FieldType) => t.type === 'map'`, whose inferred `t is AnyMapType` predicate is pinned in `schema.test.ts` with `expectTypeOf(isMapType).guards.toEqualTypeOf<AnyMapType>()`. The now-unused `assertNever` import is dropped.
- **`instanceof` guards in both codecs**: `isVectorValue`, `isBytes`, `isDocumentReference` ×2 lose their hand-written annotations.

## Deliberately unchanged

- `server-value.ts` guards (`isArrayRemove` etc.): they delegate to the boolean-returning `hasServerOp`, so there is nothing for the compiler to infer from.
- `isConstantArray` / `isConstantArrayValue`: their annotation deliberately overrides `Array.isArray`'s broken narrowing of `readonly` array unions — letting the compiler infer there would reintroduce the bug the helpers exist to fix.

## Guideline

The union-handling section of `docs/coding-guideline.md` is reframed around the ban's actual rationale: `===` on a union member is forbidden when it is a *proxy for deciding behavior* (the non-matching branch silently absorbs every future member — illustrated with `Expression`, which gains a new kind every rollout slice), while a *membership test itself* — a type-predicate helper — is the direct expression of the question and stays correct as the union grows, so it sits outside the ban rather than being an ad-hoc exception. The section also covers when an explicit annotation is still warranted and the `.guards` pinning convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
