### PR TITLE
Restrict Dependabot to lockfile updates for routine bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # This is a library, so the declared version ranges in package.json are the
+    # public contract and should be curated by humans, not bumped automatically.
+    # Only edit package.json when a new version falls outside the current range;
+    # otherwise just refresh the lockfile.
+    versioning-strategy: 'increase-if-necessary'
+    # Skip routine major-version PRs so we widen ranges deliberately by hand.
+    # This only applies to version updates; security updates ignore this and
+    # still open PRs (bumping package.json if a fix requires leaving the range).
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## What

Change the Dependabot npm config so routine updates only refresh the lockfile, while security fixes still open PRs.

- `versioning-strategy: increase-if-necessary` — `package.json` is only edited when a new version falls outside the current range; otherwise just the lockfile is refreshed.
- `ignore` routine `semver-major` version updates so we widen ranges deliberately by hand.

## Why

This is a library, so the version ranges declared in `package.json` are part of the public contract and should be curated by humans rather than bumped automatically.

`update-types` / `ignore` only apply to version updates — **security updates ignore these rules and still open PRs**, bumping `package.json` when a fix requires leaving the current range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)