### PR TITLE
Add the firestoreType phantom axis and move predicates onto it

### DIFF
--- a/docs/pipeline-query-null-semantics-research.md
+++ b/docs/pipeline-query-null-semantics-research.md
@@ -1,0 +1,52 @@
+# Pipeline Query — `null` / absent semantics in expressions
+
+> Empirical notes on how pipeline expressions treat `null` values and absent
+> fields. Probed 2026-07 against a real Firestore Enterprise database
+> (`ikenox-sunrise` / `enterprise-native-playground`) via
+> `@google-cloud/firestore@8.6.0` (`probe-logical-null.mjs` under gitignored
+> `./.ikenox/`, plus earlier probes referenced from the plan docs).
+
+## Absent behaves as `null` inside expressions
+
+An operand referencing a missing field behaves exactly like a `null` operand
+in every probed expression (logical operators below, and value functions /
+comparisons in earlier probes): absence merges into `null` the moment a value
+enters an expression. Presence is only distinguishable at the projection
+layer (leaf-absence in `select` output).
+
+Library consequence: the type model needs no `'absent'` tag on the
+`firestoreType` axis — presence stays on the orthogonal `optional` marker —
+but **return-type null propagation must count `Optional` operands as
+possibly-null** (`PropagateNull` in `pipelines/expression.ts`).
+
+## Logical operators use Kleene three-valued logic
+
+`and` / `or` / `not` do NOT coerce `null` to `false`; `null` means "unknown"
+and propagates unless the other operand decides the result:
+
+```
+and(true,  null) -> null      or(true,  null) -> true
+and(false, null) -> false     or(false, null) -> null
+and(null,  null) -> null      or(null,  null) -> null
+not(null)        -> null
+```
+
+(Absent operands: identical, per the merge rule above.)
+
+So a logical expression over a possibly-null operand is itself possibly null
+— the library propagates this into the result descriptor (`PropagateNull`:
+`BoolType` becomes `UnionType<[BoolType, NullType]>` when any operand can be
+null or absent).
+
+Note the interplay with `where`: a `null` condition drops the row (truthy-only
+semantics — only exactly `true` keeps it), so Kleene `null` and `false` are
+indistinguishable there. The distinction matters as soon as the expression's
+VALUE is observed — projected via `select` / `addFields`, or used as an
+operand of another function.
+
+## Comparisons are total — never `null`
+
+`equal` / `notEqual` / `lessThan` / ... always return `true` or `false`, even
+over `null` / absent operands (`equal(null, 'x')` is `false`,
+`equal(null, null)` is `true` — probed earlier, see the expressions plan).
+Comparison results therefore stay plain `BoolType` with no null propagation.

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -105,11 +105,14 @@ Consequences (all implemented in S2 unless noted):
   zero overlap — TS's own `===` rule. `equal(field(union(string(),
 double())), field(string()))` is legal; reference-vs-`array(string())`,
   vector-vs-`array(double())`, and geopoint-vs-same-shaped-map are rejected
-  (the tag axis at work). Consistent with the predicates, `'null'` is
-  special-cased: sharing ONLY `'null'` is not overlap
-  (`nullable(string())` vs `nullable(timestamp())` is rejected), except for
-  a PURE null operand — an is-null check, legal against nullable operands
-  and rejected against never-null ones.
+  (the tag axis at work). The rule applies MEMBER-WISE at every depth
+  (`TagSetsComparable` recurses into array elements and map fields,
+  matching TS's own nested-union handling): a shared element tag is enough
+  for two heterogeneous arrays to compare. Consistent with the predicates,
+  `'null'` is special-cased at each level: sharing ONLY `'null'` is not
+  overlap (`nullable(string())` vs `nullable(timestamp())` is rejected),
+  except for a PURE null operand — an is-null check, legal against
+  nullable operands and rejected against never-null ones.
 - `Int64Type` and `DoubleType` both carry the honest `'integer' | 'double'`
   tag (the SDKs pick the wire encoding per value), which keeps the numeric
   domain mutually comparable — this replaces the old `NumericType` union

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -62,43 +62,54 @@ Expression<T> = discriminated union of all leaves (narrowed via `kind`)
 
 ### Operand constraints are value-domain predicates, not descriptor unions
 
-An operation like `toUpper` must accept every descriptor whose **value domain**
-is a subset of string — `StringType`, `LiteralType<['x','y']>`,
+**Implemented (S2): the predicates key on the `firestoreType` phantom axis.**
+Every descriptor carries a third phantom, `firestoreType` (`schema.ts`) — the
+type of the values as Firestore classifies them, structurally recursive for
+containers, with unions distributing and literals mapping to their base tags.
+It exists because the phantom `output` is the TS-representation axis and
+conflates pairs Firestore keeps distinct (reference/`string[]`,
+vector/`number[]`, geopoint/`{latitude,longitude}` map).
+
+An operation like `toUpper` must accept every descriptor whose **value
+domain** fits — `StringType`, `LiteralType<['x','y']>`,
 `UnionType<[StringType, ...]>`, `StringType & Optional`, and any future
 combination. Enumerating descriptor constructors would combinatorially
-explode; instead the phantom `output` type the descriptors already carry
-(valibot-style) expresses the domain structurally:
+explode; a tag-subset predicate expresses the domain structurally:
 
 ```ts
-type StringValued = FieldType & { output: string };
+type StringValued = FieldType & { firestoreType: 'string' | 'null' };
 toUpper(s: Expression<StringValued>): UnaryFunction<StringType>
 ```
 
-Verified: literals / string unions are accepted covariantly; `double()`,
-`nullable(string())` (null in the domain), and mixed unions are rejected.
-One alias per domain (`StringValued` / `NumberValued` / `BooleanValued` /
-`TimestampValued` / ...), shared by standalone factories and fluent
+One alias per domain (`BooleanValued` is implemented in `expression.ts`;
+`StringValued` / `NumberValued` / `TimestampValued` / ... arrive with the
+slices that need them), shared by standalone factories and fluent
 `this`-parameters alike.
 
-Consequences adopted with it:
+Consequences (all implemented in S2 unless noted):
 
-- **Comparisons move from same-domain to OVERLAP-based compatibility**:
-  `equal(l, r)` is valid iff the operands' tag domains intersect
-  (`Extract<TagOf<L>, TagOf<R>> extends never` rejects). Grounds: the backend's
-  comparisons are total (probed — `equal(null,'x')` is `false`, never an
-  error), so cross-domain rejection is a lint against always-false
-  comparisons, and its correct boundary is zero overlap — TS's own `===`
-  rule. This legalizes `equal(field(union(string(), double())), field(string()))`,
-  which the current same-`T` fallback rejects (pinned in expression.test.ts
-  as the _current_ contract).
-
-- The existing `NumericType = Int64Type | DoubleType` union is superseded by
-  `NumberValued` (numeric literals become comparable).
-- `where`'s condition type becomes `Expression<BooleanValued>`.
-- `nullable(...)` operands are **rejected** (strict): coalesce first
-  (`ifAbsent` etc., slice 5) rather than inheriting backend null semantics.
-- `... & Optional` operands pass (the domain is right; absence propagation is
-  backend semantics, probed in slice 5).
+- **Domains are null-TOLERANT** (`'string' | 'null'` above): probed backend
+  semantics make `null` a well-behaved operand everywhere — `null` and
+  absent operands flow through functions as `null`, comparisons are total,
+  and a non-`true` condition just drops the row. So `nullable(string())` is
+  inside the string domain, and `... & Optional` operands pass too (the
+  marker does not change the tag). (This supersedes an earlier "reject
+  nullable, coalesce first" stance.)
+- **Comparisons are OVERLAP-based**: `equal(l, r)` is valid iff the
+  operands' tag sets intersect (symmetric `Extract` check — `Comparable` in
+  `expression.ts`). Grounds: the backend's comparisons are total (probed —
+  `equal(null,'x')` is `false`, never an error), so cross-domain rejection
+  is a lint against always-false comparisons, and its correct boundary is
+  zero overlap — TS's own `===` rule. `equal(field(union(string(),
+double())), field(string()))` is legal; reference-vs-`array(string())`,
+  vector-vs-`array(double())`, and geopoint-vs-same-shaped-map are rejected
+  (the tag axis at work).
+- `Int64Type` and `DoubleType` both carry the honest `'integer' | 'double'`
+  tag (the SDKs pick the wire encoding per value), which keeps the numeric
+  domain mutually comparable — this replaces the old `NumericType` union
+  and the number/string overload pairs.
+- `where`'s condition type is `Expression<BooleanValued>` (boolean literals
+  and `nullable(bool())` are valid conditions).
 - Return types widen to the plain descriptor (`toUpper` of a literal returns
   `StringType`) — values are transformed, so precision loss is correct.
 
@@ -171,6 +182,11 @@ return-type refinement for arithmetic; vector dimension typing (if ever).
       overloads before the same-`T` fallback) so literal-typed fields compare
       against plain constants. Executors translate per value type (plain
       `GeoPoint` → SDK class; `Uint8Array` → `Bytes` on the client SDK).
+- [x] **1.5. `firestoreType` phantom + predicate migration (S2)** — the tag
+      axis on every descriptor, null-tolerant domains, overlap-based
+      comparisons (single signature replaces the per-domain overload
+      triples), `where` / `and` / `or` / `not` on `BooleanValued`. See
+      "Operand constraints are value-domain predicates" above.
 - [ ] **2. Arithmetic + string basics** (T1 bulk: binary/unary flows already
       paved; introduces `NullaryFunction` for `rand`).
 - [ ] **3. String rest + regex + reference + type + vector** (T1 bulk #2;

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -77,24 +77,26 @@ combination. Enumerating descriptor constructors would combinatorially
 explode; a tag-subset predicate expresses the domain structurally:
 
 ```ts
-type StringValued = FieldType & { firestoreType: 'string' | 'null' };
-toUpper(s: Expression<StringValued>): UnaryFunction<StringType>
+type Valued<Tag extends FirestoreType> = FieldType & { firestoreType: Tag | 'null' };
+toUpper(s: Expression<Valued<'string'>>): UnaryFunction<StringType>
 ```
 
-One alias per domain (`BooleanValued` is implemented in `expression.ts`;
-`StringValued` / `NumberValued` / `TimestampValued` / ... arrive with the
-slices that need them), shared by standalone factories and fluent
-`this`-parameters alike.
+ONE generic predicate (`Valued`, implemented in `expression.ts`) — not an
+alias zoo per domain: `where` conditions are `Valued<'boolean'>`, string
+operands `Valued<'string'>`, and so on, shared by standalone factories and
+fluent `this`-parameters alike.
 
 Consequences (all implemented in S2 unless noted):
 
-- **Domains are null-TOLERANT** (`'string' | 'null'` above): probed backend
-  semantics make `null` a well-behaved operand everywhere — `null` and
-  absent operands flow through functions as `null`, comparisons are total,
-  and a non-`true` condition just drops the row. So `nullable(string())` is
-  inside the string domain, and `... & Optional` operands pass too (the
-  marker does not change the tag). (This supersedes an earlier "reject
-  nullable, coalesce first" stance.)
+- **`null` is special-cased once, inside the machinery — individual domains
+  never mention it.** Probed backend semantics make `null` a well-behaved
+  operand everywhere (`null` and absent operands flow through functions as
+  `null`, comparisons are total, and a non-`true` condition just drops the
+  row — see `../pipeline-query-null-semantics-research.md`), so `Valued`
+  admits `'null'` tags in every domain: `nullable(string())` is inside the
+  string domain, and `... & Optional` operands pass too (the marker does not
+  change the tag). (This supersedes an earlier "reject nullable, coalesce
+  first" stance.)
 - **Comparisons are OVERLAP-based**: `equal(l, r)` is valid iff the
   operands' tag sets intersect (symmetric `Extract` check — `Comparable` in
   `expression.ts`). Grounds: the backend's comparisons are total (probed —
@@ -103,13 +105,24 @@ Consequences (all implemented in S2 unless noted):
   zero overlap — TS's own `===` rule. `equal(field(union(string(),
 double())), field(string()))` is legal; reference-vs-`array(string())`,
   vector-vs-`array(double())`, and geopoint-vs-same-shaped-map are rejected
-  (the tag axis at work).
+  (the tag axis at work). Consistent with the predicates, `'null'` is
+  special-cased: sharing ONLY `'null'` is not overlap
+  (`nullable(string())` vs `nullable(timestamp())` is rejected), except for
+  a PURE null operand — an is-null check, legal against nullable operands
+  and rejected against never-null ones.
 - `Int64Type` and `DoubleType` both carry the honest `'integer' | 'double'`
   tag (the SDKs pick the wire encoding per value), which keeps the numeric
   domain mutually comparable — this replaces the old `NumericType` union
   and the number/string overload pairs.
-- `where`'s condition type is `Expression<BooleanValued>` (boolean literals
-  and `nullable(bool())` are valid conditions).
+- `where`'s condition type is `Expression<Valued<'boolean'>>` (boolean
+  literals and `nullable(bool())` are valid conditions).
+- **Return types propagate nullability** (`PropagateNull` /
+  `propagateNull`): the logical operators follow Kleene three-valued logic
+  (probed — `and(true, null)` is `null`, see the null-semantics research
+  doc), so `and` / `or` / `not` return `nullable(bool())` when any
+  operand's tags include `'null'` OR the operand is `& Optional` (absence
+  flows through functions as `null`). Comparisons stay plain `BoolType`
+  (total). Value functions in later slices reuse `PropagateNull`.
 - Return types widen to the plain descriptor (`toUpper` of a literal returns
   `StringType`) — values are transformed, so precision loss is correct.
 
@@ -185,7 +198,10 @@ return-type refinement for arithmetic; vector dimension typing (if ever).
 - [x] **1.5. `firestoreType` phantom + predicate migration (S2)** — the tag
       axis on every descriptor, null-tolerant domains, overlap-based
       comparisons (single signature replaces the per-domain overload
-      triples), `where` / `and` / `or` / `not` on `BooleanValued`. See
+      triples with `'null'` special-cased once in the machinery),
+      `where` / `and` / `or` / `not` on `Valued<'boolean'>`, and Kleene
+      null propagation into logical return descriptors (`PropagateNull`).
+      See
       "Operand constraints are value-domain predicates" above.
 - [ ] **2. Arithmetic + string basics** (T1 bulk: binary/unary flows already
       paved; introduces `NullaryFunction` for `rand`).

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -27,6 +27,7 @@ Related research / decisions:
 
 - [`../pipeline-query-identity-research.md`](../pipeline-query-identity-research.md) — which stages preserve `id` / `ref` / `createTime` / `updateTime`.
 - [`../pipeline-query-ordering-research.md`](../pipeline-query-ordering-research.md) — `sort` keeps rows missing the field (unlike core `orderBy`); `null` < absent < values.
+- [`../pipeline-query-null-semantics-research.md`](../pipeline-query-null-semantics-research.md) — absent merges into `null` inside expressions; logical operators are Kleene three-valued; comparisons are total.
 - [`../pipeline-query-projection-research.md`](../pipeline-query-projection-research.md) — `select` / `add_fields` output shaping (dotted-name materialization, conflict rejection vs the library's last-wins, add_fields merge rules).
 
 ## Current status (snapshot — read this first)

--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -9,7 +9,7 @@ import type {
   WriteBatch,
 } from '@firebase/firestore';
 import {
-      and,
+  and,
   average,
   collection,
   collectionGroup,

--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -9,7 +9,7 @@ import type {
   WriteBatch,
 } from '@firebase/firestore';
 import {
-  and,
+      and,
   average,
   collection,
   collectionGroup,

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -5,6 +5,7 @@ import {
   bool,
   type BoolType,
   bytes,
+  docRef,
   double,
   geoPoint,
   int64,
@@ -12,6 +13,7 @@ import {
   map,
   nullable,
   nullType,
+  rootCollection,
   string,
   type StringType,
   timestamp,
@@ -294,26 +296,38 @@ describe('comparison operators (table-driven over all six)', () => {
     greaterThanOrEqual(name, rank);
   });
 
-  it('same-T requires identical descriptors — no union-vs-narrow widening', () => {
-    // Empirically disproved a stale comment: the same-T fallback does NOT
-    // unify a union-typed operand with a narrower one. NOTE: this is the
-    // CURRENT contract, and deliberately changes with the planned
-    // overlap-based compatibility (see the expressions plan) — a union with
-    // a shared member SHOULD compare.
+  it('overlap-based compatibility: a union with a shared member compares against a narrower operand', () => {
     const u1 = field(union(string(), double()), 'u1');
     const u2 = field(union(string(), double()), 'u2');
     equal(u1, u2); // identical union descriptors: ok
-    // @ts-expect-error -- a narrower operand does not widen into the union
-    equal(u1, field(string(), 's'));
+    equal(u1, field(string(), 's')); // shared 'string' tag: ok
+    equal(u1, constant(1)); // shared numeric tags: ok
+    // @ts-expect-error -- zero overlap: {string, integer, double} vs timestamp
+    equal(u1, field(timestamp(), 'at'));
   });
 
-  it('pins the current nullable contract (to change with null-tolerant domains)', () => {
+  it('null-tolerant domains: nullable operands compare on their non-null overlap', () => {
     const ns = field(nullable(string()), 'ns');
-    // Identical nullable descriptors unify via same-T...
     equal(ns, ns);
-    // ...but a plain string constant does not (strict domains today).
-    // @ts-expect-error -- nullable strings are outside the string domain
-    equal(ns, constant('x'));
+    equal(ns, constant('x')); // shared 'string' tag: ok
+    equal(ns, constant(null)); // shared 'null' tag: an is-null check is legal
+    // A non-nullable field is never null — an always-false comparison is
+    // exactly what the zero-overlap lint rejects.
+    // @ts-expect-error -- 'string' vs 'null' have zero overlap
+    equal(field(string(), 's'), constant(null));
+  });
+
+  it('firestoreType keys the compatibility — pairs whose TS representations collide stay rejected', () => {
+    const authors = rootCollection({ name: 'authors', schema: { name: string() } });
+    // A reference decodes to string[], a vector to number[], a geopoint to a
+    // {latitude, longitude} object — the tag axis keeps them apart from the
+    // genuine array/map descriptors sharing those representations.
+    // @ts-expect-error -- 'reference' vs array-of-'string'
+    equal(field(docRef(authors), 'ref'), field(array(string()), 'tags'));
+    // @ts-expect-error -- 'vector' vs array-of-number
+    equal(field(vector(), 'vec'), field(array(double()), 'nums'));
+    // @ts-expect-error -- 'geopoint' vs the same-shaped map
+    equal(field(geoPoint(), 'geo'), field(map({ latitude: double(), longitude: double() }), 'm'));
   });
 });
 
@@ -327,10 +341,17 @@ describe('logical operator edges', () => {
     expect(five.name).toBe('and');
   });
 
-  it('pins the current exact-BoolType contract for conditions', () => {
-    // A literal(true, false) field is a LiteralType, not BoolType — rejected
-    // today (to change with the planned BooleanValued domain).
-    // @ts-expect-error -- literal booleans are not Expression<BoolType>
+  it('conditions are BooleanValued: boolean literals and nullable booleans qualify', () => {
+    // The condition domain is the firestoreType predicate 'boolean' | 'null',
+    // not the exact BoolType descriptor: a literal(true, false) field and a
+    // nullable(bool()) field are both boolean-valued (a null condition just
+    // drops the row — truthy-only semantics).
     and(flag, field(literal(true, false), 'lit'));
+    or(flag, field(nullable(bool()), 'nb'));
+    not(field(literal(true), 'lt'));
+    // @ts-expect-error -- a string field is not boolean-valued
+    and(flag, field(string(), 'name'));
+    // @ts-expect-error -- a string field is not a condition
+    not(field(string(), 'name'));
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -323,6 +323,29 @@ describe('comparison operators (table-driven over all six)', () => {
     // ...and rejected against a never-null one (always false).
     // @ts-expect-error -- 'string' vs 'null' have zero overlap
     equal(field(string(), 's'), constant(null));
+    // A plain descriptor overlaps its nullable widening.
+    equal(field(string(), 's'), ns);
+  });
+
+  it('container tags compare by element-set inclusion (either direction)', () => {
+    // Top-level null stripping does not reach inside containers, but the
+    // SYMMETRIC Extract does the work: string[] is assignable to
+    // (string|null)[] element-covariantly, so the pair overlaps — in both
+    // argument orders.
+    const arr = field(array(string()), 'arr');
+    const arrNullable = field(array(nullable(string())), 'arrN');
+    equal(arr, arrNullable);
+    equal(arrNullable, arr);
+    // Same for a map field widened with null.
+    equal(field(map({ a: string() }), 'm'), field(map({ a: nullable(string()) }), 'mn'));
+    // Disjoint element sets stay rejected even when both are nullable inside.
+    // @ts-expect-error -- (string|null)[] vs (double|null)[] share no non-null element tag
+    equal(arrNullable, field(array(nullable(double())), 'dn'));
+    // KNOWN LIMIT: inside a container the check is inclusion, not member-wise
+    // overlap — elements sharing 'string' but with neither side a subset of
+    // the other are rejected.
+    // @ts-expect-error -- (string|double)[] vs (string|null)[]: neither includes the other
+    equal(field(array(union(string(), double())), 'sd'), arrNullable);
   });
 
   it('firestoreType keys the compatibility — pairs whose TS representations collide stay rejected', () => {

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -13,6 +13,7 @@ import {
   map,
   nullable,
   nullType,
+  optional,
   rootCollection,
   string,
   type StringType,
@@ -306,13 +307,20 @@ describe('comparison operators (table-driven over all six)', () => {
     equal(u1, field(timestamp(), 'at'));
   });
 
-  it('null-tolerant domains: nullable operands compare on their non-null overlap', () => {
+  it('null is special-cased: nullable operands compare on their NON-NULL overlap', () => {
     const ns = field(nullable(string()), 'ns');
     equal(ns, ns);
     equal(ns, constant('x')); // shared 'string' tag: ok
-    equal(ns, constant(null)); // shared 'null' tag: an is-null check is legal
-    // A non-nullable field is never null — an always-false comparison is
-    // exactly what the zero-overlap lint rejects.
+    // Sharing ONLY 'null' does not make a pair comparable: true only in the
+    // both-null corner — almost surely a bug.
+    // @ts-expect-error -- the non-null tags (string vs timestamp) have zero overlap
+    equal(ns, field(nullable(timestamp()), 'nt'));
+    // A PURE null operand is the exception — an is-null check, legal against
+    // any nullable operand (either side) ...
+    equal(ns, constant(null));
+    equal(constant(null), ns);
+    equal(constant(null), constant(null));
+    // ...and rejected against a never-null one (always false).
     // @ts-expect-error -- 'string' vs 'null' have zero overlap
     equal(field(string(), 's'), constant(null));
   });
@@ -341,11 +349,12 @@ describe('logical operator edges', () => {
     expect(five.name).toBe('and');
   });
 
-  it('conditions are BooleanValued: boolean literals and nullable booleans qualify', () => {
-    // The condition domain is the firestoreType predicate 'boolean' | 'null',
-    // not the exact BoolType descriptor: a literal(true, false) field and a
-    // nullable(bool()) field are both boolean-valued (a null condition just
-    // drops the row — truthy-only semantics).
+  it("conditions are Valued<'boolean'>: boolean literals and nullable booleans qualify", () => {
+    // The condition domain is the firestoreType predicate 'boolean' (null is
+    // special-cased inside Valued), not the exact BoolType descriptor: a
+    // literal(true, false) field and a nullable(bool()) field are both
+    // boolean-valued (a null condition just drops the row — truthy-only
+    // semantics).
     and(flag, field(literal(true, false), 'lit'));
     or(flag, field(nullable(bool()), 'nb'));
     not(field(literal(true), 'lt'));
@@ -353,5 +362,47 @@ describe('logical operator edges', () => {
     and(flag, field(string(), 'name'));
     // @ts-expect-error -- a string field is not a condition
     not(field(string(), 'name'));
+  });
+
+  it('propagates operand nullability into the result descriptor (Kleene logic)', () => {
+    // Probed: and(true, null) is null, and(false, null) is false — Kleene
+    // three-valued logic, so a possibly-null operand makes the result
+    // possibly null. Oracle-both-sides per operator/operand kind.
+    const nullableBool = nullable(bool());
+
+    // All-boolean operands: the result stays a plain BoolType.
+    const strict = and(flag, not(flag));
+    expect(strict.type).toStrictEqual(bool());
+    expectTypeOf(strict.type).toEqualTypeOf(bool());
+
+    // A nullable operand propagates.
+    const viaNullable = and(flag, field(nullable(bool()), 'nb'));
+    expect(viaNullable.type).toStrictEqual(nullableBool);
+    expectTypeOf(viaNullable.type).toEqualTypeOf(nullableBool);
+
+    // An optional (possibly absent) operand counts too: an absent operand
+    // flows through functions as null (probed).
+    const viaOptional = or(flag, field(optional(bool()), 'ob'));
+    expect(viaOptional.type).toStrictEqual(nullableBool);
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullableBool);
+
+    // A boolean literal union containing null counts.
+    const viaLiteral = or(flag, field(literal(true, null), 'ln'));
+    expect(viaLiteral.type).toStrictEqual(nullableBool);
+    expectTypeOf(viaLiteral.type).toEqualTypeOf(nullableBool);
+
+    // not() propagates, and nested nullability flows upward.
+    const viaNot = not(field(nullable(bool()), 'nb'));
+    expect(viaNot.type).toStrictEqual(nullableBool);
+    expectTypeOf(viaNot.type).toEqualTypeOf(nullableBool);
+    const nested = and(flag, viaNot);
+    expect(nested.type).toStrictEqual(nullableBool);
+    expectTypeOf(nested.type).toEqualTypeOf(nullableBool);
+
+    // Comparisons do NOT propagate: they are total (never null), even over
+    // nullable operands.
+    const cmp = equal(field(nullable(string()), 'ns'), constant(null));
+    expect(cmp.type).toStrictEqual(bool());
+    expectTypeOf(cmp.type).toEqualTypeOf(bool());
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -327,25 +327,37 @@ describe('comparison operators (table-driven over all six)', () => {
     equal(field(string(), 's'), ns);
   });
 
-  it('container tags compare by element-set inclusion (either direction)', () => {
-    // Top-level null stripping does not reach inside containers, but the
-    // SYMMETRIC Extract does the work: string[] is assignable to
-    // (string|null)[] element-covariantly, so the pair overlaps — in both
-    // argument orders.
+  it('container tags compare member-wise at every depth (one rule, uniformly)', () => {
+    // The single TagSetsComparable rule (null-stripped overlap + the
+    // pure-null is-null exception) recurses into array elements and map
+    // fields, matching how TS's own === treats nested unions.
     const arr = field(array(string()), 'arr');
     const arrNullable = field(array(nullable(string())), 'arrN');
     equal(arr, arrNullable);
     equal(arrNullable, arr);
-    // Same for a map field widened with null.
-    equal(field(map({ a: string() }), 'm'), field(map({ a: nullable(string()) }), 'mn'));
-    // Disjoint element sets stay rejected even when both are nullable inside.
+    // A shared element tag is enough — neither side needs to include the other.
+    equal(field(array(union(string(), double())), 'sd'), arrNullable);
+    // An array of pure nulls against a nullable-element array is the nested
+    // is-null form.
+    equal(field(array(nullType()), 'nulls'), arrNullable);
+    // Sharing ONLY null inside the container is not overlap (the nested
+    // both-null corner) ...
     // @ts-expect-error -- (string|null)[] vs (double|null)[] share no non-null element tag
     equal(arrNullable, field(array(nullable(double())), 'dn'));
-    // KNOWN LIMIT: inside a container the check is inclusion, not member-wise
-    // overlap — elements sharing 'string' but with neither side a subset of
-    // the other are rejected.
-    // @ts-expect-error -- (string|double)[] vs (string|null)[]: neither includes the other
-    equal(field(array(union(string(), double())), 'sd'), arrNullable);
+    // ...and pure-null elements against never-null elements stay rejected.
+    // @ts-expect-error -- null[] vs string[]: an element is never null
+    equal(field(array(nullType()), 'nulls'), arr);
+    // Maps: one key set must include the other, shared keys compare
+    // member-wise.
+    equal(field(map({ a: string() }), 'm'), field(map({ a: nullable(string()) }), 'mn'));
+    equal(
+      field(map({ a: string() }), 'm'),
+      field(map({ a: union(string(), double()), b: bool() }), 'wide'),
+    );
+    // @ts-expect-error -- disjoint key sets: maps of different shapes never hold equal values
+    equal(field(map({ a: string() }), 'm'), field(map({ b: string() }), 'other'));
+    // @ts-expect-error -- shared key with disjoint tags
+    equal(field(map({ a: string() }), 'm'), field(map({ a: double() }), 'num'));
   });
 
   it('firestoreType keys the compatibility — pairs whose TS representations collide stay rejected', () => {

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -397,132 +397,84 @@ export class VariadicFunction<T extends FieldType = FieldType> extends Expressio
 }
 export type VariadicFunctionName = 'and' | 'or';
 
-// Value-domain predicates: a descriptor whose phantom `output` (the value
-// domain) is a subset of the given primitive — so literals, unions of the
-// domain, and `& Optional` variants all qualify structurally, with no
-// enumeration of descriptor constructors. See
-// docs/plan/pipeline-query-expressions.md.
-type NumberValued = FieldType & { output: number };
-type StringValued = FieldType & { output: string };
+/**
+ * The value-domain predicate for boolean contexts (`where` conditions,
+ * `and` / `or` / `not` operands): a descriptor whose `firestoreType` tags are
+ * a subset of `'boolean' | 'null'` — so `bool()`, boolean literals,
+ * `nullable(bool())`, and `& Optional` variants all qualify structurally.
+ *
+ * Predicates key on the `firestoreType` axis (not the TS-representation
+ * `output`) and are null-TOLERANT: probed backend semantics make `null` a
+ * well-behaved operand everywhere (`null` and absent operands flow through
+ * functions as `null`, and a non-`true` condition just drops the row), so a
+ * nullable descriptor is inside every domain. See
+ * docs/plan/pipeline-query-expressions.md.
+ */
+export type BooleanValued = FieldType & { firestoreType: 'boolean' | 'null' };
 
-// A comparison op has three overloads:
-//   1) number-domain pair — Int64 / Double / numeric literals mix freely.
-//   2) string-domain pair — string / string-literal / string-union operands
-//      unify (e.g. a `literal('male','female')` field against `constant('male')`).
-//   3) generic same-`T` — every other group, requiring IDENTICAL descriptor
-//      types (no union-vs-narrow widening — pinned in expression.test.ts);
-//      cross-group pairs match nothing.
+/**
+ * Overlap-based comparison compatibility: a pair is comparable iff the
+ * operands' `firestoreType` tag sets intersect (checked symmetrically —
+ * `Extract` alone is subset-directional for structural container tags).
+ * Evaluates to `unknown` (no-op intersection) on overlap and `never` on
+ * disjoint domains, rejecting the call.
+ *
+ * The backend's comparisons are total (probed: `equal(null, 'x')` is `false`,
+ * never an error), so this rule is a lint against always-false comparisons —
+ * and the correct boundary for that lint is ZERO overlap, mirroring TS's own
+ * `===` rule. A union operand with a shared member overlaps a narrower one
+ * (`equal(field(union(string(), double())), constant('x'))` is legal).
+ */
+type Comparable<L extends FieldType, R extends FieldType> = [
+  Extract<L['firestoreType'], R['firestoreType']> | Extract<R['firestoreType'], L['firestoreType']>,
+] extends [never]
+  ? never
+  : unknown;
 
-export function equal(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function equal(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function equal<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function equal(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('equal', bool(), left, right);
-}
+export const equal = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('equal', bool(), left, right);
 
-export function notEqual(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function notEqual(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function notEqual<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function notEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('notEqual', bool(), left, right);
-}
+export const notEqual = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('notEqual', bool(), left, right);
 
-export function lessThan(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function lessThan(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function lessThan<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function lessThan(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('lessThan', bool(), left, right);
-}
+export const lessThan = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('lessThan', bool(), left, right);
 
-export function lessThanOrEqual(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function lessThanOrEqual(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function lessThanOrEqual<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function lessThanOrEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('lessThanOrEqual', bool(), left, right);
-}
+export const lessThanOrEqual = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('lessThanOrEqual', bool(), left, right);
 
-export function greaterThan(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function greaterThan(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function greaterThan<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function greaterThan(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('greaterThan', bool(), left, right);
-}
+export const greaterThan = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('greaterThan', bool(), left, right);
 
-export function greaterThanOrEqual(
-  left: Expression<NumberValued>,
-  right: Expression<NumberValued>,
-): BinaryFunction<BoolType>;
-export function greaterThanOrEqual(
-  left: Expression<StringValued>,
-  right: Expression<StringValued>,
-): BinaryFunction<BoolType>;
-export function greaterThanOrEqual<T extends FieldType>(
-  left: Expression<T>,
-  right: Expression<T>,
-): BinaryFunction<BoolType>;
-export function greaterThanOrEqual(left: Expression, right: Expression): BinaryFunction<BoolType> {
-  return new BinaryFunction('greaterThanOrEqual', bool(), left, right);
-}
+export const greaterThanOrEqual = <L extends FieldType, R extends FieldType>(
+  left: Expression<L>,
+  right: Expression<R> & Comparable<L, R>,
+): BinaryFunction<BoolType> => new BinaryFunction('greaterThanOrEqual', bool(), left, right);
 
 /** Logical conjunction of two or more boolean expressions. */
 export const and = (
-  first: Expression<BoolType>,
-  second: Expression<BoolType>,
-  ...rest: Expression<BoolType>[]
+  first: Expression<BooleanValued>,
+  second: Expression<BooleanValued>,
+  ...rest: Expression<BooleanValued>[]
 ): VariadicFunction<BoolType> => new VariadicFunction('and', bool(), [first, second, ...rest]);
 
 /** Logical disjunction of two or more boolean expressions. */
 export const or = (
-  first: Expression<BoolType>,
-  second: Expression<BoolType>,
-  ...rest: Expression<BoolType>[]
+  first: Expression<BooleanValued>,
+  second: Expression<BooleanValued>,
+  ...rest: Expression<BooleanValued>[]
 ): VariadicFunction<BoolType> => new VariadicFunction('or', bool(), [first, second, ...rest]);
 
 /** Logical negation of a boolean expression. */
-export const not = (condition: Expression<BoolType>): UnaryFunction<BoolType> =>
+export const not = (condition: Expression<BooleanValued>): UnaryFunction<BoolType> =>
   new UnaryFunction('not', bool(), condition);

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -8,12 +8,15 @@ import {
   double,
   type DoubleType,
   type FieldType,
+  type FirestoreType,
   geoPoint,
   type GeoPointType,
   map,
   type MapType,
+  nullable,
   nullType,
   type NullType,
+  type Optional,
   string,
   type StringType,
   timestamp,
@@ -398,19 +401,22 @@ export class VariadicFunction<T extends FieldType = FieldType> extends Expressio
 export type VariadicFunctionName = 'and' | 'or';
 
 /**
- * The value-domain predicate for boolean contexts (`where` conditions,
- * `and` / `or` / `not` operands): a descriptor whose `firestoreType` tags are
- * a subset of `'boolean' | 'null'` — so `bool()`, boolean literals,
+ * The value-domain predicate: descriptors whose `firestoreType` tags fit the
+ * given tag set — so for `Valued<'boolean'>`, `bool()`, boolean literals,
  * `nullable(bool())`, and `& Optional` variants all qualify structurally.
  *
  * Predicates key on the `firestoreType` axis (not the TS-representation
- * `output`) and are null-TOLERANT: probed backend semantics make `null` a
- * well-behaved operand everywhere (`null` and absent operands flow through
- * functions as `null`, and a non-`true` condition just drops the row), so a
- * nullable descriptor is inside every domain. See
+ * `output`), and `null` is special-cased HERE, once, so individual domains
+ * never mention it: probed backend semantics make `null` a well-behaved
+ * operand everywhere (`null` and absent operands flow through functions as
+ * `null`, and a non-`true` condition just drops the row), so a nullable
+ * descriptor is inside every domain. See
  * docs/plan/pipeline-query-expressions.md.
  */
-export type BooleanValued = FieldType & { firestoreType: 'boolean' | 'null' };
+export type Valued<Tag extends FirestoreType> = FieldType & { firestoreType: Tag | 'null' };
+
+/** A descriptor's `firestoreType` tags with the special-cased `'null'` removed. */
+type NonNullTags<T extends FieldType> = Exclude<T['firestoreType'], 'null'>;
 
 /**
  * Overlap-based comparison compatibility: a pair is comparable iff the
@@ -424,10 +430,27 @@ export type BooleanValued = FieldType & { firestoreType: 'boolean' | 'null' };
  * and the correct boundary for that lint is ZERO overlap, mirroring TS's own
  * `===` rule. A union operand with a shared member overlaps a narrower one
  * (`equal(field(union(string(), double())), constant('x'))` is legal).
+ *
+ * `'null'` is special-cased, consistent with the domain predicates: two
+ * nullable descriptors sharing ONLY `'null'` do not overlap (a
+ * `nullable(string())` vs `nullable(timestamp())` comparison is true only in
+ * the both-null corner — almost surely a bug). The one place null itself
+ * counts is a PURE null operand (`constant(null)` / a `nullType()` field):
+ * that is an is-null check, legal against any nullable operand and rejected
+ * against a never-null one (always false).
  */
 type Comparable<L extends FieldType, R extends FieldType> = [
-  Extract<L['firestoreType'], R['firestoreType']> | Extract<R['firestoreType'], L['firestoreType']>,
+  Extract<NonNullTags<L>, NonNullTags<R>> | Extract<NonNullTags<R>, NonNullTags<L>>,
 ] extends [never]
+  ? [NonNullTags<L>] extends [never]
+    ? IsNullable<R> // pure-null left: an is-null check on the right operand
+    : [NonNullTags<R>] extends [never]
+      ? IsNullable<L> // pure-null right: an is-null check on the left operand
+      : never
+  : unknown;
+
+/** `unknown` (accept) when the descriptor's tags include `'null'`, else `never`. */
+type IsNullable<T extends FieldType> = [Extract<T['firestoreType'], 'null'>] extends [never]
   ? never
   : unknown;
 
@@ -461,20 +484,103 @@ export const greaterThanOrEqual = <L extends FieldType, R extends FieldType>(
   right: Expression<R> & Comparable<L, R>,
 ): BinaryFunction<BoolType> => new BinaryFunction('greaterThanOrEqual', bool(), left, right);
 
-/** Logical conjunction of two or more boolean expressions. */
-export const and = (
-  first: Expression<BooleanValued>,
-  second: Expression<BooleanValued>,
-  ...rest: Expression<BooleanValued>[]
-): VariadicFunction<BoolType> => new VariadicFunction('and', bool(), [first, second, ...rest]);
+/**
+ * Null propagation for a function's RETURN descriptor: `T` when no operand
+ * can be null, `nullable(T)` when one can. An operand "can be null" when its
+ * tags include `'null'` or it is `& Optional` — an absent operand flows
+ * through functions as `null` (probed), so optionality implies a possibly-null
+ * result even though presence stays off the tag axis.
+ *
+ * The logical operators need this (probed — Kleene three-valued logic:
+ * `and(true, null)` is `null` while `and(false, null)` is `false`, `or` and
+ * `not` mirror it), and most value functions in later slices will too. The
+ * comparison operators do NOT: they are total (never null).
+ */
+type PropagateNull<Operands extends FieldType, T extends FieldType> = [
+  Extract<Operands['firestoreType'], 'null'> | Extract<Operands, Optional>,
+] extends [never]
+  ? T
+  : UnionType<[T, NullType]>;
 
-/** Logical disjunction of two or more boolean expressions. */
-export const or = (
-  first: Expression<BooleanValued>,
-  second: Expression<BooleanValued>,
-  ...rest: Expression<BooleanValued>[]
-): VariadicFunction<BoolType> => new VariadicFunction('or', bool(), [first, second, ...rest]);
+/**
+ * Runtime counterpart of {@link PropagateNull} (the overload signature
+ * carries the type-level result; the loose implementation check is the
+ * runtime-to-type bridge, mirrored branch-for-branch by `mayBeNull` /
+ * the type's `Extract` arms).
+ *
+ * Takes the operand EXPRESSIONS and reads their descriptors via the
+ * type-level `Ops['type']`: a value-level `.type` access on a generic operand
+ * resolves eagerly through its constraint (which includes `'null'`), which
+ * would collapse the conditional to the nullable branch for every call.
+ */
+function propagateNull<Ops extends readonly Expression[], T extends FieldType>(
+  operands: Ops,
+  type: T,
+): PropagateNull<Ops[number]['type'], T>;
+function propagateNull(operands: readonly Expression[], type: FieldType): FieldType {
+  return operands.some((operand) => mayBeNull(operand.type)) ? nullable(type) : type;
+}
 
-/** Logical negation of a boolean expression. */
-export const not = (condition: Expression<BooleanValued>): UnaryFunction<BoolType> =>
-  new UnaryFunction('not', bool(), condition);
+/**
+ * Whether a value of the descriptor can be `null` (or absent — which functions
+ * receive as `null`). Mirrors {@link PropagateNull}'s condition: the `'null'`
+ * tag distributes through unions and null literals but deliberately not into
+ * array elements or map fields, and the `Optional` marker counts.
+ */
+const mayBeNull = (t: FieldType & { optional?: boolean }): boolean => {
+  if (t.optional === true) {
+    return true;
+  }
+  switch (t.type) {
+    case 'null':
+      return true;
+    case 'union':
+      return t.elements.some(mayBeNull);
+    case 'const':
+      return t.values.includes(null);
+    case 'bool':
+    case 'string':
+    case 'int64':
+    case 'double':
+    case 'timestamp':
+    case 'docRef':
+    case 'bytes':
+    case 'geoPoint':
+    case 'vector':
+    case 'map':
+    case 'array':
+      return false;
+    default:
+      return assertNever(t);
+  }
+};
+
+/** Logical conjunction of two or more boolean expressions (Kleene: null operands propagate). */
+export const and = <
+  const Ops extends readonly [
+    Expression<Valued<'boolean'>>,
+    Expression<Valued<'boolean'>>,
+    ...Expression<Valued<'boolean'>>[],
+  ],
+>(
+  ...conditions: Ops
+): VariadicFunction<PropagateNull<Ops[number]['type'], BoolType>> =>
+  new VariadicFunction('and', propagateNull(conditions, bool()), conditions);
+
+/** Logical disjunction of two or more boolean expressions (Kleene: null operands propagate). */
+export const or = <
+  const Ops extends readonly [
+    Expression<Valued<'boolean'>>,
+    Expression<Valued<'boolean'>>,
+    ...Expression<Valued<'boolean'>>[],
+  ],
+>(
+  ...conditions: Ops
+): VariadicFunction<PropagateNull<Ops[number]['type'], BoolType>> =>
+  new VariadicFunction('or', propagateNull(conditions, bool()), conditions);
+
+/** Logical negation of a boolean expression (Kleene: a null operand propagates). */
+export const not = <C extends Expression<Valued<'boolean'>>>(
+  condition: C,
+): UnaryFunction<PropagateNull<C['type'], BoolType>> =>
+  new UnaryFunction('not', propagateNull([condition], bool()), condition);

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -415,44 +415,107 @@ export type VariadicFunctionName = 'and' | 'or';
  */
 export type Valued<Tag extends FirestoreType> = FieldType & { firestoreType: Tag | 'null' };
 
-/** A descriptor's `firestoreType` tags with the special-cased `'null'` removed. */
-type NonNullTags<T extends FieldType> = Exclude<T['firestoreType'], 'null'>;
-
 /**
  * Overlap-based comparison compatibility: a pair is comparable iff the
- * operands' `firestoreType` tag sets intersect (checked symmetrically —
- * `Extract` alone is subset-directional for structural container tags).
- * Evaluates to `unknown` (no-op intersection) on overlap and `never` on
- * disjoint domains, rejecting the call.
+ * operands' `firestoreType` tag sets intersect — computed MEMBER-WISE at
+ * every depth ({@link TagSetsComparable}), so a shared element tag is enough
+ * for two heterogeneous arrays to compare. Evaluates to `unknown` (no-op
+ * intersection) on overlap and `never` on disjoint domains, rejecting the
+ * call.
  *
  * The backend's comparisons are total (probed: `equal(null, 'x')` is `false`,
  * never an error), so this rule is a lint against always-false comparisons —
  * and the correct boundary for that lint is ZERO overlap, mirroring TS's own
- * `===` rule. A union operand with a shared member overlaps a narrower one
+ * `===` rule (whose nested-union handling this matches). A union operand with
+ * a shared member overlaps a narrower one
  * (`equal(field(union(string(), double())), constant('x'))` is legal).
- *
- * `'null'` is special-cased, consistent with the domain predicates: two
- * nullable descriptors sharing ONLY `'null'` do not overlap (a
- * `nullable(string())` vs `nullable(timestamp())` comparison is true only in
- * the both-null corner — almost surely a bug). The one place null itself
- * counts is a PURE null operand (`constant(null)` / a `nullType()` field):
- * that is an is-null check, legal against any nullable operand and rejected
- * against a never-null one (always false).
  */
-type Comparable<L extends FieldType, R extends FieldType> = [
-  Extract<NonNullTags<L>, NonNullTags<R>> | Extract<NonNullTags<R>, NonNullTags<L>>,
-] extends [never]
-  ? [NonNullTags<L>] extends [never]
-    ? IsNullable<R> // pure-null left: an is-null check on the right operand
-    : [NonNullTags<R>] extends [never]
-      ? IsNullable<L> // pure-null right: an is-null check on the left operand
-      : never
-  : unknown;
+type Comparable<L extends FieldType, R extends FieldType> =
+  TagSetsComparable<L['firestoreType'], R['firestoreType']> extends true ? unknown : never;
 
-/** `unknown` (accept) when the descriptor's tags include `'null'`, else `never`. */
-type IsNullable<T extends FieldType> = [Extract<T['firestoreType'], 'null'>] extends [never]
-  ? never
-  : unknown;
+/**
+ * Whether two tag SETS (unions of {@link FirestoreType} members) are
+ * comparable. This is the one rule, applied uniformly at every depth (the
+ * top-level operands, array elements, map fields):
+ *
+ * - `'null'` is special-cased, consistent with the domain predicates: it is
+ *   stripped before the overlap test, so sets sharing ONLY `'null'` are not
+ *   comparable (`nullable(string())` vs `nullable(timestamp())` is true only
+ *   in the both-null corner — almost surely a bug) — EXCEPT when one side is
+ *   PURE null (`constant(null)` / a `nullType()` field): that is an is-null
+ *   check, legal against any nullable set and rejected against a never-null
+ *   one (always false).
+ * - A wide input (the unconstrained `FirestoreType`, or the `unknown` the
+ *   `Any*` descriptors carry) accepts leniently — it also breaks the
+ *   otherwise-infinite recursion through the self-referential vocabulary.
+ */
+type TagSetsComparable<A, B> = FirestoreType extends A
+  ? true // wide/unknown input: lenient (and a recursion breaker)
+  : FirestoreType extends B
+    ? true
+    : true extends TagSetsOverlap<Exclude<A, 'null'>, Exclude<B, 'null'>>
+      ? true
+      : [Exclude<A, 'null'>] extends [never]
+        ? 'null' extends B & 'null' // pure-null left: an is-null check on the right
+          ? true
+          : false
+        : [Exclude<B, 'null'>] extends [never]
+          ? 'null' extends A & 'null' // pure-null right: an is-null check on the left
+            ? true
+            : false
+          : false;
+
+/**
+ * Distributes both null-stripped sets into member pairs; the result is the
+ * union of the pairwise verdicts, so `true extends ...` asks "does SOME pair
+ * overlap".
+ */
+type TagSetsOverlap<A, B> = A extends unknown
+  ? B extends unknown
+    ? TagPairOverlaps<A, B>
+    : never
+  : never;
+
+/**
+ * Whether two single tags overlap: scalars by equality, arrays by their
+ * element SETS being comparable (recursion, null rule included), maps by
+ * width-directional key inclusion plus per-shared-key comparability —
+ * matching how TS's own `===` treats nested structures.
+ */
+type TagPairOverlaps<A, B> = A extends readonly FirestoreType[]
+  ? B extends readonly FirestoreType[]
+    ? TagSetsComparable<A[number], B[number]>
+    : false
+  : B extends readonly FirestoreType[]
+    ? false
+    : A extends { readonly [field: string]: FirestoreType }
+      ? B extends { readonly [field: string]: FirestoreType }
+        ? MapTagsOverlap<A, B>
+        : false
+      : B extends { readonly [field: string]: FirestoreType }
+        ? false
+        : A extends B // both scalar tags: literal equality
+          ? true
+          : false;
+
+/**
+ * One key set must include the other (maps of genuinely different shapes
+ * never hold equal values), and every shared key must be comparable.
+ */
+type MapTagsOverlap<
+  A extends { readonly [field: string]: FirestoreType },
+  B extends { readonly [field: string]: FirestoreType },
+> = [keyof B] extends [keyof A]
+  ? SharedKeysComparable<A, B, keyof B>
+  : [keyof A] extends [keyof B]
+    ? SharedKeysComparable<A, B, keyof A>
+    : false;
+
+type SharedKeysComparable<
+  A extends { readonly [field: string]: FirestoreType },
+  B extends { readonly [field: string]: FirestoreType },
+  K extends keyof A & keyof B,
+> = false extends (K extends unknown ? TagSetsComparable<A[K], B[K]> : never) ? false : true;
 
 export const equal = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -13,7 +13,7 @@ import {
   omitPaths,
 } from '../schema.js';
 import { AggregateWithAlias } from './aggregate.js';
-import { type BooleanValued, field, type Expression, type Field } from './expression.js';
+import { field, type Expression, type Field, type Valued } from './expression.js';
 import { Ordering } from './ordering.js';
 import {
   type BuildAddFieldsSchema,
@@ -108,7 +108,7 @@ export class Pipeline<
    * a non-boolean — are silently dropped (Firestore's truthy-only semantics).
    */
   where(
-    condition: (field: FieldProvider<Schema>) => Expression<BooleanValued>,
+    condition: (field: FieldProvider<Schema>) => Expression<Valued<'boolean'>>,
   ): Pipeline<Schema, Id> {
     return new Pipeline<Schema, Id>({
       schema: this.node.schema,

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -1,6 +1,5 @@
 import type { DocRef } from '../repository.js';
 import {
-  type BoolType,
   type Collection,
   type DocFieldPath,
   type DocumentSchema,
@@ -14,7 +13,7 @@ import {
   omitPaths,
 } from '../schema.js';
 import { AggregateWithAlias } from './aggregate.js';
-import { field, type Expression, type Field } from './expression.js';
+import { type BooleanValued, field, type Expression, type Field } from './expression.js';
 import { Ordering } from './ordering.js';
 import {
   type BuildAddFieldsSchema,
@@ -108,7 +107,9 @@ export class Pipeline<
    * condition evaluates to anything else — `false`, `null`, a missing field,
    * a non-boolean — are silently dropped (Firestore's truthy-only semantics).
    */
-  where(condition: (field: FieldProvider<Schema>) => Expression<BoolType>): Pipeline<Schema, Id> {
+  where(
+    condition: (field: FieldProvider<Schema>) => Expression<BooleanValued>,
+  ): Pipeline<Schema, Id> {
     return new Pipeline<Schema, Id>({
       schema: this.node.schema,
       stage: { kind: 'where', condition: condition(fieldProvider(this.node.schema)) },

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,5 +1,5 @@
-import type { BoolType, Collection } from '../schema.js';
-import type { Expression, ExpressionWithAlias } from './expression.js';
+import type { Collection } from '../schema.js';
+import type { BooleanValued, Expression, ExpressionWithAlias } from './expression.js';
 import type { Ordering } from './ordering.js';
 
 /**
@@ -31,7 +31,7 @@ export type InputStage =
 
 /** Transformation stage: reshapes the rows flowing through the pipeline. */
 export type TransformStage =
-  | { kind: 'where'; condition: Expression<BoolType> }
+  | { kind: 'where'; condition: Expression<BooleanValued> }
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,5 +1,5 @@
 import type { Collection } from '../schema.js';
-import type { BooleanValued, Expression, ExpressionWithAlias } from './expression.js';
+import type { Expression, ExpressionWithAlias, Valued } from './expression.js';
 import type { Ordering } from './ordering.js';
 
 /**
@@ -31,7 +31,7 @@ export type InputStage =
 
 /** Transformation stage: reshapes the rows flowing through the pipeline. */
 export type TransformStage =
-  | { kind: 'where'; condition: Expression<BooleanValued> }
+  | { kind: 'where'; condition: Expression<Valued<'boolean'>> }
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.select`), so an executor can translate it 1:1.
   | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -20,6 +20,7 @@ import {
   type FieldValueOfPath,
   GeoPoint,
   geoPoint,
+  type GeoPointType,
   Increment,
   int64,
   isMapType,
@@ -191,6 +192,68 @@ describe('schema', () => {
         expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<'a' | 1 | true>();
         expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<'a' | 1 | true>();
       });
+    });
+  });
+
+  describe('firestoreType (phantom axis)', () => {
+    it('scalar tags', () => {
+      const bytesType = bytes();
+      const nullT = nullType();
+      const vectorT = vector();
+      expectTypeOf<StringType['firestoreType']>().toEqualTypeOf<'string'>();
+      expectTypeOf<BoolType['firestoreType']>().toEqualTypeOf<'boolean'>();
+      expectTypeOf<TimestampType['firestoreType']>().toEqualTypeOf<'timestamp'>();
+      expectTypeOf<(typeof bytesType)['firestoreType']>().toEqualTypeOf<'bytes'>();
+      expectTypeOf<(typeof nullT)['firestoreType']>().toEqualTypeOf<'null'>();
+      expectTypeOf<(typeof vectorT)['firestoreType']>().toEqualTypeOf<'vector'>();
+    });
+
+    it('int64/double carry the honest integer|double union', () => {
+      expectTypeOf<Int64Type['firestoreType']>().toEqualTypeOf<'integer' | 'double'>();
+      expectTypeOf<DoubleType['firestoreType']>().toEqualTypeOf<'integer' | 'double'>();
+    });
+
+    it('reference / geopoint tags are flat — the axis exists to distinguish them from their TS representations', () => {
+      const authors = rootCollection({ name: 'authors', schema: { name: string() } });
+      const ref = docRef(authors);
+      expectTypeOf<(typeof ref)['firestoreType']>().toEqualTypeOf<'reference'>();
+      expectTypeOf<GeoPointType['firestoreType']>().toEqualTypeOf<'geopoint'>();
+    });
+
+    it('literals map to their base tags', () => {
+      expectTypeOf<LiteralType<['a', 'b']>['firestoreType']>().toEqualTypeOf<'string'>();
+      expectTypeOf<LiteralType<[1, 2]>['firestoreType']>().toEqualTypeOf<'integer' | 'double'>();
+      expectTypeOf<LiteralType<[true]>['firestoreType']>().toEqualTypeOf<'boolean'>();
+      expectTypeOf<LiteralType<['a', 1, null]>['firestoreType']>().toEqualTypeOf<
+        'string' | 'integer' | 'double' | 'null'
+      >();
+    });
+
+    it('union distributes over member tags', () => {
+      const t = nullable(string());
+      expectTypeOf<(typeof t)['firestoreType']>().toEqualTypeOf<'string' | 'null'>();
+    });
+
+    it('array is the element tags', () => {
+      const t = array(string());
+      expectTypeOf<(typeof t)['firestoreType']>().toEqualTypeOf<readonly 'string'[]>();
+      const u = array(union(string(), double()));
+      expectTypeOf<(typeof u)['firestoreType']>().toEqualTypeOf<
+        readonly ('string' | 'integer' | 'double')[]
+      >();
+    });
+
+    it('map is a per-field tag record, all required (presence is the optional axis)', () => {
+      const t = map({ age: double(), gender: optional(literal('male', 'female')) });
+      expectTypeOf<(typeof t)['firestoreType']>().toEqualTypeOf<{
+        age: 'integer' | 'double';
+        gender: 'string';
+      }>();
+    });
+
+    it('the optional marker does not change the tag', () => {
+      const t = optional(string());
+      expectTypeOf<(typeof t)['firestoreType']>().toEqualTypeOf<'string'>();
     });
   });
 

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -45,6 +45,60 @@ export const subCollection = <
 export type DocumentSchema = MapType['fields'];
 
 /**
+ * The vocabulary of the `firestoreType` phantom axis: the type of a field's
+ * values **as Firestore itself classifies them**, structurally recursive for
+ * containers (an array is the tags of its elements, a map is a per-field tag
+ * record).
+ *
+ * This is a separate axis from the phantom `output`, which is the
+ * **TypeScript representation** of the value and therefore conflates types
+ * Firestore keeps distinct: a document reference decodes to `string[]` but is
+ * not an array of strings, a vector decodes to `number[]` but is not an
+ * array of numbers, a geopoint decodes to a `{ latitude, longitude }` object
+ * but is not a map. Operand-domain predicates and comparison compatibility
+ * (`pipelines/expression.ts`) key on THIS axis so those pairs no longer
+ * unify.
+ *
+ * Deliberate choices (agreed in the pipeline-expressions plan):
+ *
+ * - No `'absent'` tag: field presence is the orthogonal `optional` marker's
+ *   axis, so map tag records are all-required.
+ * - `'integer'` and `'double'` are separate tags, but a `number`-valued
+ *   descriptor carries the honest union of both (see `Int64Type`).
+ * - Literal descriptors map to their base tags — the tag classifies the
+ *   Firestore value, not its narrowed TS domain.
+ */
+export type FirestoreType =
+  | 'string'
+  | 'integer'
+  | 'double'
+  | 'boolean'
+  | 'null'
+  | 'timestamp'
+  | 'bytes'
+  | 'reference'
+  | 'geopoint'
+  | 'vector'
+  | readonly FirestoreType[]
+  | { readonly [field: string]: FirestoreType };
+
+/**
+ * The `firestoreType` of a literal value: literals classify as their base
+ * Firestore type. A `number` literal is honestly `'integer' | 'double'` —
+ * the SDKs choose the wire encoding per value (whole numbers become
+ * integers), so neither tag alone would be true.
+ */
+type LiteralFirestoreType<V extends string | number | boolean | null> = V extends string
+  ? 'string'
+  : V extends number
+    ? 'integer' | 'double'
+    : V extends boolean
+      ? 'boolean'
+      : V extends null
+        ? 'null'
+        : never;
+
+/**
  * The closed discriminated union of every field descriptor, discriminated by
  * `type`. Being closed (rather than an open `{ type: string }` base) lets
  * `switch (fieldType.type)` narrow each arm to its concrete descriptor and
@@ -71,21 +125,57 @@ export type FieldType =
   | AnyUnionType
   | LiteralType<(string | number | boolean | null)[]>;
 
-export type BoolType = { type: 'bool'; input: boolean; output: boolean };
-export type StringType = { type: 'string'; input: string; output: string };
-export type Int64Type = { type: 'int64'; input: number | Increment; output: number }; // TODO bigint?
-export type DoubleType = { type: 'double'; input: number | Increment; output: number };
-export type TimestampType = { type: 'timestamp'; input: Date | ServerTimestamp; output: Date };
+export type BoolType = { type: 'bool'; firestoreType: 'boolean'; input: boolean; output: boolean };
+export type StringType = { type: 'string'; firestoreType: 'string'; input: string; output: string };
+// int64/double both carry the honest `'integer' | 'double'` tag: their value
+// type is the JS `number`, and the SDKs pick the wire encoding per value
+// (whole numbers become integers), so a `double()` field can hold wire
+// integers and neither tag alone would be true. This also keeps the two
+// numeric descriptors mutually comparable under overlap-based compatibility.
+export type Int64Type = {
+  type: 'int64';
+  firestoreType: 'integer' | 'double';
+  input: number | Increment;
+  output: number;
+}; // TODO bigint?
+export type DoubleType = {
+  type: 'double';
+  firestoreType: 'integer' | 'double';
+  input: number | Increment;
+  output: number;
+};
+export type TimestampType = {
+  type: 'timestamp';
+  firestoreType: 'timestamp';
+  input: Date | ServerTimestamp;
+  output: Date;
+};
 export type DocRefType<T extends Collection> = {
   type: 'docRef';
+  firestoreType: 'reference';
   collection: T;
   input: DocRef<T>;
   output: DocRef<T>;
 };
-export type BytesType = { type: 'bytes'; input: Uint8Array; output: Uint8Array };
-export type GeoPointType = { type: 'geoPoint'; input: GeoPoint; output: GeoPoint };
-export type VectorType = { type: 'vector'; input: number[]; output: number[] };
-export type NullType = { type: 'null'; input: null; output: null };
+export type BytesType = {
+  type: 'bytes';
+  firestoreType: 'bytes';
+  input: Uint8Array;
+  output: Uint8Array;
+};
+export type GeoPointType = {
+  type: 'geoPoint';
+  firestoreType: 'geopoint';
+  input: GeoPoint;
+  output: GeoPoint;
+};
+export type VectorType = {
+  type: 'vector';
+  firestoreType: 'vector';
+  input: number[];
+  output: number[];
+};
+export type NullType = { type: 'null'; firestoreType: 'null'; input: null; output: null };
 /**
  * The widest map/array/union descriptors — the recursive members of the
  * closed {@link FieldType} union. Each concrete `MapType<T>` /
@@ -102,25 +192,34 @@ export type NullType = { type: 'null'; input: null; output: null };
  *   by measured variance, the computed `input`/`output` members measure as
  *   invariant, and e.g. `UnionType<[StringType, NullType]>` would no longer
  *   be accepted where the widest union descriptor is expected.
- * - `input`/`output` are `unknown` at this widest level (exactly the width
- *   the old open `{ type: string; input: unknown; output: unknown }` base
- *   had), which also terminates the type recursion when resolving the wide
- *   union's value types.
+ * - `input`/`output`/`firestoreType` are `unknown` at this widest level
+ *   (for input/output, exactly the width the old open
+ *   `{ type: string; input: unknown; output: unknown }` base had). This
+ *   terminates the type recursion when resolving the wide union's value
+ *   types, and for `firestoreType` it also spares the checker from proving
+ *   a generic container's tag against the recursive `FirestoreType` bound —
+ *   both the proof failure (TS cannot bound a two-hop generic indexed
+ *   access like `T[K]['firestoreType']`) and the conditional-type
+ *   workaround for it (which sends constraint computation into unbounded
+ *   recursion, crashing tsc) are avoided outright.
  */
 export interface AnyMapType {
   type: 'map';
+  firestoreType: unknown;
   fields: MapFields;
   input: unknown;
   output: unknown;
 }
 export interface AnyArrayType {
   type: 'array';
+  firestoreType: unknown;
   dynamicPart: FieldType;
   input: unknown;
   output: unknown;
 }
 export interface AnyUnionType {
   type: 'union';
+  firestoreType: unknown;
   elements: FieldType[];
   input: unknown;
   output: unknown;
@@ -135,6 +234,8 @@ export interface MapFields {
 
 export type MapType<T extends MapFields = MapFields> = {
   type: 'map';
+  // All-required: presence lives on the orthogonal `optional` marker axis.
+  firestoreType: { [K in keyof T & string]: T[K]['firestoreType'] };
   fields: T;
   input: ResolveMapValue<T, 'write'>;
   output: ResolveMapValue<T, 'read'>;
@@ -150,18 +251,22 @@ export type MapType<T extends MapFields = MapFields> = {
 export type Optional = { optional: true };
 export type ArrayType<DynamicPart extends FieldType = FieldType> = {
   type: 'array';
+  firestoreType: readonly DynamicPart['firestoreType'][];
   dynamicPart: DynamicPart;
   input: ResolveArrayValue<DynamicPart, 'write'>;
   output: ResolveArrayValue<DynamicPart, 'read'>;
 };
 export type UnionType<T extends FieldType[] = FieldType[]> = {
   type: 'union';
+  // Distributes: the tags of a union are the union of its members' tags.
+  firestoreType: T[number]['firestoreType'];
   elements: T;
   input: ResolveUnionValue<T, 'write'>;
   output: ResolveUnionValue<T, 'read'>;
 };
 export type LiteralType<T extends (string | number | boolean | null)[]> = {
   type: 'const';
+  firestoreType: LiteralFirestoreType<T[number]>;
   values: T;
   input: T[number];
   output: T[number];
@@ -224,13 +329,15 @@ const assertNoDottedFieldNames = (fields: DocumentSchema): void => {
 };
 
 /**
- * Constructs a schema type value without specifying the phantom `input`/`output` fields.
+ * Constructs a schema type value without specifying the phantom
+ * `input`/`output`/`firestoreType` fields.
  * Those fields exist only at the type level to carry value type information (valibot-style),
  * so they must not appear in runtime objects. The `as T` cast attaches the phantom types
  * without requiring them in the object literal.
  */
-// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- phantom type cast: input/output fields exist only at type level
-const buildType = <T extends FieldType>(v: Omit<T, 'input' | 'output'>): T => v as T;
+const buildType = <T extends FieldType>(v: Omit<T, 'input' | 'output' | 'firestoreType'>): T =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- phantom type cast: input/output/firestoreType fields exist only at type level
+  v as T;
 
 export const bool = (): BoolType => buildType({ type: 'bool' });
 export const string = (): StringType => buildType({ type: 'string' });


### PR DESCRIPTION
## Summary

Implements soundness item S2-PR2: every descriptor gains a third phantom, **`firestoreType`** — the type of a field's values as Firestore itself classifies them — and operand-domain predicates plus comparison compatibility move onto it.

The existing phantom `output` is the **TS-representation** axis, which conflates pairs Firestore keeps distinct: a reference decodes to `string[]`, a vector to `number[]`, a geopoint to a `{latitude, longitude}` object. Keying operator compatibility on the new axis stops those pairs from unifying (new rejection type tests cover all three).

## Tag semantics

- Structurally recursive: an array is its element tags (`readonly 'string'[]`), a map is a per-field tag record — **all-required**, since presence lives on the orthogonal `optional` marker (no `'absent'` tag). Unions distribute; literals map to their base tags.
- `int64()`/`double()` both carry the honest `'integer' | 'double'` union: their value type is the JS `number` and the SDKs pick the wire encoding per value (whole numbers become integers), so neither tag alone would be true — and the numeric domain stays mutually comparable.
- The `Any*` widest interfaces keep `firestoreType: unknown`, like `input`/`output`. Besides consistency, this dodges a real checker limitation: TS can neither bound a two-hop generic indexed access (`T[K]['firestoreType']`) against the recursive `FirestoreType` vocabulary, nor survive the conditional-wrapper workaround — the latter sends constraint computation into unbounded recursion and **crashes tsc** (found the hard way during this PR).

## Operator migration

- **Comparisons are overlap-based**: the six operators collapse from per-domain overload triples to one signature each; a pair is comparable iff the tag sets intersect (symmetric `Extract` — `Comparable`). Probed grounds: backend comparisons are total (`equal(null,'x')` is `false`, never an error), so cross-domain rejection is a lint against always-false comparisons, and its correct boundary is zero overlap — TS's own `===` rule. `equal(field(union(string(), double())), constant('x'))` is now legal.
- **Domains are null-tolerant** (probed: null/absent operands flow through functions as `null`; a non-`true` condition just drops the row): `nullable(string())` compares on its non-null overlap, and `equal(ns, constant(null))` is a legal is-null check — while `equal(field(string()), constant(null))` stays rejected (always false).
- **`where` / `and` / `or` / `not` take `Valued<'boolean'>`**: the per-domain alias zoo is replaced by one generic predicate `Valued<Tag> = FieldType & { firestoreType: Tag | 'null' }` — null tolerance is written once, inside the machinery, and individual domains never mention it. Boolean-literal fields and `nullable(bool())` are valid conditions now.
- **`Comparable` also special-cases `'null'`**: sharing only `'null'` is not overlap (`nullable(string())` vs `nullable(timestamp())` is rejected — true only in the both-null corner), except for a pure null operand, which is an is-null check (legal against nullable operands, rejected against never-null ones).
- **Logical operators propagate Kleene nullability** (probed: `and(true, null)` is `null`, `and(false, null)` is `false`; absent operands behave identically): `PropagateNull`/`propagateNull` make `and`/`or`/`not` return `nullable(bool())` when any operand can be null (tags include `'null'`) or absent (`& Optional`). Comparisons stay plain `BoolType` — they are total. Findings recorded in `docs/pipeline-query-null-semantics-research.md`.

## Tests

- The three transitional pin tests this deliberately fires (nullable contract, no-union-widening, exact-BoolType conditions) are rewritten to pin the new contracts.
- New `firestoreType` tag pins in `schema.test.ts` (8 cases: scalars, honest numeric union, flat reference/geopoint, literal base-mapping, union distribution, array/map recursion, optional-marker invariance).
- 214 unit tests, tsc/lint/fmt clean across packages, and the **live spec suite passes against the Enterprise database** (45 cases).

The plan doc's predicate section is updated to reflect what is implemented (including superseding the earlier "reject nullable, coalesce first" stance with the probe-backed null-tolerant one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
