### PR TITLE
Add arithmetic and basic string expression functions (slice 2)

### DIFF
--- a/docs/pipeline-query-null-semantics-research.md
+++ b/docs/pipeline-query-null-semantics-research.md
@@ -44,6 +44,23 @@ indistinguishable there. The distinction matters as soon as the expression's
 VALUE is observed — projected via `select` / `addFields`, or used as an
 operand of another function.
 
+## Value functions propagate `null` — including boolean-returning ones
+
+Every probed slice-2 function returns `null` when any operand is `null` or
+absent (`probe-slice2-null.mjs`): arithmetic (`add(7, null)`), string
+transforms (`toUpper(null)`), lengths, `stringConcat` — and notably the
+boolean-returning string predicates (`startsWith(null, 'x')` is `null`,
+absent operands identical). Their results are therefore possibly-null
+descriptors under `PropagateNull`, in contrast to the comparisons below.
+
+## Errors are a separate channel from `null`
+
+Arithmetic domain violations (`divide(x, 0)`, `ln(0)`, `sqrt(-1)`) do NOT
+yield `null`: they produce backend ERROR values. An unhandled error value
+fails the whole query (`INVALID_ARGUMENT`), while `isError(...)` observes it
+(`true`) and `ifError(..., fallback)` replaces it — the error-handling
+functions arrive in slice 5.
+
 ## Comparisons are total — never `null`
 
 `equal` / `notEqual` / `lessThan` / ... always return `true` or `false`, even

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -178,6 +178,11 @@ return-type refinement for arithmetic; vector dimension typing (if ever).
 
 ## Rollout slices (one PR each, TDD with live spec per slice)
 
+Every slice MUST add its functions to the live spec's **function catalog**
+(`pipeline-spec.ts`, "function catalog" describe): one straightforward
+constant-operand evaluation per function, pinning the wire translation of
+both executors and the basic backend semantics in one round trip per family.
+
 - [x] **0. Shapes + comparison + logical core** (#213).
 - [x] **1. `constant` type inference.** `ConstantTypeOf<V>` (type) mirrored by
       `constantTypeOf` (runtime). Classification: everything with an

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -206,8 +206,19 @@ return-type refinement for arithmetic; vector dimension typing (if ever).
       null propagation into logical return descriptors (`PropagateNull`).
       See
       "Operand constraints are value-domain predicates" above.
-- [ ] **2. Arithmetic + string basics** (T1 bulk: binary/unary flows already
-      paved; introduces `NullaryFunction` for `rand`).
+- [x] **2. Arithmetic + string basics** (T1 bulk; introduces
+      `NullaryFunction` for `rand` and the dual-arity pattern early —
+      `round` / `trunc` take optional decimal places, the `trim` family an
+      optional character set, each overloading to unary + binary shapes).
+      Notes: the SDK has no standalone `log` (only `ln` / `log10`);
+      `stringConcat` is the string-typed concat (bare `concat` is the
+      generic form). All slice-2 functions PROPAGATE null — including the
+      boolean-returning string predicates (`startsWith(null, 'x')` is
+      `null`), unlike the total comparisons. Arithmetic error edges
+      (divide by zero, `ln(0)`, `sqrt(-1)`) produce backend ERROR values
+      for the slice-5 `isError` / `ifError` channel. Probed: integer /
+      integer division TRUNCATES (a whole JS number wire-encodes as an
+      integer) — pinned in the live spec.
 - [ ] **3. String rest + regex + reference + type + vector** (T1 bulk #2;
       introduces `TernaryFunction` and the dual-shape optional-arg pattern via
       `substring` / `stringReplace*`).

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -1,19 +1,47 @@
 import { Bytes, type Firestore, GeoPoint, vector } from '@firebase/firestore';
 import {
+  abs as sdkAbs,
+  add as sdkAdd,
   and as sdkAnd,
   array as sdkArray,
+  byteLength as sdkByteLength,
+  ceil as sdkCeil,
+  charLength as sdkCharLength,
   constant as sdkConstant,
+  divide as sdkDivide,
+  endsWith as sdkEndsWith,
   equal as sdkEqual,
   execute as executePipeline,
+  exp as sdkExp,
   field,
+  floor as sdkFloor,
   greaterThan as sdkGreaterThan,
   greaterThanOrEqual as sdkGreaterThanOrEqual,
   lessThan as sdkLessThan,
   lessThanOrEqual as sdkLessThanOrEqual,
+  ln as sdkLn,
+  log10 as sdkLog10,
+  ltrim as sdkLtrim,
   map as sdkMap,
+  mod as sdkMod,
+  multiply as sdkMultiply,
   not as sdkNot,
   notEqual as sdkNotEqual,
   or as sdkOr,
+  pow as sdkPow,
+  rand as sdkRand,
+  round as sdkRound,
+  rtrim as sdkRtrim,
+  sqrt as sdkSqrt,
+  startsWith as sdkStartsWith,
+  stringConcat as sdkStringConcat,
+  stringContains as sdkStringContains,
+  stringReverse as sdkStringReverse,
+  subtract as sdkSubtract,
+  toLower as sdkToLower,
+  toUpper as sdkToUpper,
+  trim as sdkTrim,
+  trunc as sdkTrunc,
   type Expression as SdkExpression,
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
@@ -27,6 +55,7 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type NullaryFunctionName,
   UnaryFunctionName,
   VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
@@ -167,6 +196,8 @@ const toSdkExpression = (expression: Expression): SdkExpression => {
       // Value nodes also appear as constant-composite leaves; toSdkConstant
       // is the single home for their translation.
       return toSdkConstant(expression);
+    case 'nullaryFunction':
+      return nullaryFns[expression.name]();
     case 'unaryFunction':
       return unaryFns[expression.name](toSdkExpression(expression.operand));
     case 'binaryFunction':
@@ -245,8 +276,27 @@ const isConstantArrayValue = (value: Constant['value']): value is ConstantArray 
 // (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
 // type-tag only, no wire change.)
 
+const nullaryFns: Record<NullaryFunctionName, () => SdkExpression> = { rand: sdkRand };
+
 const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> = {
   not: (o) => sdkNot(o.asBoolean()),
+  abs: sdkAbs,
+  ceil: sdkCeil,
+  floor: sdkFloor,
+  round: sdkRound,
+  trunc: sdkTrunc,
+  sqrt: sdkSqrt,
+  exp: sdkExp,
+  ln: sdkLn,
+  log10: sdkLog10,
+  charLength: sdkCharLength,
+  byteLength: sdkByteLength,
+  toLower: sdkToLower,
+  toUpper: sdkToUpper,
+  stringReverse: sdkStringReverse,
+  trim: sdkTrim,
+  ltrim: sdkLtrim,
+  rtrim: sdkRtrim,
 };
 
 const binaryFns: Record<BinaryFunctionName, (l: SdkExpression, r: SdkExpression) => SdkExpression> =
@@ -257,6 +307,20 @@ const binaryFns: Record<BinaryFunctionName, (l: SdkExpression, r: SdkExpression)
     lessThanOrEqual: sdkLessThanOrEqual,
     greaterThan: sdkGreaterThan,
     greaterThanOrEqual: sdkGreaterThanOrEqual,
+    add: sdkAdd,
+    subtract: sdkSubtract,
+    multiply: sdkMultiply,
+    divide: sdkDivide,
+    mod: sdkMod,
+    pow: sdkPow,
+    round: sdkRound,
+    trunc: sdkTrunc,
+    trim: sdkTrim,
+    ltrim: sdkLtrim,
+    rtrim: sdkRtrim,
+    startsWith: sdkStartsWith,
+    endsWith: sdkEndsWith,
+    stringContains: sdkStringContains,
   };
 
 const variadicFns: Record<
@@ -265,6 +329,7 @@ const variadicFns: Record<
 > = {
   and: (f, s, ...r) => sdkAnd(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
   or: (f, s, ...r) => sdkOr(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
+  stringConcat: sdkStringConcat,
 };
 
 const toSdkOrdering = (ordering: Ordering) => {
@@ -275,6 +340,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
     case 'variadicFunction':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,16 +1,26 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  add,
   and,
+  charLength,
   constant,
+  divide,
   equal,
   geoPointValue,
   vectorValue,
   greaterThanOrEqual,
   lessThan,
+  multiply,
   not,
   notEqual,
   or,
+  rand,
+  round,
+  startsWith,
+  stringConcat,
+  toUpper,
+  trim,
 } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
@@ -277,6 +287,111 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             },
           ],
         );
+      });
+    });
+
+    describe('arithmetic and string functions', () => {
+      const { source, expectPipeline } = setup();
+
+      it('computes nested arithmetic over fields and constants', async () => {
+        await expectPipeline(
+          source().select((field) => [
+            'name',
+            add(multiply(field('rank'), constant(10)), constant(1)).as('score'),
+          ]),
+          [
+            { data: { name: 'alice', score: 11 } },
+            { data: { name: 'bob', score: 21 } },
+            { data: { name: 'carol', score: 31 } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('integer division truncates; a double operand makes it a double division', async () => {
+        // A whole JS number is wire-encoded as an INTEGER, and
+        // integer / integer is a truncating division — the honest
+        // 'integer' | 'double' tag on number-valued descriptors at work.
+        await expectPipeline(
+          source().select((field) => ['name', divide(field('rank'), constant(2)).as('half')]),
+          [
+            { data: { name: 'alice', half: 0 } },
+            { data: { name: 'bob', half: 1 } },
+            { data: { name: 'carol', half: 1 } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('round takes an optional decimal-places operand', async () => {
+        await expectPipeline(
+          source().select((field) => [
+            'name',
+            round(divide(field('rank'), constant(2.5)), constant(2)).as('scaled'),
+          ]),
+          [
+            { data: { name: 'alice', scaled: 0.4 } },
+            { data: { name: 'bob', scaled: 0.8 } },
+            { data: { name: 'carol', scaled: 1.2 } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('string transforms, lengths, concatenation, and character-set trim', async () => {
+        await expectPipeline(
+          source().select((field) => [
+            stringConcat(toUpper(field('name')), constant('!')).as('shout'),
+            charLength(field('name')).as('len'),
+            trim(field('name'), constant('al')).as('trimmed'),
+          ]),
+          [
+            { data: { shout: 'ALICE!', len: 5, trimmed: 'ice' } },
+            { data: { shout: 'BOB!', len: 3, trimmed: 'bob' } },
+            { data: { shout: 'CAROL!', len: 5, trimmed: 'caro' } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('a string predicate is a valid where condition', async () => {
+        const [a1] = items;
+        await expectPipeline(
+          source().where((field) => startsWith(field('name'), constant('a'))),
+          [a1],
+        );
+      });
+
+      it('null propagation end-to-end: an optional operand yields nullable output', async () => {
+        // profile.gender is optional: bob's is absent, and absence flows
+        // through functions as null (probed) — the projected schema is
+        // nullable(string()) and the row decodes a null VALUE.
+        await expectPipeline(
+          source().select((field) => ['name', toUpper(field('profile.gender')).as('g')]),
+          [
+            { data: { name: 'alice', g: 'FEMALE' } },
+            { data: { name: 'bob', g: null } },
+            { data: { name: 'carol', g: 'MALE' } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('a null condition drops the row (string predicate over an optional field)', async () => {
+        const [, , a3] = items;
+        await expectPipeline(
+          source().where((field) => startsWith(field('profile.gender'), constant('m'))),
+          [a3],
+        );
+      });
+
+      it('rand produces a double in [0, 1) per row', async () => {
+        const results = await executor.execute(source().select(() => [rand().as('r')]));
+        expect(results).toHaveLength(3);
+        for (const row of results) {
+          expect(row.data.r).toBeGreaterThanOrEqual(0);
+          expect(row.data.r).toBeLessThan(1);
+        }
       });
     });
 

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,26 +1,46 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  abs,
   add,
   and,
+  byteLength,
+  ceil,
   charLength,
   constant,
   divide,
+  endsWith,
   equal,
+  exp,
+  floor,
   geoPointValue,
   vectorValue,
+  greaterThan,
   greaterThanOrEqual,
   lessThan,
+  lessThanOrEqual,
+  ln,
+  log10,
+  ltrim,
+  mod,
   multiply,
   not,
   notEqual,
   or,
+  pow,
   rand,
   round,
+  rtrim,
+  sqrt,
   startsWith,
   stringConcat,
+  stringContains,
+  stringReverse,
+  subtract,
+  toLower,
   toUpper,
   trim,
+  trunc,
 } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
@@ -288,6 +308,140 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
           ],
         );
       });
+    });
+
+    // Every expression function gets at least one straightforward live
+    // evaluation here — the catalog pins each function's wire translation and
+    // its basic backend semantics in one round trip per family. Every future
+    // slice MUST add its functions to this catalog.
+    describe('function catalog (one straightforward evaluation per function)', () => {
+      const { source, expectPipeline } = setup();
+      /** A single-row source: the catalog evaluates constant expressions only. */
+      const one = () => source().limit(1);
+
+      it('arithmetic', async () => {
+        await expectPipeline(
+          one().select(() => [
+            add(constant(1), constant(2)).as('add'),
+            subtract(constant(5), constant(3)).as('subtract'),
+            multiply(constant(2), constant(3)).as('multiply'),
+            divide(constant(7), constant(2.5)).as('divide'),
+            mod(constant(7), constant(3)).as('mod'),
+            pow(constant(2), constant(3)).as('pow'),
+            abs(constant(-5)).as('abs'),
+            ceil(constant(1.2)).as('ceil'),
+            floor(constant(1.8)).as('floor'),
+            round(constant(2.4)).as('round'),
+            round(constant(2.44), constant(1)).as('roundTo'),
+            trunc(constant(2.9)).as('trunc'),
+            trunc(constant(2.99), constant(1)).as('truncTo'),
+            sqrt(constant(9)).as('sqrt'),
+            exp(constant(0)).as('exp'),
+            ln(constant(1)).as('ln'),
+            log10(constant(100)).as('log10'),
+          ]),
+          [
+            {
+              data: {
+                add: 3,
+                subtract: 2,
+                multiply: 6,
+                divide: 2.8,
+                mod: 1,
+                pow: 8,
+                abs: 5,
+                ceil: 2,
+                floor: 1,
+                round: 2,
+                roundTo: 2.4,
+                trunc: 2,
+                truncTo: 2.9,
+                sqrt: 3,
+                exp: 1,
+                ln: 0,
+                log10: 2,
+              },
+            },
+          ],
+        );
+      });
+
+      it('string', async () => {
+        await expectPipeline(
+          one().select(() => [
+            charLength(constant('aあ')).as('charLength'),
+            byteLength(constant('aあ')).as('byteLength'),
+            toLower(constant('AbC')).as('toLower'),
+            toUpper(constant('AbC')).as('toUpper'),
+            stringReverse(constant('abc')).as('stringReverse'),
+            trim(constant('  pad  ')).as('trim'),
+            ltrim(constant('  pad  ')).as('ltrim'),
+            rtrim(constant('  pad  ')).as('rtrim'),
+            trim(constant('xpadx'), constant('x')).as('trimChars'),
+            ltrim(constant('xpadx'), constant('x')).as('ltrimChars'),
+            rtrim(constant('xpadx'), constant('x')).as('rtrimChars'),
+            startsWith(constant('abc'), constant('a')).as('startsWith'),
+            endsWith(constant('abc'), constant('z')).as('endsWith'),
+            stringContains(constant('abc'), constant('b')).as('stringContains'),
+            stringConcat(constant('a'), constant('b'), constant('c')).as('stringConcat'),
+          ]),
+          [
+            {
+              data: {
+                charLength: 2,
+                byteLength: 4,
+                toLower: 'abc',
+                toUpper: 'ABC',
+                stringReverse: 'cba',
+                trim: 'pad',
+                ltrim: 'pad  ',
+                rtrim: '  pad',
+                trimChars: 'pad',
+                ltrimChars: 'padx',
+                rtrimChars: 'xpad',
+                startsWith: true,
+                endsWith: false,
+                stringContains: true,
+                stringConcat: 'abc',
+              },
+            },
+          ],
+        );
+      });
+
+      it('comparison and logical', async () => {
+        await expectPipeline(
+          one().select(() => [
+            equal(constant(1), constant(1)).as('equal'),
+            notEqual(constant(1), constant(1)).as('notEqual'),
+            lessThan(constant(1), constant(2)).as('lessThan'),
+            lessThanOrEqual(constant(2), constant(2)).as('lessThanOrEqual'),
+            greaterThan(constant(1), constant(2)).as('greaterThan'),
+            greaterThanOrEqual(constant(2), constant(2)).as('greaterThanOrEqual'),
+            and(equal(constant(1), constant(1)), equal(constant(2), constant(2))).as('and'),
+            or(equal(constant(1), constant(2)), equal(constant(2), constant(2))).as('or'),
+            not(equal(constant(1), constant(2))).as('not'),
+          ]),
+          [
+            {
+              data: {
+                equal: true,
+                notEqual: false,
+                lessThan: true,
+                lessThanOrEqual: true,
+                greaterThan: false,
+                greaterThanOrEqual: true,
+                and: true,
+                or: true,
+                not: true,
+              },
+            },
+          ],
+        );
+      });
+
+      // rand (the remaining nullary) is covered by its own range test below —
+      // its value is not deterministic.
     });
 
     describe('arithmetic and string functions', () => {

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -22,22 +22,51 @@ import {
   vector,
 } from '../schema.js';
 import {
+  abs,
+  add,
   and,
   BinaryFunction,
+  byteLength,
+  ceil,
+  charLength,
   Constant,
   constant,
+  divide,
+  endsWith,
   equal,
+  exp,
   type ExpressionWithAlias,
   Field,
   field,
+  floor,
   geoPointValue,
   greaterThan,
   greaterThanOrEqual,
   lessThan,
   lessThanOrEqual,
+  ln,
+  log10,
+  ltrim,
+  mod,
+  multiply,
   not,
   notEqual,
+  NullaryFunction,
   or,
+  pow,
+  rand,
+  round,
+  rtrim,
+  sqrt,
+  startsWith,
+  stringConcat,
+  stringContains,
+  stringReverse,
+  subtract,
+  toLower,
+  toUpper,
+  trim,
+  trunc,
   UnaryFunction,
   VariadicFunction,
   vectorValue,
@@ -439,5 +468,164 @@ describe('logical operator edges', () => {
     const cmp = equal(field(nullable(string()), 'ns'), constant(null));
     expect(cmp.type).toStrictEqual(bool());
     expectTypeOf(cmp.type).toEqualTypeOf(bool());
+  });
+});
+
+describe('arithmetic operators', () => {
+  const rank = field(double(), 'rank');
+  const count = field(int64(), 'count');
+
+  it('builds shape-grouped nodes across all three arities', () => {
+    expect(rand()).toStrictEqual(new NullaryFunction('rand', double()));
+    expect(abs(rank)).toStrictEqual(new UnaryFunction('abs', double(), rank));
+    expect(add(rank, count)).toStrictEqual(new BinaryFunction('add', double(), rank, count));
+  });
+
+  it('every unary function shares the numeric domain and DoubleType result', () => {
+    const table = [
+      ['abs', abs],
+      ['ceil', ceil],
+      ['floor', floor],
+      ['sqrt', sqrt],
+      ['exp', exp],
+      ['ln', ln],
+      ['log10', log10],
+    ] as const;
+    for (const [fnName, fn] of table) {
+      expect(fn(count)).toStrictEqual(new UnaryFunction(fnName, double(), count));
+      expect(fn(field(literal(1, 2), 'lv')).name).toBe(fnName);
+    }
+    // round/trunc are overloaded (dual-arity), so a union-typed table entry
+    // is not callable — exercised individually.
+    expect(round(count)).toStrictEqual(new UnaryFunction('round', double(), count));
+    expect(trunc(count)).toStrictEqual(new UnaryFunction('trunc', double(), count));
+    // @ts-expect-error -- a string operand is not numeric
+    abs(field(string(), 'name'));
+  });
+
+  it('every binary function shares the numeric domain and DoubleType result', () => {
+    const table = [
+      ['add', add],
+      ['subtract', subtract],
+      ['multiply', multiply],
+      ['divide', divide],
+      ['mod', mod],
+      ['pow', pow],
+    ] as const;
+    for (const [fnName, fn] of table) {
+      expect(fn(rank, constant(2))).toStrictEqual(
+        new BinaryFunction(fnName, double(), rank, constant(2)),
+      );
+    }
+    // @ts-expect-error -- a string operand is not numeric
+    add(field(string(), 'name'), constant(1));
+    // @ts-expect-error -- a boolean operand is not numeric
+    multiply(rank, field(bool(), 'flag'));
+  });
+
+  it('round/trunc are dual-arity: an optional decimal-places operand', () => {
+    expect(round(rank, constant(2))).toStrictEqual(
+      new BinaryFunction('round', double(), rank, constant(2)),
+    );
+    expect(trunc(rank, count)).toStrictEqual(new BinaryFunction('trunc', double(), rank, count));
+    // @ts-expect-error -- decimal places must be numeric
+    round(rank, constant('2'));
+  });
+
+  it('propagates operand nullability, and rand (no operands) never does', () => {
+    const nullableDouble = nullable(double());
+    const viaNullable = add(rank, field(nullable(int64()), 'nc'));
+    expect(viaNullable.type).toStrictEqual(nullableDouble);
+    expectTypeOf(viaNullable.type).toEqualTypeOf(nullableDouble);
+    const viaOptional = sqrt(field(optional(double()), 'od'));
+    expect(viaOptional.type).toStrictEqual(nullableDouble);
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullableDouble);
+    const viaDecimals = round(rank, field(nullable(int64()), 'nd'));
+    expect(viaDecimals.type).toStrictEqual(nullableDouble);
+    expectTypeOf(viaDecimals.type).toEqualTypeOf(nullableDouble);
+    expectTypeOf(rand().type).toEqualTypeOf(double());
+  });
+});
+
+describe('string operators', () => {
+  const name = field(string(), 'name');
+  const gender = field(literal('male', 'female'), 'gender');
+
+  it('transforms return StringType, lengths return Int64Type', () => {
+    const table = [
+      ['toLower', toLower, string()],
+      ['toUpper', toUpper, string()],
+      ['stringReverse', stringReverse, string()],
+      ['charLength', charLength, int64()],
+      ['byteLength', byteLength, int64()],
+    ] as const;
+    for (const [fnName, fn, resultType] of table) {
+      expect(fn(name)).toStrictEqual(new UnaryFunction(fnName, resultType, name));
+      // Literal-typed string fields are inside the domain.
+      expect(fn(gender).name).toBe(fnName);
+    }
+    // The trim family is overloaded (dual-arity), so a union-typed table
+    // entry is not callable — exercised individually.
+    expect(trim(name)).toStrictEqual(new UnaryFunction('trim', string(), name));
+    expect(ltrim(name)).toStrictEqual(new UnaryFunction('ltrim', string(), name));
+    expect(rtrim(name)).toStrictEqual(new UnaryFunction('rtrim', string(), name));
+    expect(trim(gender).name).toBe('trim');
+    // @ts-expect-error -- a numeric operand is not a string
+    toUpper(field(double(), 'rank'));
+  });
+
+  it('trim family is dual-arity: an optional character-set operand', () => {
+    expect(trim(name, constant('"'))).toStrictEqual(
+      new BinaryFunction('trim', string(), name, constant('"')),
+    );
+    expect(ltrim(name, constant('x')).name).toBe('ltrim');
+    expect(rtrim(name, constant('x')).name).toBe('rtrim');
+    // @ts-expect-error -- the character set must be a string
+    trim(name, constant(1));
+  });
+
+  it('predicates return BoolType but PROPAGATE null (unlike comparisons)', () => {
+    const table = [
+      ['startsWith', startsWith],
+      ['endsWith', endsWith],
+      ['stringContains', stringContains],
+    ] as const;
+    for (const [fnName, fn] of table) {
+      expect(fn(name, constant('a'))).toStrictEqual(
+        new BinaryFunction(fnName, bool(), name, constant('a')),
+      );
+      const viaNullable = fn(field(nullable(string()), 'ns'), constant('a'));
+      expect(viaNullable.type).toStrictEqual(nullable(bool()));
+      expectTypeOf(viaNullable.type).toEqualTypeOf(nullable(bool()));
+    }
+    // A propagated predicate is still a valid condition (BooleanValued domain).
+    and(field(bool(), 'flag'), startsWith(field(nullable(string()), 'ns'), constant('a')));
+    // @ts-expect-error -- a numeric operand is not a string
+    startsWith(field(double(), 'rank'), constant('a'));
+  });
+
+  it('stringConcat takes two or more strings and propagates nullability', () => {
+    const c = stringConcat(name, constant('-'), gender);
+    expect(c).toStrictEqual(
+      new VariadicFunction('stringConcat', string(), [name, constant('-'), gender]),
+    );
+    expectTypeOf(c.type).toEqualTypeOf(string());
+    const viaNullable = stringConcat(name, field(nullable(string()), 'ns'));
+    expect(viaNullable.type).toStrictEqual(nullable(string()));
+    expectTypeOf(viaNullable.type).toEqualTypeOf(nullable(string()));
+    // @ts-expect-error -- stringConcat requires at least two operands
+    stringConcat(name);
+    // @ts-expect-error -- a numeric operand is not a string
+    stringConcat(name, field(double(), 'rank'));
+  });
+
+  it('composes: function results feed other functions within their domains', () => {
+    // toUpper(name)'s StringType result is a string operand...
+    charLength(toUpper(name));
+    // ...and charLength's Int64Type result is a numeric operand.
+    add(charLength(name), constant(1));
+    lessThan(charLength(name), constant(10));
+    // @ts-expect-error -- a numeric result is not a string operand
+    toUpper(charLength(name));
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -11,6 +11,8 @@ import {
   type FirestoreType,
   geoPoint,
   type GeoPointType,
+  int64,
+  type Int64Type,
   map,
   type MapType,
   nullable,
@@ -44,6 +46,7 @@ export type Expression<T extends FieldType = FieldType> =
   | Constant<T>
   | GeoPointValue
   | VectorValue
+  | NullaryFunction<T>
   | UnaryFunction<T>
   | BinaryFunction<T>
   | VariadicFunction<T>;
@@ -354,6 +357,18 @@ export const vectorValue = (values: readonly number[]): VectorValue => new Vecto
 // compatibility, return types) lives in the factory signatures. See
 // "Restructure FunctionCall" in docs/plan/pipeline-query.md.
 
+/** A function call with no operands. */
+export class NullaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'nullaryFunction';
+  constructor(
+    readonly name: NullaryFunctionName,
+    readonly type: T,
+  ) {
+    super();
+  }
+}
+export type NullaryFunctionName = 'rand';
+
 /** A function call with a single operand. */
 export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
   readonly kind = 'unaryFunction';
@@ -365,7 +380,28 @@ export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBa
     super();
   }
 }
-export type UnaryFunctionName = 'not';
+// A name appearing in two shape unions (round/trunc/trim/ltrim/rtrim) is the
+// dual-arity pattern: the factory overloads to a unary and a binary form and
+// each executor table translates its own arity.
+export type UnaryFunctionName =
+  | 'not'
+  | 'abs'
+  | 'ceil'
+  | 'floor'
+  | 'round'
+  | 'trunc'
+  | 'sqrt'
+  | 'exp'
+  | 'ln'
+  | 'log10'
+  | 'charLength'
+  | 'byteLength'
+  | 'toLower'
+  | 'toUpper'
+  | 'stringReverse'
+  | 'trim'
+  | 'ltrim'
+  | 'rtrim';
 
 /** A function call with exactly two operands. */
 export class BinaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -385,7 +421,21 @@ export type BinaryFunctionName =
   | 'lessThan'
   | 'lessThanOrEqual'
   | 'greaterThan'
-  | 'greaterThanOrEqual';
+  | 'greaterThanOrEqual'
+  | 'add'
+  | 'subtract'
+  | 'multiply'
+  | 'divide'
+  | 'mod'
+  | 'pow'
+  | 'round'
+  | 'trunc'
+  | 'trim'
+  | 'ltrim'
+  | 'rtrim'
+  | 'startsWith'
+  | 'endsWith'
+  | 'stringContains';
 
 /** A function call with two or more uniform operands. */
 export class VariadicFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -398,7 +448,7 @@ export class VariadicFunction<T extends FieldType = FieldType> extends Expressio
     super();
   }
 }
-export type VariadicFunctionName = 'and' | 'or';
+export type VariadicFunctionName = 'and' | 'or' | 'stringConcat';
 
 /**
  * The value-domain predicate: descriptors whose `firestoreType` tags fit the
@@ -647,3 +697,277 @@ export const not = <C extends Expression<Valued<'boolean'>>>(
   condition: C,
 ): UnaryFunction<PropagateNull<C['type'], BoolType>> =>
   new UnaryFunction('not', propagateNull([condition], bool()), condition);
+
+// Operand shorthands for the factories below. These name EXPRESSION domains
+// (the null special-casing itself lives once, in `Valued`).
+type NumericOperand = Expression<Valued<'integer' | 'double'>>;
+type StringOperand = Expression<Valued<'string'>>;
+
+// ---- arithmetic ----
+// All arithmetic returns a plain DoubleType (its 'integer' | 'double' tag is
+// the honest numeric domain; per-operator integer/double refinement is a
+// deferred cross-cutting item — see the expressions plan). Error edges
+// (divide by zero, ln(0), sqrt of a negative) produce backend ERROR values,
+// not null — the error channel is handled by isError/ifError (slice 5).
+
+/** A uniformly distributed random double in [0, 1), regenerated per row. */
+export const rand = (): NullaryFunction<DoubleType> => new NullaryFunction('rand', double());
+
+/** Numeric addition. */
+export const add = <L extends NumericOperand, R extends NumericOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('add', propagateNull([left, right], double()), left, right);
+
+/** Numeric subtraction (`left - right`). */
+export const subtract = <L extends NumericOperand, R extends NumericOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('subtract', propagateNull([left, right], double()), left, right);
+
+/** Numeric multiplication. */
+export const multiply = <L extends NumericOperand, R extends NumericOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('multiply', propagateNull([left, right], double()), left, right);
+
+/** Numeric division (`left / right`); a zero divisor is a backend ERROR value. */
+export const divide = <L extends NumericOperand, R extends NumericOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('divide', propagateNull([left, right], double()), left, right);
+
+/** Modulo (`left % right`). */
+export const mod = <L extends NumericOperand, R extends NumericOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('mod', propagateNull([left, right], double()), left, right);
+
+/** Exponentiation (`base ** exponent`). */
+export const pow = <L extends NumericOperand, R extends NumericOperand>(
+  base: L,
+  exponent: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('pow', propagateNull([base, exponent], double()), base, exponent);
+
+/** Absolute value. */
+export const abs = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('abs', propagateNull([expression], double()), expression);
+
+/** Rounds up to the nearest whole number. */
+export const ceil = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('ceil', propagateNull([expression], double()), expression);
+
+/** Rounds down to the nearest whole number. */
+export const floor = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('floor', propagateNull([expression], double()), expression);
+
+/** Square root; a negative operand is a backend ERROR value. */
+export const sqrt = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('sqrt', propagateNull([expression], double()), expression);
+
+/** The exponential function (e ** operand). */
+export const exp = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('exp', propagateNull([expression], double()), expression);
+
+/** Natural logarithm; a non-positive operand is a backend ERROR value. */
+export const ln = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('ln', propagateNull([expression], double()), expression);
+
+/** Base-10 logarithm; a non-positive operand is a backend ERROR value. */
+export const log10 = <Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
+  new UnaryFunction('log10', propagateNull([expression], double()), expression);
+
+/** Rounds to the nearest whole number, or to `decimalPlaces` decimal places. */
+export function round<Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>>;
+export function round<Op extends NumericOperand, P extends NumericOperand>(
+  expression: Op,
+  decimalPlaces: P,
+): BinaryFunction<PropagateNull<Op['type'] | P['type'], DoubleType>>;
+export function round(
+  expression: Expression,
+  decimalPlaces?: Expression,
+): UnaryFunction | BinaryFunction {
+  return decimalPlaces === undefined
+    ? new UnaryFunction('round', propagateNull([expression], double()), expression)
+    : new BinaryFunction(
+        'round',
+        propagateNull([expression, decimalPlaces], double()),
+        expression,
+        decimalPlaces,
+      );
+}
+
+/** Truncates toward zero, to a whole number or to `decimalPlaces` decimal places. */
+export function trunc<Op extends NumericOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], DoubleType>>;
+export function trunc<Op extends NumericOperand, P extends NumericOperand>(
+  expression: Op,
+  decimalPlaces: P,
+): BinaryFunction<PropagateNull<Op['type'] | P['type'], DoubleType>>;
+export function trunc(
+  expression: Expression,
+  decimalPlaces?: Expression,
+): UnaryFunction | BinaryFunction {
+  return decimalPlaces === undefined
+    ? new UnaryFunction('trunc', propagateNull([expression], double()), expression)
+    : new BinaryFunction(
+        'trunc',
+        propagateNull([expression, decimalPlaces], double()),
+        expression,
+        decimalPlaces,
+      );
+}
+
+// ---- string ----
+
+/** The number of characters (Unicode code points) in a string. */
+export const charLength = <Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('charLength', propagateNull([expression], int64()), expression);
+
+/** The number of bytes in a string's UTF-8 encoding. */
+export const byteLength = <Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('byteLength', propagateNull([expression], int64()), expression);
+
+/** Lowercases a string. */
+export const toLower = <Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
+  new UnaryFunction('toLower', propagateNull([expression], string()), expression);
+
+/** Uppercases a string. */
+export const toUpper = <Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
+  new UnaryFunction('toUpper', propagateNull([expression], string()), expression);
+
+/** Reverses a string. */
+export const stringReverse = <Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
+  new UnaryFunction('stringReverse', propagateNull([expression], string()), expression);
+
+/** Trims whitespace from both ends, or every character of `charactersToTrim`. */
+export function trim<Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>>;
+export function trim<Op extends StringOperand, C extends StringOperand>(
+  expression: Op,
+  charactersToTrim: C,
+): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function trim(
+  expression: Expression,
+  charactersToTrim?: Expression,
+): UnaryFunction | BinaryFunction {
+  return charactersToTrim === undefined
+    ? new UnaryFunction('trim', propagateNull([expression], string()), expression)
+    : new BinaryFunction(
+        'trim',
+        propagateNull([expression, charactersToTrim], string()),
+        expression,
+        charactersToTrim,
+      );
+}
+
+/** Trims the leading end — see {@link trim}. */
+export function ltrim<Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>>;
+export function ltrim<Op extends StringOperand, C extends StringOperand>(
+  expression: Op,
+  charactersToTrim: C,
+): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function ltrim(
+  expression: Expression,
+  charactersToTrim?: Expression,
+): UnaryFunction | BinaryFunction {
+  return charactersToTrim === undefined
+    ? new UnaryFunction('ltrim', propagateNull([expression], string()), expression)
+    : new BinaryFunction(
+        'ltrim',
+        propagateNull([expression, charactersToTrim], string()),
+        expression,
+        charactersToTrim,
+      );
+}
+
+/** Trims the trailing end — see {@link trim}. */
+export function rtrim<Op extends StringOperand>(
+  expression: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>>;
+export function rtrim<Op extends StringOperand, C extends StringOperand>(
+  expression: Op,
+  charactersToTrim: C,
+): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function rtrim(
+  expression: Expression,
+  charactersToTrim?: Expression,
+): UnaryFunction | BinaryFunction {
+  return charactersToTrim === undefined
+    ? new UnaryFunction('rtrim', propagateNull([expression], string()), expression)
+    : new BinaryFunction(
+        'rtrim',
+        propagateNull([expression, charactersToTrim], string()),
+        expression,
+        charactersToTrim,
+      );
+}
+
+// The string predicates PROPAGATE null (probed: startsWith(null, 'x') is
+// null), unlike the comparison operators, which are total — hence the
+// PropagateNull in their return types.
+
+/** Whether `value` starts with `prefix`. */
+export const startsWith = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  prefix: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('startsWith', propagateNull([value, prefix], bool()), value, prefix);
+
+/** Whether `value` ends with `suffix`. */
+export const endsWith = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  suffix: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('endsWith', propagateNull([value, suffix], bool()), value, suffix);
+
+/** Whether `value` contains `substring`. */
+export const stringContains = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  substring: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('stringContains', propagateNull([value, substring], bool()), value, substring);
+
+/** Concatenates two or more strings. */
+export const stringConcat = <
+  const Ops extends readonly [StringOperand, StringOperand, ...StringOperand[]],
+>(
+  ...strings: Ops
+): VariadicFunction<PropagateNull<Ops[number]['type'], StringType>> =>
+  new VariadicFunction('stringConcat', propagateNull(strings, string()), strings);

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -288,6 +288,7 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
     case 'variadicFunction':

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -8,6 +8,7 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type NullaryFunctionName,
   UnaryFunctionName,
   VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
@@ -148,6 +149,8 @@ const toSdkExpression = (expression: Expression): Pipelines.Expression => {
       // Value nodes also appear as constant-composite leaves; toSdkConstant
       // is the single home for their translation.
       return toSdkConstant(expression);
+    case 'nullaryFunction':
+      return nullaryFns[expression.name]();
     case 'unaryFunction':
       return unaryFns[expression.name](toSdkExpression(expression.operand));
     case 'binaryFunction':
@@ -221,8 +224,31 @@ const toSdkConstant = (value: Constant['value']): Pipelines.Expression => {
 // (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
 // type-tag only, no wire change.)
 
+const nullaryFns: Record<NullaryFunctionName, () => Pipelines.Expression> = {
+  rand: Pipelines.rand,
+};
+
 const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines.Expression> = {
   not: (o) => Pipelines.not(o.asBoolean()),
+  abs: Pipelines.abs,
+  ceil: Pipelines.ceil,
+  // floor/ltrim/rtrim exist at runtime but the SDK's namespace typings only
+  // declare their fluent forms — translate through those.
+  floor: (o) => o.floor(),
+  round: Pipelines.round,
+  trunc: Pipelines.trunc,
+  sqrt: Pipelines.sqrt,
+  exp: Pipelines.exp,
+  ln: Pipelines.ln,
+  log10: Pipelines.log10,
+  charLength: Pipelines.charLength,
+  byteLength: Pipelines.byteLength,
+  toLower: Pipelines.toLower,
+  toUpper: Pipelines.toUpper,
+  stringReverse: Pipelines.stringReverse,
+  trim: Pipelines.trim,
+  ltrim: (o) => o.ltrim(),
+  rtrim: (o) => o.rtrim(),
 };
 
 const binaryFns: Record<
@@ -235,6 +261,20 @@ const binaryFns: Record<
   lessThanOrEqual: Pipelines.lessThanOrEqual,
   greaterThan: Pipelines.greaterThan,
   greaterThanOrEqual: Pipelines.greaterThanOrEqual,
+  add: Pipelines.add,
+  subtract: Pipelines.subtract,
+  multiply: Pipelines.multiply,
+  divide: Pipelines.divide,
+  mod: Pipelines.mod,
+  pow: Pipelines.pow,
+  round: Pipelines.round,
+  trunc: Pipelines.trunc,
+  trim: Pipelines.trim,
+  ltrim: (l, r) => l.ltrim(r),
+  rtrim: (l, r) => l.rtrim(r),
+  startsWith: Pipelines.startsWith,
+  endsWith: Pipelines.endsWith,
+  stringContains: Pipelines.stringContains,
 };
 
 const variadicFns: Record<
@@ -247,6 +287,7 @@ const variadicFns: Record<
 > = {
   and: (f, s, ...r) => Pipelines.and(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
   or: (f, s, ...r) => Pipelines.or(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
+  stringConcat: Pipelines.stringConcat,
 };
 
 /** `Array.isArray` narrows poorly over readonly-array unions — a dedicated guard does. */
@@ -261,6 +302,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
     case 'variadicFunction':


### PR DESCRIPTION
## Summary

Expressions rollout slice 2: the arithmetic family and basic string functions, introducing **`NullaryFunction`** (for `rand`) and the **dual-arity pattern** ahead of schedule (`round`/`trunc` with optional decimal places, the `trim` family with an optional character set — each overloads to unary + binary shapes, appearing in both name unions).

- **Arithmetic**: `add` `subtract` `multiply` `divide` `mod` `pow` / `abs` `ceil` `floor` `sqrt` `exp` `ln` `log10` / `round` `trunc` (dual-arity) / `rand`. All return `DoubleType` — the honest `'integer' | 'double'` tag is the numeric domain; per-operator integer/double refinement stays the deferred T4 item. (The SDK has no standalone `log`, only `ln`/`log10`.)
- **String**: `charLength` `byteLength` (→ `Int64Type`), `toLower` `toUpper` `stringReverse`, `trim` `ltrim` `rtrim` (dual-arity), `startsWith` `endsWith` `stringContains`, `stringConcat` (variadic, ≥2).

## Probed findings (recorded in `docs/pipeline-query-null-semantics-research.md`)

- **Every slice-2 function propagates null/absent — including the boolean-returning string predicates** (`startsWith(null, 'x')` is `null`), unlike the total comparisons. All factories thread `PropagateNull`, so e.g. `toUpper` of an optional field types as `nullable(string())`.
- **Arithmetic domain violations are ERROR values, not null** (`divide(x,0)`, `ln(0)`, `sqrt(-1)`): unhandled they fail the query; `isError`/`ifError` (slice 5) observe/replace them.
- **integer/integer division truncates** (whole JS numbers wire-encode as integers) — pinned in the live spec.

## Mechanics

- The closed name unions forced both executors' `Record` tables shut until every new function was translated — the intended workflow.
- gcloud's namespace typings lack standalone `floor`/`ltrim`/`rtrim` (runtime exports exist); those translate through their fluent forms.
- `selection.ts` and both ordering switches gained the `'nullaryFunction'` arm via exhaustiveness errors.

## Tests

- 10 new unit tests (226 total): per-shape whole-instance oracles, domain rejections, PropagateNull per operand kind, dual-arity forms, cross-function composition (`add(charLength(name), constant(1))`).
- 8 new live spec cases (53 total, all passing against the Enterprise DB): nested arithmetic, integer division, round decimals, string ops incl. character-set trim, string predicates as `where` conditions, **end-to-end null propagation** (optional operand → `null` output value decoding through the nullable projected schema), and `rand`'s per-row `[0,1)` range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)