### PR TITLE
Add string-rest, regex, reference, type and vector functions (slice 3)

### DIFF
--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -4,6 +4,16 @@
 
 - All functions and type definitions MUST include JSDoc comments describing their purpose, role, and any notable details
 - Add explanatory comments to object and class field definitions when necessary
+- **Record non-obvious design decisions (the WHY) — and route them by
+  audience.** A rationale that affects how the API is USED (why a value is
+  represented this way, why an input is rejected, why two similar-looking
+  types are distinct — e.g. why the context-free `DocRefType` reads/writes a
+  path string rather than a `string[]`) belongs in the **JSDoc**, where a
+  consumer hovering the symbol sees it. A rationale that only matters to
+  maintainers (compiler workarounds, why an implementation shape was chosen
+  over an alternative, probe references) stays a **plain comment** inside the
+  implementation. The test: "would a user of this API make a wrong decision
+  without knowing this?" — yes → JSDoc, no → plain comment.
 
 ## Code Style
 

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -9,6 +9,25 @@
 
 Follow the project's linting and formatting rules enforced by `pnpm check`.
 
+## Design principles
+
+- **Systemic consistency is the top priority — no ad-hoc special cases.** A
+  new capability must be an instance of an existing rule of the system (or a
+  deliberate, documented extension of one), not a one-off carve-out.
+  Precedent: values without an unambiguous plain-JS representation get
+  dedicated expression nodes — `geoPointValue`, `vectorValue`, and later
+  `docRefValue` all follow the ONE classification rule rather than each
+  getting bespoke treatment. When a proposal only works for the case at hand,
+  find the rule it should be an instance of first.
+- **Deferring parts is fine; deviating structures is not.** Implementation
+  cost may postpone a piece of the system (an unimplemented function family,
+  a not-yet-supported descriptor), but what IS built must always have the
+  same fundamental structure as the intended end state. Building something
+  "for now" on a structure that the final design will have to replace is not
+  acceptable — a missing limb is recoverable, a wrong skeleton is not.
+  Likewise, do not dismiss a consistent-but-rare case as "low practical
+  utility"; uniformity of the system is itself the utility.
+
 ## Type assertions
 
 - **Do not use type assertions (`as`, `as unknown as`, non-null `!`).** They are

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -75,6 +75,24 @@ records the observed behavior so we can encode it in the
   elements — useful for "explode" patterns where you want to know which
   source document each emitted row came from.
 
+## `__name__` is a REFERENCE value, not a string
+
+Probed (2026-07, `probe-slice3.mjs`): `type(field("__name__"))` is
+`"reference"`, and the reference-domain functions accept it while rejecting
+strings (`documentId(constant("authors/a1"))` →
+`INVALID_ARGUMENT: requires \`Reference\` but got \`STRING\``). Comparisons
+are total, so an `equal(field("**name**"), <string>)` would silently be
+always-false — a trap, not an error.
+
+Library consequence: `FieldTypeOfPath` resolves `'__name__'` to the
+`ReferenceType` pseudo-descriptor (`schema.ts`) with the `'reference'`
+firestoreType tag, so string comparisons and string functions over the raw
+key are rejected at the type level; `documentId(field('__name__'))` /
+`collectionId(...)` bridge it into the string domain. Its `output` stays
+`string` — the core query API's id-filter contract
+(`where(eq('__name__', id))`) — and it is neither writable nor decodable as
+document data (the codecs reject it).
+
 ## Read-identity (row key) vs. `__name__` field / DML-capability
 
 Two distinct notions are easy to conflate:

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -84,14 +84,30 @@ strings (`documentId(constant("authors/a1"))` →
 are total, so an `equal(field("**name**"), <string>)` would silently be
 always-false — a trap, not an error.
 
+Comparison semantics (probed 2026-07): the pipeline backend never converts —
+`equal(__name__, <string>)` is `false` for EVERY string form (the bare id,
+the relative path, the full resource path), and only a reference constant
+matches (`constant(db.doc(...))` in the SDK / `docRefValue(collection, id)`
+in this library). The core query API's `where(eq('__name__', '1'))` accepting
+a string is an SDK convenience: the core query has a collection context to
+convert the string into a reference before it hits the wire; a pipeline has
+none, so the raw type shows through.
+
+A projected raw key (`field("__name__").as("k")`) materializes in the SDK as
+a `DocumentReference` instance (NOT a path string — an earlier note here was
+imprecise).
+
 Library consequence: `FieldTypeOfPath` resolves `'__name__'` to the
 `ReferenceType` pseudo-descriptor (`schema.ts`) with the `'reference'`
 firestoreType tag, so string comparisons and string functions over the raw
 key are rejected at the type level; `documentId(field('__name__'))` /
-`collectionId(...)` bridge it into the string domain. Its `output` stays
-`string` — the core query API's id-filter contract
-(`where(eq('__name__', id))`) — and it is neither writable nor decodable as
-document data (the codecs reject it).
+`collectionId(...)` bridge it into the string domain, and
+`docRefValue(collection, id)` is the matching comparand. Its `output` is
+`string`: the core query API's id-filter contract, and the decode of a
+projected raw key (the codecs decode the `DocumentReference` to its relative
+path string — the context-free representation; a schema-known `docRef`
+field decodes to a `DocRef` id tuple as usual). It is never writable
+(`input: never`).
 
 ## Read-identity (row key) vs. `__name__` field / DML-capability
 
@@ -126,16 +142,16 @@ read-identity (`Id`) parameter.
 rule is symmetric across all three and depends on whether the field keeps its
 reserved name:
 
-| projection (inside `select`)                | `id`+`ref` | `createTime` | `updateTime` | lands in `data` as |
-| ------------------------------------------- | ---------- | ------------ | ------------ | ------------------ |
-| `field("__name__")` (un-aliased)            | ✓          | —            | —            | — (consumed)       |
-| `field("__create_time__")` (un-al.)         | —          | ✓            | —            | — (consumed)       |
-| `field("__update_time__")` (un-al.)         | —          | —            | ✓            | — (consumed)       |
-| all three un-aliased                        | ✓          | ✓            | ✓            | — (consumed)       |
-| `field("__name__").as("__name__")`          | ✓          | —            | —            | — (consumed)       |
-| `field("__name__").as("docId")`             | ✗          | —            | —            | `docId` (path str) |
-| `field("__create_time__").as("ct")`         | —          | ✗            | —            | `ct` (Timestamp)   |
-| `documentId(field("__name__")).as("docId")` | ✗          | —            | —            | `docId`            |
+| projection (inside `select`)                | `id`+`ref` | `createTime` | `updateTime` | lands in `data` as  |
+| ------------------------------------------- | ---------- | ------------ | ------------ | ------------------- |
+| `field("__name__")` (un-aliased)            | ✓          | —            | —            | — (consumed)        |
+| `field("__create_time__")` (un-al.)         | —          | ✓            | —            | — (consumed)        |
+| `field("__update_time__")` (un-al.)         | —          | —            | ✓            | — (consumed)        |
+| all three un-aliased                        | ✓          | ✓            | ✓            | — (consumed)        |
+| `field("__name__").as("__name__")`          | ✓          | —            | —            | — (consumed)        |
+| `field("__name__").as("docId")`             | ✗          | —            | —            | `docId` (reference) |
+| `field("__create_time__").as("ct")`         | —          | ✗            | —            | `ct` (Timestamp)    |
+| `documentId(field("__name__")).as("docId")` | ✗          | —            | —            | `docId`             |
 
 Key points (probed on `enterprise-native-playground`, `@google-cloud/firestore@8.6.0`):
 

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -98,16 +98,18 @@ a `DocumentReference` instance (NOT a path string — an earlier note here was
 imprecise).
 
 Library consequence: `FieldTypeOfPath` resolves `'__name__'` to the
-`ReferenceType` pseudo-descriptor (`schema.ts`) with the `'reference'`
-firestoreType tag, so string comparisons and string functions over the raw
-key are rejected at the type level; `documentId(field('__name__'))` /
+context-free reference descriptor `DocRefType<'unknown'>` (`schema.ts` —
+ONE unified descriptor; the type parameter is the referenced collection when
+the schema knows it, or the `'unknown'` sentinel when it does not) with the
+`'reference'` firestoreType tag, so string comparisons and string functions
+over the raw key are rejected at the type level; `documentId(field('__name__'))` /
 `collectionId(...)` bridge it into the string domain, and
-`docRefValue(collection, id)` is the matching comparand. Its `output` is
-`string`: the core query API's id-filter contract, and the decode of a
-projected raw key (the codecs decode the `DocumentReference` to its relative
-path string — the context-free representation; a schema-known `docRef`
-field decodes to a `DocRef` id tuple as usual). It is never writable
-(`input: never`).
+`docRefValue(collection, id)` is the matching comparand. The context-free
+flavor's `output` is `string`: the core query API's id-filter contract, and
+the decode of a projected raw key (the codecs decode the
+`DocumentReference` to its relative path string; a schema-known
+`docRef(collection)` field decodes to a `DocRef` id tuple as usual). It is
+never writable (`input: never`).
 
 ## Read-identity (row key) vs. `__name__` field / DML-capability
 

--- a/docs/pipeline-query-null-semantics-research.md
+++ b/docs/pipeline-query-null-semantics-research.md
@@ -53,9 +53,26 @@ boolean-returning string predicates (`startsWith(null, 'x')` is `null`,
 absent operands identical). Their results are therefore possibly-null
 descriptors under `PropagateNull`, in contrast to the comparisons below.
 
+## Type-observing functions propagate only ABSENCE
+
+`type()` / `isType()` observe `null` as a first-class type — `type(null)` is
+the string `"null"`, `isType(null, 'null')` is `true` — so a `null` operand
+does NOT null their result; an ABSENT operand still does (`type(absent)` is
+`null`). Their return descriptors use the absence-only `PropagateAbsence`
+variant. Relatedly, `type()` distinguishes `int64` from `float64` PER VALUE
+(`type(7)` is `"int64"`, `type(7.5)` is `"float64"`) — the wire encoding the
+honest `'integer' | 'double'` tag models.
+
+## `regexFind` is null on no match
+
+`regexFind` returns `null` when the pattern has no match — so its return
+descriptor is ALWAYS nullable, independent of operand nullability.
+`regexFindAll` returns `[]` instead and stays non-null.
+
 ## Errors are a separate channel from `null`
 
-Arithmetic domain violations (`divide(x, 0)`, `ln(0)`, `sqrt(-1)`) do NOT
+Arithmetic domain violations (`divide(x, 0)`, `ln(0)`, `sqrt(-1)`), invalid
+regex patterns, and vector dimension mismatches do NOT
 yield `null`: they produce backend ERROR values. An unhandled error value
 fails the whole query (`INVALID_ARGUMENT`), while `isError(...)` observes it
 (`true`) and `ifError(..., fallback)` replaces it — the error-handling

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -240,9 +240,15 @@ both executors and the basic backend semantics in one round trip per family.
       wire-literal (factory takes a literal union, lifted via `constant`;
       executors recover the raw string for the SDK helpers). The reserved
       `__name__` is a REFERENCE (probed via `type(__name__)`), so
-      `FieldTypeOfPath` now resolves it to the new `ReferenceType`
-      pseudo-descriptor (tag `'reference'`, `output: string` for the core
-      query API's id filters) — `documentId(field('__name__'))` bridges it
+      `FieldTypeOfPath` now resolves it to the context-free
+      `DocRefType<'unknown'>` (ONE unified reference descriptor — the type
+      parameter is the known collection or the `'unknown'` sentinel; the
+      context-free flavor has `output: string` for the core query API's id
+      filters and `input: never`). Future refinement, same skeleton: while a
+      pipeline's read-identity is alive (`Id = DocRef<T>`), the source
+      collection IS statically known — `fieldProvider` could resolve
+      `'__name__'` to `DocRefType<T>` and fall back to `'unknown'` once the
+      identity ratchet drops (deferred; `documentId` covers today's uses) — `documentId(field('__name__'))` bridges it
       into the string domain, and comparing `__name__` against strings is
       now correctly rejected (probed: the backend matches NO string form —
       only a reference value). `docRefValue(collection, id)` joins

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -224,9 +224,27 @@ both executors and the basic backend semantics in one round trip per family.
       for the slice-5 `isError` / `ifError` channel. Probed: integer /
       integer division TRUNCATES (a whole JS number wire-encodes as an
       integer) — pinned in the live spec.
-- [ ] **3. String rest + regex + reference + type + vector** (T1 bulk #2;
-      introduces `TernaryFunction` and the dual-shape optional-arg pattern via
-      `substring` / `stringReplace*`).
+- [x] **3. String rest + regex + reference + type + vector** (T1 bulk #2;
+      introduces `TernaryFunction`; `substring` reuses the dual-arity
+      pattern — `stringReplace*` turned out fully ternary). Notes:
+      `split` / `join` deferred to the array slice (their typing IS array
+      typing). Probed: `regexFind` returns null on NO MATCH (always-nullable
+      return, independent of operands) while `regexFindAll` returns `[]`;
+      invalid regex patterns and vector dimension mismatches are backend
+      ERROR values; `type()` / `isType()` are type-OBSERVING — a null value
+      yields the name `'null'`, so only ABSENCE propagates
+      (`PropagateAbsence`). `type()`'s vocabulary is the backend naming
+      (`int64` / `float64` / `geo_point`, distinct per VALUE — another
+      artifact of the honest numeric tag), pinned as
+      `LiteralType<FirestoreTypeName[]>`; `isType`'s name must be a
+      wire-literal (factory takes a literal union, lifted via `constant`;
+      executors recover the raw string for the SDK helpers). The reserved
+      `__name__` is a REFERENCE (probed via `type(__name__)`), so
+      `FieldTypeOfPath` now resolves it to the new `ReferenceType`
+      pseudo-descriptor (tag `'reference'`, `output: string` for the core
+      query API's id filters) — `documentId(field('__name__'))` bridges it
+      into the string domain, and comparing `__name__` against strings is
+      now correctly rejected.
 - [ ] **4. Timestamp family** (literal-union factory args pattern:
       `TimeUnit`, truncation granularity).
 - [ ] **5. Existence/error + conditional + logicalMax/Min + equalAny/notEqualAny**

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -244,7 +244,16 @@ both executors and the basic backend semantics in one round trip per family.
       pseudo-descriptor (tag `'reference'`, `output: string` for the core
       query API's id filters) — `documentId(field('__name__'))` bridges it
       into the string domain, and comparing `__name__` against strings is
-      now correctly rejected.
+      now correctly rejected (probed: the backend matches NO string form —
+      only a reference value). `docRefValue(collection, id)` joins
+      `geoPointValue` / `vectorValue` as the third dedicated value node
+      (same classification rule: an id tuple is a plain `string[]` = an
+      array constant) and is the matching comparand; executors thread `db`
+      to build the wire reference (the codec's `buildEncodeField`
+      precedent). The `Expression<T>` union now binds the non-generic value
+      nodes through their `type` property (`GeoPointValue & { type: T }`) —
+      previously every value node inhabited every operand domain
+      (`toUpper(geoPointValue(...))` type-checked).
 - [ ] **4. Timestamp family** (literal-union factory args pattern:
       `TimeUnit`, truncation granularity).
 - [ ] **5. Existence/error + conditional + logicalMax/Min + equalAny/notEqualAny**

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -129,6 +129,18 @@ double())), field(string()))` is legal; reference-vs-`array(string())`,
 - Return types widen to the plain descriptor (`toUpper` of a literal returns
   `StringType`) — values are transformed, so precision loss is correct.
 
+### Planned ergonomics: direct literal operands (no explicit `constant()`)
+
+Raw values should be writable directly as operands —
+`equal(field('rank'), 1)`, `startsWith(field('name'), 'a')`,
+`equal(field('__name__'), docRefValue(...))` — with the factory lifting them
+via `constant()` internally, exactly like the official SDK
+(`equal(field('x'), 5)`). ONE lifting rule applied uniformly across every
+factory (an operand position accepts `Expression<D> | <the ConstantValue
+subset whose inferred descriptor fits D>`), not per-function ad-hoc
+overloads. Value constructors (`geoPointValue` / `vectorValue` /
+`docRefValue`) are values, so they ride the same rule.
+
 ### Optional arguments (e.g. `substring(s, start, len?)`)
 
 The factory overloads to **two shapes**: 2-arg calls build a `BinaryFunction`,
@@ -256,10 +268,12 @@ both executors and the basic backend semantics in one round trip per family.
       (same classification rule: an id tuple is a plain `string[]` = an
       array constant) and is the matching comparand; executors thread `db`
       to build the wire reference (the codec's `buildEncodeField`
-      precedent). The `Expression<T>` union now binds the non-generic value
-      nodes through their `type` property (`GeoPointValue & { type: T }`) —
-      previously every value node inhabited every operand domain
-      (`toUpper(geoPointValue(...))` type-checked).
+      precedent). Value nodes are NOT expressions: `constant()` is the one
+      point where any value (scalar, map, `geoPointValue` / `vectorValue` /
+      `docRefValue`) lifts into an expression, matching the SDK's
+      `constant(new GeoPoint(...))` — this closed the hole where every value
+      node inhabited every operand domain (`toUpper(geoPointValue(...))`
+      type-checked), and needed no type-level membership trick.
 - [ ] **4. Timestamp family** (literal-union factory args pattern:
       `TimeUnit`, truncation granularity).
 - [ ] **5. Existence/error + conditional + logicalMax/Min + equalAny/notEqualAny**

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -335,6 +335,31 @@ Deferred to a later iteration (still tracked here, not currently in scope):
   - Settle whether `Ordering` is imported as a value or `import type` in
     `pipeline.ts` (it is currently a value import of a type).
 
+## Reference values: segment-path unification (next up, own PR)
+
+Agreed direction (2026-07): unify the reference VALUE representation across
+the known-collection and context-free flavors as a **segment path including
+collection names** — `['authors', <id>]`, `['authors', <id>, 'posts', <id>]`
+— typed with LITERAL collection-name positions when the collection is known
+and `string[]` when it is not, so known/unknown becomes purely a gradient of
+tuple precision (this also dissolves the ids-tuple vs segments ambiguity
+that previously forced the context-free flavor onto a path string).
+
+Constraints / scope:
+
+- **The repository API keeps its ids-only interface** (`get(['a1'])`,
+  `Doc.id`, `DocRef<T>` as-is): a repository is already collection-bound, so
+  making callers repeat the collection name is pure ceremony. The segment
+  form is a SEPARATE type for reference VALUES (a `docRef(...)` field's
+  read/write value, `DocRefType<'unknown'>`'s value, `docRefValue`'s
+  payload), converting to/from ids at the repository boundary.
+- Prerequisite: `Collection` must capture `name` / `parent` as LITERAL types
+  (`const` type parameters) for the precise tuples.
+- Ripples: both codecs' docRef decode (collect names from the ref walk —
+  already available), `documentPath` (becomes ~a join), the core query's
+  docRef filter encoding (today's raw pass-through needs revisiting),
+  `docRefValue`'s argument shape, specs and README examples.
+
 ## Expressions — remaining gaps
 
 - [~] **Restructure `FunctionCall` into shape-grouped classes when the ~85

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -46,9 +46,14 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
     case 'string':
       return z.string();
     case 'reference':
-      // The '__name__' pseudo-descriptor — an expression-context type that
-      // never appears in document data.
-      throw new Error(`unsupported schema field type: ${fieldType.type}`);
+      // The '__name__' pseudo-descriptor: a projected raw key decodes to its
+      // relative path string — the context-free representation its `output`
+      // declares (there is no schema-known collection to build a DocRef id
+      // tuple from).
+      return z
+        .unknown()
+        .refine(isDocumentReference)
+        .transform((ref) => ref.path);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -126,8 +131,7 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
     case 'string':
       return z.string();
     case 'reference':
-      // The '__name__' pseudo-descriptor — an expression-context type that
-      // never appears in document data.
+      // The '__name__' pseudo-descriptor is never writable (input: never).
       throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -45,15 +45,6 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
-    case 'reference':
-      // The '__name__' pseudo-descriptor: a projected raw key decodes to its
-      // relative path string — the context-free representation its `output`
-      // declares (there is no schema-known collection to build a DocRef id
-      // tuple from).
-      return z
-        .unknown()
-        .refine(isDocumentReference)
-        .transform((ref) => ref.path);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -75,6 +66,16 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
     case 'vector':
       return z.instanceof(FirestoreVectorValue).transform((vv) => vv.toArray());
     case 'docRef':
+      if (fieldType.collection === 'unknown') {
+        // The context-free flavor (the '__name__' pseudo-descriptor): with no
+        // schema-known collection to build a DocRef id tuple from, a
+        // projected raw key decodes to its relative path string — the
+        // representation its `output` declares.
+        return z
+          .unknown()
+          .refine(isDocumentReference)
+          .transform((ref) => ref.path);
+      }
       return z
         .unknown()
         .refine(isDocumentReference)
@@ -130,9 +131,6 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
-    case 'reference':
-      // The '__name__' pseudo-descriptor is never writable (input: never).
-      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'null':
@@ -163,9 +161,14 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
           .transform(() => firestoreServerTimestamp()),
       ]);
     case 'docRef': {
+      if (fieldType.collection === 'unknown') {
+        // The context-free flavor is never writable (input: never).
+        throw new Error('unsupported schema field type: context-free docRef');
+      }
+      const { collection } = fieldType;
       return z.array(z.string()).transform((ref) =>
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        doc(db, documentPath(fieldType.collection, ref as DocRef<Collection>)),
+        doc(db, documentPath(collection, ref as DocRef<Collection>)),
       );
     }
     case 'map': {

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -45,6 +45,10 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
+    case 'reference':
+      // The '__name__' pseudo-descriptor — an expression-context type that
+      // never appears in document data.
+      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -121,6 +125,10 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
+    case 'reference':
+      // The '__name__' pseudo-descriptor — an expression-context type that
+      // never appears in document data.
+      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'null':

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -162,8 +162,9 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
       ]);
     case 'docRef': {
       if (fieldType.collection === 'unknown') {
-        // The context-free flavor is never writable (input: never).
-        throw new Error('unsupported schema field type: context-free docRef');
+        // The context-free flavor writes a relative path string — the one
+        // reference representation that needs no collection context.
+        return z.string().transform((path) => doc(db, path));
       }
       const { collection } = fieldType;
       return z.array(z.string()).transform((ref) =>

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -1,4 +1,4 @@
-import { Bytes, type Firestore, GeoPoint, vector } from '@firebase/firestore';
+import { Bytes, doc, type Firestore, GeoPoint, vector } from '@firebase/firestore';
 import {
   abs as sdkAbs,
   add as sdkAdd,
@@ -64,12 +64,13 @@ import {
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
 } from '@firebase/firestore/pipelines';
-import { collectionPath } from 'firestore-repository/path';
+import { collectionPath, documentPath } from 'firestore-repository/path';
 import {
   type BinaryFunctionName,
   type Constant,
   type ConstantArray,
   type Expression,
+  DocRefValue,
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
@@ -127,7 +128,7 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
         return assertNever(input);
     }
     for (const stage of transforms) {
-      sdk = applyStage(sdk, stage);
+      sdk = applyStage(db, sdk, stage);
     }
 
     const { fromFirestore } = buildFirestoreUtilities(db, collection);
@@ -145,14 +146,14 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
   return { execute };
 };
 
-const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
+const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
   switch (stage.kind) {
     case 'sort': {
       const [first, ...rest] = stage.orderings.map(toSdkOrdering);
       return first === undefined ? sdk : sdk.sort(first, ...rest);
     }
     case 'select': {
-      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      const [first, ...rest] = stage.selections.map((selection) => toSdkSelectable(db, selection));
       if (first === undefined) {
         throw new Error('firebase pipeline executor: select requires at least one selection');
       }
@@ -166,7 +167,7 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
       return sdk.removeFields(first, ...rest);
     }
     case 'addFields': {
-      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      const [first, ...rest] = stage.selections.map((selection) => toSdkSelectable(db, selection));
       if (first === undefined) {
         throw new Error('firebase pipeline executor: addFields requires at least one field');
       }
@@ -175,7 +176,7 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
-      return sdk.where(toSdkExpression(stage.condition).asBoolean());
+      return sdk.where(toSdkExpression(db, stage.condition).asBoolean());
     case 'limit':
       return sdk.limit(stage.limit);
     case 'offset':
@@ -201,43 +202,50 @@ const applyStage = (sdk: SdkPipeline, stage: TransformStage): SdkPipeline => {
  * with its own path as the alias — the same wire proto as the SDK's string
  * handling for `select`, in the form `addFields` also accepts.
  */
-const toSdkSelectable = (s: string | ExpressionWithAlias): SdkSelectable =>
-  typeof s === 'string' ? field(s) : toSdkExpression(s.expression).as(s.alias);
+const toSdkSelectable = (db: Firestore, s: string | ExpressionWithAlias): SdkSelectable =>
+  typeof s === 'string' ? field(s) : toSdkExpression(db, s.expression).as(s.alias);
 
 /** Translates the repository expression AST into an SDK expression. */
-const toSdkExpression = (expression: Expression): SdkExpression => {
+/**
+ * Translates the repository expression AST into an SDK expression. Threads
+ * `db` for the one value kind whose SDK form needs it: a document-reference
+ * constant is built via `doc(db, ...)` (the codec's `buildEncodeField`
+ * precedent).
+ */
+const toSdkExpression = (db: Firestore, expression: Expression): SdkExpression => {
   switch (expression.kind) {
     case 'field':
       return field(expression.path);
     case 'constant':
-      return toSdkConstant(expression.value);
+      return toSdkConstant(db, expression.value);
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
       // Value nodes also appear as constant-composite leaves; toSdkConstant
       // is the single home for their translation.
-      return toSdkConstant(expression);
+      return toSdkConstant(db, expression);
     case 'nullaryFunction':
       return nullaryFns[expression.name]();
     case 'unaryFunction':
-      return unaryFns[expression.name](toSdkExpression(expression.operand));
+      return unaryFns[expression.name](toSdkExpression(db, expression.operand));
     case 'binaryFunction':
       return binaryFns[expression.name](
-        toSdkExpression(expression.left),
-        toSdkExpression(expression.right),
+        toSdkExpression(db, expression.left),
+        toSdkExpression(db, expression.right),
         expression,
       );
     case 'ternaryFunction':
       return ternaryFns[expression.name](
-        toSdkExpression(expression.first),
-        toSdkExpression(expression.second),
-        toSdkExpression(expression.third),
+        toSdkExpression(db, expression.first),
+        toSdkExpression(db, expression.second),
+        toSdkExpression(db, expression.third),
       );
     case 'variadicFunction': {
       const [first, second, ...rest] = expression.operands;
       return variadicFns[expression.name](
-        toSdkExpression(first),
-        toSdkExpression(second),
-        ...rest.map(toSdkExpression),
+        toSdkExpression(db, first),
+        toSdkExpression(db, second),
+        ...rest.map((operand) => toSdkExpression(db, operand)),
       );
     }
     default:
@@ -253,7 +261,7 @@ const toSdkExpression = (expression: Expression): SdkExpression => {
  * vectors are dedicated nodes, so an array is always an array constant and a
  * plain object always a map constant.
  */
-const toSdkConstant = (value: Constant['value']): SdkExpression => {
+const toSdkConstant = (db: Firestore, value: Constant['value']): SdkExpression => {
   if (value === null) {
     return sdkConstant(value);
   }
@@ -269,8 +277,11 @@ const toSdkConstant = (value: Constant['value']): SdkExpression => {
   if (value instanceof VectorValue) {
     return sdkConstant(vector([...value.values]));
   }
+  if (value instanceof DocRefValue) {
+    return sdkConstant(doc(db, documentPath(value.collection, value.id)));
+  }
   if (isConstantArrayValue(value)) {
-    return sdkArray(value.map(toSdkConstant));
+    return sdkArray(value.map((element) => toSdkConstant(db, element)));
   }
   switch (typeof value) {
     case 'string':
@@ -281,7 +292,7 @@ const toSdkConstant = (value: Constant['value']): SdkExpression => {
       return sdkConstant(value);
     case 'object':
       return sdkMap(
-        Object.fromEntries(Object.entries(value).map(([k, v]) => [k, toSdkConstant(v)])),
+        Object.fromEntries(Object.entries(value).map(([k, v]) => [k, toSdkConstant(db, v)])),
       );
     case 'bigint':
     case 'symbol':
@@ -397,6 +408,7 @@ const literalStringOperand = (operand: Expression): string => {
     case 'field':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
@@ -425,6 +437,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -205,7 +205,6 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
 const toSdkSelectable = (db: Firestore, s: string | ExpressionWithAlias): SdkSelectable =>
   typeof s === 'string' ? field(s) : toSdkExpression(db, s.expression).as(s.alias);
 
-/** Translates the repository expression AST into an SDK expression. */
 /**
  * Translates the repository expression AST into an SDK expression. Threads
  * `db` for the one value kind whose SDK form needs it: a document-reference

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -217,12 +217,6 @@ const toSdkExpression = (db: Firestore, expression: Expression): SdkExpression =
       return field(expression.path);
     case 'constant':
       return toSdkConstant(db, expression.value);
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
-      // Value nodes also appear as constant-composite leaves; toSdkConstant
-      // is the single home for their translation.
-      return toSdkConstant(db, expression);
     case 'nullaryFunction':
       return nullaryFns[expression.name]();
     case 'unaryFunction':
@@ -405,9 +399,6 @@ const literalStringOperand = (operand: Expression): string => {
       throw new Error('expected a literal string constant operand');
     }
     case 'field':
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
@@ -434,9 +425,6 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -7,18 +7,25 @@ import {
   byteLength as sdkByteLength,
   ceil as sdkCeil,
   charLength as sdkCharLength,
+  collectionId as sdkCollectionId,
+  cosineDistance as sdkCosineDistance,
   constant as sdkConstant,
   divide as sdkDivide,
+  documentId as sdkDocumentId,
+  dotProduct as sdkDotProduct,
   endsWith as sdkEndsWith,
   equal as sdkEqual,
+  euclideanDistance as sdkEuclideanDistance,
   execute as executePipeline,
   exp as sdkExp,
   field,
   floor as sdkFloor,
   greaterThan as sdkGreaterThan,
   greaterThanOrEqual as sdkGreaterThanOrEqual,
+  isType as sdkIsType,
   lessThan as sdkLessThan,
   lessThanOrEqual as sdkLessThanOrEqual,
+  like as sdkLike,
   ln as sdkLn,
   log10 as sdkLog10,
   ltrim as sdkLtrim,
@@ -30,18 +37,29 @@ import {
   or as sdkOr,
   pow as sdkPow,
   rand as sdkRand,
+  regexContains as sdkRegexContains,
+  regexFind as sdkRegexFind,
+  regexFindAll as sdkRegexFindAll,
+  regexMatch as sdkRegexMatch,
   round as sdkRound,
   rtrim as sdkRtrim,
   sqrt as sdkSqrt,
   startsWith as sdkStartsWith,
   stringConcat as sdkStringConcat,
   stringContains as sdkStringContains,
+  stringIndexOf as sdkStringIndexOf,
+  stringRepeat as sdkStringRepeat,
+  stringReplaceAll as sdkStringReplaceAll,
+  stringReplaceOne as sdkStringReplaceOne,
   stringReverse as sdkStringReverse,
+  substring as sdkSubstring,
   subtract as sdkSubtract,
   toLower as sdkToLower,
   toUpper as sdkToUpper,
   trim as sdkTrim,
   trunc as sdkTrunc,
+  type as sdkType,
+  vectorLength as sdkVectorLength,
   type Expression as SdkExpression,
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
@@ -55,7 +73,9 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type BinaryFunction,
   type NullaryFunctionName,
+  type TernaryFunctionName,
   UnaryFunctionName,
   VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
@@ -204,6 +224,13 @@ const toSdkExpression = (expression: Expression): SdkExpression => {
       return binaryFns[expression.name](
         toSdkExpression(expression.left),
         toSdkExpression(expression.right),
+        expression,
+      );
+    case 'ternaryFunction':
+      return ternaryFns[expression.name](
+        toSdkExpression(expression.first),
+        toSdkExpression(expression.second),
+        toSdkExpression(expression.third),
       );
     case 'variadicFunction': {
       const [first, second, ...rest] = expression.operands;
@@ -297,31 +324,89 @@ const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> =
   trim: sdkTrim,
   ltrim: sdkLtrim,
   rtrim: sdkRtrim,
+  documentId: sdkDocumentId,
+  collectionId: sdkCollectionId,
+  type: sdkType,
+  vectorLength: sdkVectorLength,
 };
 
-const binaryFns: Record<BinaryFunctionName, (l: SdkExpression, r: SdkExpression) => SdkExpression> =
-  {
-    equal: sdkEqual,
-    notEqual: sdkNotEqual,
-    lessThan: sdkLessThan,
-    lessThanOrEqual: sdkLessThanOrEqual,
-    greaterThan: sdkGreaterThan,
-    greaterThanOrEqual: sdkGreaterThanOrEqual,
-    add: sdkAdd,
-    subtract: sdkSubtract,
-    multiply: sdkMultiply,
-    divide: sdkDivide,
-    mod: sdkMod,
-    pow: sdkPow,
-    round: sdkRound,
-    trunc: sdkTrunc,
-    trim: sdkTrim,
-    ltrim: sdkLtrim,
-    rtrim: sdkRtrim,
-    startsWith: sdkStartsWith,
-    endsWith: sdkEndsWith,
-    stringContains: sdkStringContains,
-  };
+// Entries receive the raw AST node too: functions with backend-mandated
+// LITERAL arguments (isType's type name) must hand the SDK helper the plain
+// string, which is unrecoverable from the translated constant expression.
+const binaryFns: Record<
+  BinaryFunctionName,
+  (l: SdkExpression, r: SdkExpression, node: BinaryFunction) => SdkExpression
+> = {
+  equal: sdkEqual,
+  notEqual: sdkNotEqual,
+  lessThan: sdkLessThan,
+  lessThanOrEqual: sdkLessThanOrEqual,
+  greaterThan: sdkGreaterThan,
+  greaterThanOrEqual: sdkGreaterThanOrEqual,
+  add: sdkAdd,
+  subtract: sdkSubtract,
+  multiply: sdkMultiply,
+  divide: sdkDivide,
+  mod: sdkMod,
+  pow: sdkPow,
+  round: sdkRound,
+  trunc: sdkTrunc,
+  trim: sdkTrim,
+  ltrim: sdkLtrim,
+  rtrim: sdkRtrim,
+  startsWith: sdkStartsWith,
+  endsWith: sdkEndsWith,
+  stringContains: sdkStringContains,
+  stringIndexOf: sdkStringIndexOf,
+  stringRepeat: sdkStringRepeat,
+  substring: (l, r) => sdkSubstring(l, r),
+  like: sdkLike,
+  regexContains: sdkRegexContains,
+  regexMatch: sdkRegexMatch,
+  regexFind: sdkRegexFind,
+  regexFindAll: sdkRegexFindAll,
+  isType: (l, _r, node) => sdkIsType(l, literalStringOperand(node.right)),
+  cosineDistance: sdkCosineDistance,
+  dotProduct: sdkDotProduct,
+  euclideanDistance: sdkEuclideanDistance,
+};
+
+const ternaryFns: Record<
+  TernaryFunctionName,
+  (a: SdkExpression, b: SdkExpression, c: SdkExpression) => SdkExpression
+> = {
+  stringReplaceAll: sdkStringReplaceAll,
+  stringReplaceOne: sdkStringReplaceOne,
+  substring: sdkSubstring,
+};
+
+/**
+ * Recovers the literal string a factory lifted into a constant operand
+ * (e.g. `isType`'s type name): the backend requires the wire argument to be
+ * a constant, and the SDK helper takes it as a plain string.
+ */
+const literalStringOperand = (operand: Expression): string => {
+  switch (operand.kind) {
+    case 'constant': {
+      const { value } = operand;
+      if (typeof value === 'string') {
+        return value;
+      }
+      throw new Error('expected a literal string constant operand');
+    }
+    case 'field':
+    case 'geoPointValue':
+    case 'vectorValue':
+    case 'nullaryFunction':
+    case 'unaryFunction':
+    case 'binaryFunction':
+    case 'ternaryFunction':
+    case 'variadicFunction':
+      throw new Error(`expected a constant operand, got ${operand.kind}`);
+    default:
+      return assertNever(operand);
+  }
+};
 
 const variadicFns: Record<
   VariadicFunctionName,
@@ -343,6 +428,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
+    case 'ternaryFunction':
     case 'variadicFunction':
       throw new Error('firebase pipeline executor: only field orderings are supported in sort yet');
     default:

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -4,6 +4,24 @@ import {
   abs,
   add,
   and,
+  collectionId,
+  cosineDistance,
+  documentId,
+  dotProduct,
+  euclideanDistance,
+  isType,
+  like,
+  regexContains,
+  regexFind,
+  regexFindAll,
+  regexMatch,
+  stringIndexOf,
+  stringRepeat,
+  stringReplaceAll,
+  stringReplaceOne,
+  substring,
+  type,
+  vectorLength,
   byteLength,
   ceil,
   charLength,
@@ -136,7 +154,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       }
     };
 
-    return { items, source, expectPipeline };
+    return { items, source, expectPipeline, collectionName: () => collection.name };
   };
 
   describe('pipeline specification', () => {
@@ -315,7 +333,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     // its basic backend semantics in one round trip per family. Every future
     // slice MUST add its functions to this catalog.
     describe('function catalog (one straightforward evaluation per function)', () => {
-      const { source, expectPipeline } = setup();
+      const { source, expectPipeline, collectionName } = setup();
       /** A single-row source: the catalog evaluates constant expressions only. */
       const one = () => source().limit(1);
 
@@ -437,6 +455,97 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
               },
             },
           ],
+        );
+      });
+
+      it('string (slice 3) and regex', async () => {
+        await expectPipeline(
+          one().select(() => [
+            stringIndexOf(constant('abc'), constant('b')).as('indexOf'),
+            stringIndexOf(constant('abc'), constant('z')).as('indexOfMiss'),
+            stringRepeat(constant('ab'), constant(2)).as('repeat'),
+            stringReplaceAll(constant('aba'), constant('a'), constant('x')).as('replaceAll'),
+            stringReplaceOne(constant('aba'), constant('a'), constant('x')).as('replaceOne'),
+            substring(constant('abc'), constant(1)).as('substringToEnd'),
+            substring(constant('abc'), constant(1), constant(1)).as('substringLen'),
+            like(constant('abc'), constant('a%')).as('like'),
+            regexContains(constant('abc'), constant('b+')).as('regexContains'),
+            regexMatch(constant('abc'), constant('b+')).as('regexMatchPartial'),
+            regexMatch(constant('abc'), constant('a.c')).as('regexMatchFull'),
+            regexFind(constant('abc'), constant('b+')).as('regexFind'),
+            regexFind(constant('abc'), constant('z+')).as('regexFindMiss'),
+            regexFindAll(constant('abc'), constant('[ab]')).as('regexFindAll'),
+            regexFindAll(constant('abc'), constant('z+')).as('regexFindAllMiss'),
+          ]),
+          [
+            {
+              data: {
+                indexOf: 1,
+                indexOfMiss: -1,
+                repeat: 'abab',
+                replaceAll: 'xbx',
+                replaceOne: 'xba',
+                substringToEnd: 'bc',
+                substringLen: 'b',
+                like: true,
+                regexContains: true,
+                regexMatchPartial: false,
+                regexMatchFull: true,
+                regexFind: 'b',
+                regexFindMiss: null,
+                regexFindAll: ['a', 'b'],
+                regexFindAllMiss: [],
+              },
+            },
+          ],
+        );
+      });
+
+      it('type / isType and vector', async () => {
+        await expectPipeline(
+          one().select(() => [
+            type(constant('x')).as('typeString'),
+            // A whole JS number wire-encodes as an integer — type() observes
+            // int64, the honest 'integer' | 'double' tag at work.
+            type(constant(7)).as('typeInt'),
+            type(constant(7.5)).as('typeDouble'),
+            type(constant(null)).as('typeNull'),
+            isType(constant('x'), 'string').as('isTypeHit'),
+            isType(constant('x'), 'int64').as('isTypeMiss'),
+            vectorLength(vectorValue([1, 2, 3])).as('vectorLength'),
+            dotProduct(vectorValue([1, 2, 3]), vectorValue([1, 1, 1])).as('dotProduct'),
+            euclideanDistance(vectorValue([1, 2]), vectorValue([4, 6])).as('euclidean'),
+            cosineDistance(vectorValue([1, 0]), vectorValue([1, 0])).as('cosine'),
+          ]),
+          [
+            {
+              data: {
+                typeString: 'string',
+                typeInt: 'int64',
+                typeDouble: 'float64',
+                typeNull: 'null',
+                isTypeHit: true,
+                isTypeMiss: false,
+                vectorLength: 3,
+                dotProduct: 6,
+                euclidean: 5,
+                cosine: 0,
+              },
+            },
+          ],
+        );
+      });
+
+      it('reference: documentId / collectionId over __name__', async () => {
+        const sorted = source()
+          .sort((field) => [asc(field('rank'))])
+          .limit(1);
+        await expectPipeline(
+          sorted.select((field) => [
+            documentId(field('__name__')).as('id'),
+            collectionId(field('__name__')).as('cid'),
+          ]),
+          [{ data: { id: 'a1', cid: collectionName() } }],
         );
       });
 

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -297,8 +297,8 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
               constant(null).as('z'),
               constant(new Date('2024-01-02T03:04:05.678Z')).as('t'),
               constant(new Uint8Array([1, 2, 3])).as('by'),
-              geoPointValue(35.68, 139.69).as('g'),
-              vectorValue([0.5, 0.25]).as('v'),
+              constant(geoPointValue(35.68, 139.69)).as('g'),
+              constant(vectorValue([0.5, 0.25])).as('v'),
               constant([1, 2, 3]).as('arr'),
               constant([1, 'a', true]).as('mixed'),
               constant({
@@ -519,10 +519,16 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             type(constant(null)).as('typeNull'),
             isType(constant('x'), 'string').as('isTypeHit'),
             isType(constant('x'), 'int64').as('isTypeMiss'),
-            vectorLength(vectorValue([1, 2, 3])).as('vectorLength'),
-            dotProduct(vectorValue([1, 2, 3]), vectorValue([1, 1, 1])).as('dotProduct'),
-            euclideanDistance(vectorValue([1, 2]), vectorValue([4, 6])).as('euclidean'),
-            cosineDistance(vectorValue([1, 0]), vectorValue([1, 0])).as('cosine'),
+            vectorLength(constant(vectorValue([1, 2, 3]))).as('vectorLength'),
+            dotProduct(constant(vectorValue([1, 2, 3])), constant(vectorValue([1, 1, 1]))).as(
+              'dotProduct',
+            ),
+            euclideanDistance(constant(vectorValue([1, 2])), constant(vectorValue([4, 6]))).as(
+              'euclidean',
+            ),
+            cosineDistance(constant(vectorValue([1, 0])), constant(vectorValue([1, 0]))).as(
+              'cosine',
+            ),
           ]),
           [
             {
@@ -550,7 +556,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         // genuine reference value.
         await expectPipeline(
           source().where((field) =>
-            equal(field('__name__'), docRefValue(liveCollection(), ['a1'])),
+            equal(field('__name__'), constant(docRefValue(liveCollection(), ['a1']))),
           ),
           [a1],
         );

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -22,6 +22,7 @@ import {
   substring,
   type,
   vectorLength,
+  docRefValue,
   byteLength,
   ceil,
   charLength,
@@ -154,7 +155,13 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       }
     };
 
-    return { items, source, expectPipeline, collectionName: () => collection.name };
+    return {
+      items,
+      source,
+      expectPipeline,
+      collectionName: () => collection.name,
+      liveCollection: () => collection,
+    };
   };
 
   describe('pipeline specification', () => {
@@ -333,7 +340,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     // its basic backend semantics in one round trip per family. Every future
     // slice MUST add its functions to this catalog.
     describe('function catalog (one straightforward evaluation per function)', () => {
-      const { source, expectPipeline, collectionName } = setup();
+      const { items, source, expectPipeline, collectionName, liveCollection } = setup();
       /** A single-row source: the catalog evaluates constant expressions only. */
       const one = () => source().limit(1);
 
@@ -533,6 +540,36 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
               },
             },
           ],
+        );
+      });
+
+      it('reference: __name__ equals a docRefValue constant (never a string)', async () => {
+        const [a1] = items;
+        // Probed: the pipeline backend never matches __name__ against any
+        // string form (id / relative path / full resource path) — only a
+        // genuine reference value.
+        await expectPipeline(
+          source().where((field) =>
+            equal(field('__name__'), docRefValue(liveCollection(), ['a1'])),
+          ),
+          [a1],
+        );
+      });
+
+      it('reference: a projected raw __name__ decodes to its path string', async () => {
+        await expectPipeline(
+          source()
+            .sort((field) => [asc(field('rank'))])
+            .limit(1)
+            .select((field) => [field('__name__').as('key'), 'name']),
+          [{ data: { key: `${collectionName()}/a1`, name: 'alice' } }],
+        );
+      });
+
+      it('reference: a docRefValue inside a constant map decodes to a DocRef id tuple', async () => {
+        await expectPipeline(
+          one().select(() => [constant({ author: docRefValue(liveCollection(), ['a2']) }).as('m')]),
+          [{ data: { m: { author: ['a2'] } } }],
         );
       });
 

--- a/packages/firestore-repository/src/__test__/specification.ts
+++ b/packages/firestore-repository/src/__test__/specification.ts
@@ -1006,6 +1006,9 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           map: map({ a: double(), b: array(string()), nested: map({ c: int64() }) }),
           null: nullType(),
           docRef: docRef(authorsCollection),
+          // The context-free flavor: a reference to no one particular
+          // collection, round-tripping relative path strings.
+          anyRef: docRef(),
           str: string(),
           vector: vector(),
           literalStr: literal('foo', 'bar', 'baz'),
@@ -1030,6 +1033,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
             map: { a: 123, b: ['foo', 'bar'], nested: { c: 7 } },
             null: null,
             docRef: [randomString()],
+            anyRef: 'SomeOtherCollection/some-doc-id',
             str: randomString(),
             vector: [1, 2, 3, 4, 5],
             literalStr: 'foo',

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -62,6 +62,8 @@ import {
   startsWith,
   collectionId,
   cosineDistance,
+  docRefValue,
+  DocRefValue,
   documentId,
   dotProduct,
   euclideanDistance,
@@ -753,5 +755,46 @@ describe('reference / type / vector operators', () => {
     dotProduct(vec, field(array(double()), 'nums'));
     // @ts-expect-error -- a string is not a vector
     vectorLength(field(string(), 'name'));
+  });
+});
+
+describe('document-reference values', () => {
+  const authors = rootCollection({ name: 'authors', schema: { name: string() } });
+
+  it('docRefValue is a dedicated node carrying its collection and id', () => {
+    const ref = docRefValue(authors, ['a1']);
+    expect(ref).toStrictEqual(new DocRefValue(authors, ['a1']));
+    expect(ref.type).toStrictEqual(docRef(authors));
+    expectTypeOf(ref.type).toEqualTypeOf(docRef(authors));
+  });
+
+  it('compares against reference operands only (probed: strings never match)', () => {
+    const ref = docRefValue(authors, ['a1']);
+    equal(field(referenceType(), '__name__'), ref);
+    equal(field(docRef(authors), 'ref'), ref);
+    // @ts-expect-error -- a reference never equals a string (always-false on the backend)
+    equal(ref, constant('authors/a1'));
+  });
+
+  it('value nodes are domain-bound: a node only inhabits expressions its descriptor fits', () => {
+    // The Expression<T> union binds GeoPointValue/VectorValue/DocRefValue
+    // through their `type` property — without that, every value node would
+    // satisfy every operand domain.
+    // @ts-expect-error -- a geopoint is not a string operand
+    toUpper(geoPointValue(1, 2));
+    // @ts-expect-error -- a vector is not a numeric operand
+    abs(vectorValue([1]));
+    // @ts-expect-error -- a geopoint never equals a string
+    equal(geoPointValue(1, 2), constant('x'));
+    // ...and inference reads the node's own descriptor, so same-domain pairs work.
+    equal(geoPointValue(1, 2), field(geoPoint(), 'geo'));
+    dotProduct(vectorValue([1, 2]), field(vector(), 'vec'));
+  });
+
+  it('doubles as a composite constant leaf, like geopoint/vector nodes', () => {
+    const c = constant({ author: docRefValue(authors, ['a1']) });
+    const oracle = map({ author: docRef(authors) });
+    expect(c.type).toStrictEqual(oracle);
+    expectTypeOf(c.type).toEqualTypeOf(oracle);
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -224,10 +224,11 @@ describe('aliasing (.as)', () => {
     const c = constant(1);
     expect(c.as('n')).toStrictEqual({ expression: c, alias: 'n' });
 
-    const g = geoPointValue(1, 2);
+    // Value nodes are not expressions — they alias through constant().
+    const g = constant(geoPointValue(1, 2));
     expect(g.as('g')).toStrictEqual({ expression: g, alias: 'g' });
 
-    const v = vectorValue([1]);
+    const v = constant(vectorValue([1]));
     expect(v.as('v')).toStrictEqual({ expression: v, alias: 'v' });
 
     const cmp = equal(field(double(), 'rank'), constant(1));
@@ -324,8 +325,8 @@ describe('comparison operators (table-driven over all six)', () => {
       // same-T pairs for the remaining groups
       expect(cmp(field(timestamp(), 'at'), constant(new Date(0))).name).toBe(fnName);
       expect(cmp(field(bytes(), 'raw'), constant(new Uint8Array([1]))).name).toBe(fnName);
-      expect(cmp(field(geoPoint(), 'geo'), geoPointValue(1, 2)).name).toBe(fnName);
-      expect(cmp(field(vector(), 'vec'), vectorValue([1])).name).toBe(fnName);
+      expect(cmp(field(geoPoint(), 'geo'), constant(geoPointValue(1, 2))).name).toBe(fnName);
+      expect(cmp(field(vector(), 'vec'), constant(vectorValue([1]))).name).toBe(fnName);
       expect(cmp(field(nullType(), 'z'), constant(null)).name).toBe(fnName);
       // function operands nest (bool same-T)
       expect(cmp(equal(rank, count), constant(true)).name).toBe(fnName);
@@ -744,8 +745,8 @@ describe('reference / type / vector operators', () => {
 
   it('vector functions take vector operands only', () => {
     const vec = field(vector(), 'vec');
-    expect(dotProduct(vec, vectorValue([1, 2]))).toStrictEqual(
-      new BinaryFunction('dotProduct', double(), vec, vectorValue([1, 2])),
+    expect(dotProduct(vec, constant(vectorValue([1, 2])))).toStrictEqual(
+      new BinaryFunction('dotProduct', double(), vec, constant(vectorValue([1, 2]))),
     );
     expect(cosineDistance(vec, vec).name).toBe('cosineDistance');
     expect(euclideanDistance(vec, vec).name).toBe('euclideanDistance');
@@ -768,26 +769,28 @@ describe('document-reference values', () => {
   });
 
   it('compares against reference operands only (probed: strings never match)', () => {
-    const ref = docRefValue(authors, ['a1']);
+    const ref = constant(docRefValue(authors, ['a1']));
     equal(field(docRef(), '__name__'), ref);
     equal(field(docRef(authors), 'ref'), ref);
     // @ts-expect-error -- a reference never equals a string (always-false on the backend)
     equal(ref, constant('authors/a1'));
   });
 
-  it('value nodes are domain-bound: a node only inhabits expressions its descriptor fits', () => {
-    // The Expression<T> union binds GeoPointValue/VectorValue/DocRefValue
-    // through their `type` property — without that, every value node would
-    // satisfy every operand domain.
-    // @ts-expect-error -- a geopoint is not a string operand
+  it('value nodes are not expressions: they enter only via constant(), which scopes their domain', () => {
+    // A value node is a VALUE — constant() is the one lifting point (like
+    // the SDK's constant(new GeoPoint(...))), and the lifted Constant<T>
+    // carries the precise descriptor into domains and inference.
+    // @ts-expect-error -- a raw value node is not an expression operand
     toUpper(geoPointValue(1, 2));
-    // @ts-expect-error -- a vector is not a numeric operand
-    abs(vectorValue([1]));
+    // @ts-expect-error -- a geopoint constant is not a string operand
+    toUpper(constant(geoPointValue(1, 2)));
+    // @ts-expect-error -- a vector constant is not a numeric operand
+    abs(constant(vectorValue([1])));
     // @ts-expect-error -- a geopoint never equals a string
-    equal(geoPointValue(1, 2), constant('x'));
-    // ...and inference reads the node's own descriptor, so same-domain pairs work.
-    equal(geoPointValue(1, 2), field(geoPoint(), 'geo'));
-    dotProduct(vectorValue([1, 2]), field(vector(), 'vec'));
+    equal(constant(geoPointValue(1, 2)), constant('x'));
+    // Same-domain pairs work, with inference reading the lifted descriptor.
+    equal(constant(geoPointValue(1, 2)), field(geoPoint(), 'geo'));
+    dotProduct(constant(vectorValue([1, 2])), field(vector(), 'vec'));
   });
 
   it('doubles as a composite constant leaf, like geopoint/vector nodes', () => {

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -14,7 +14,6 @@ import {
   nullable,
   nullType,
   optional,
-  referenceType,
   rootCollection,
   string,
   type StringType,
@@ -707,7 +706,7 @@ describe('reference / type / vector operators', () => {
   const authors = rootCollection({ name: 'authors', schema: { name: string() } });
 
   it('documentId/collectionId take reference operands only', () => {
-    const key = field(referenceType(), '__name__');
+    const key = field(docRef(), '__name__');
     const refField = field(docRef(authors), 'ref');
     expect(documentId(key)).toStrictEqual(new UnaryFunction('documentId', string(), key));
     expect(collectionId(key).name).toBe('collectionId');
@@ -770,7 +769,7 @@ describe('document-reference values', () => {
 
   it('compares against reference operands only (probed: strings never match)', () => {
     const ref = docRefValue(authors, ['a1']);
-    equal(field(referenceType(), '__name__'), ref);
+    equal(field(docRef(), '__name__'), ref);
     equal(field(docRef(authors), 'ref'), ref);
     // @ts-expect-error -- a reference never equals a string (always-false on the backend)
     equal(ref, constant('authors/a1'));

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -14,6 +14,7 @@ import {
   nullable,
   nullType,
   optional,
+  referenceType,
   rootCollection,
   string,
   type StringType,
@@ -59,10 +60,29 @@ import {
   rtrim,
   sqrt,
   startsWith,
+  collectionId,
+  cosineDistance,
+  documentId,
+  dotProduct,
+  euclideanDistance,
+  isType,
+  like,
+  regexContains,
+  regexFind,
+  regexFindAll,
+  regexMatch,
   stringConcat,
   stringContains,
+  stringIndexOf,
+  stringRepeat,
+  stringReplaceAll,
+  stringReplaceOne,
   stringReverse,
+  substring,
   subtract,
+  TernaryFunction,
+  type,
+  vectorLength,
   toLower,
   toUpper,
   trim,
@@ -627,5 +647,111 @@ describe('string operators', () => {
     lessThan(charLength(name), constant(10));
     // @ts-expect-error -- a numeric result is not a string operand
     toUpper(charLength(name));
+  });
+});
+
+describe('string operators (slice 3)', () => {
+  const name = field(string(), 'name');
+
+  it('indexOf / repeat / replace / substring shapes and domains', () => {
+    expect(stringIndexOf(name, constant('b'))).toStrictEqual(
+      new BinaryFunction('stringIndexOf', int64(), name, constant('b')),
+    );
+    expect(stringRepeat(name, constant(2))).toStrictEqual(
+      new BinaryFunction('stringRepeat', string(), name, constant(2)),
+    );
+    expect(stringReplaceAll(name, constant('a'), constant('x'))).toStrictEqual(
+      new TernaryFunction('stringReplaceAll', string(), name, constant('a'), constant('x')),
+    );
+    expect(stringReplaceOne(name, constant('a'), constant('x'))).toStrictEqual(
+      new TernaryFunction('stringReplaceOne', string(), name, constant('a'), constant('x')),
+    );
+    // @ts-expect-error -- the repeat count is numeric
+    stringRepeat(name, constant('2'));
+    // @ts-expect-error -- a numeric operand is not a string
+    stringReplaceAll(field(double(), 'rank'), constant('a'), constant('x'));
+  });
+
+  it('substring is dual-arity: an optional length operand', () => {
+    expect(substring(name, constant(1))).toStrictEqual(
+      new BinaryFunction('substring', string(), name, constant(1)),
+    );
+    expect(substring(name, constant(1), constant(2))).toStrictEqual(
+      new TernaryFunction('substring', string(), name, constant(1), constant(2)),
+    );
+    // @ts-expect-error -- position is numeric
+    substring(name, constant('1'));
+  });
+
+  it('like and the regex predicates propagate null; regexFind is ALWAYS nullable', () => {
+    for (const fn of [like, regexContains, regexMatch] as const) {
+      expect(fn(name, constant('a%')).type).toStrictEqual(bool());
+      const viaNullable = fn(field(nullable(string()), 'ns'), constant('a'));
+      expect(viaNullable.type).toStrictEqual(nullable(bool()));
+    }
+    // regexFind returns null on NO MATCH, so it is nullable even over
+    // non-null operands (probed).
+    const found = regexFind(name, constant('b+'));
+    expect(found.type).toStrictEqual(nullable(string()));
+    expectTypeOf(found.type).toEqualTypeOf(nullable(string()));
+    // regexFindAll returns an empty array instead — plain unless operands are nullable.
+    const all = regexFindAll(name, constant('b+'));
+    expect(all.type).toStrictEqual(array(string()));
+    expectTypeOf(all.type).toEqualTypeOf(array(string()));
+  });
+});
+
+describe('reference / type / vector operators', () => {
+  const authors = rootCollection({ name: 'authors', schema: { name: string() } });
+
+  it('documentId/collectionId take reference operands only', () => {
+    const key = field(referenceType(), '__name__');
+    const refField = field(docRef(authors), 'ref');
+    expect(documentId(key)).toStrictEqual(new UnaryFunction('documentId', string(), key));
+    expect(collectionId(key).name).toBe('collectionId');
+    documentId(refField);
+    collectionId(refField);
+    // @ts-expect-error -- a string is not a reference (probed: the backend rejects it too)
+    documentId(field(string(), 'name'));
+    // A nullable/optional reference propagates.
+    const viaOptional = documentId(field(optional(docRef(authors)), 'oref'));
+    expect(viaOptional.type).toStrictEqual(nullable(string()));
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullable(string()));
+  });
+
+  it('type() observes null and returns the backend type-name vocabulary', () => {
+    const t = type(field(nullable(string()), 'ns'));
+    // Type-observing: a null VALUE yields the name 'null' — only ABSENCE
+    // propagates, so a nullable (but present) operand keeps the plain
+    // literal descriptor...
+    expect(t.type.type).toBe('const');
+    expectTypeOf(t.type).not.toEqualTypeOf(nullable(t.type));
+    // ...while an optional operand becomes nullable.
+    const viaOptional = type(field(optional(string()), 'os'));
+    expect(viaOptional.type.type).toBe('union');
+  });
+
+  it('isType lifts its literal type name into a constant operand', () => {
+    const call = isType(field(string(), 'name'), 'string');
+    expect(call).toStrictEqual(
+      new BinaryFunction('isType', bool(), field(string(), 'name'), constant('string')),
+    );
+    isType(field(double(), 'rank'), 'float64');
+    // @ts-expect-error -- an arbitrary string is not a backend type name
+    isType(field(string(), 'name'), 'varchar');
+  });
+
+  it('vector functions take vector operands only', () => {
+    const vec = field(vector(), 'vec');
+    expect(dotProduct(vec, vectorValue([1, 2]))).toStrictEqual(
+      new BinaryFunction('dotProduct', double(), vec, vectorValue([1, 2])),
+    );
+    expect(cosineDistance(vec, vec).name).toBe('cosineDistance');
+    expect(euclideanDistance(vec, vec).name).toBe('euclideanDistance');
+    expect(vectorLength(vec)).toStrictEqual(new UnaryFunction('vectorLength', int64(), vec));
+    // @ts-expect-error -- a number array field is not a vector (the tag axis at work)
+    dotProduct(vec, field(array(double()), 'nums'));
+    // @ts-expect-error -- a string is not a vector
+    vectorLength(field(string(), 'name'));
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -47,18 +47,15 @@ import { assertNever } from '../util.js';
  * public type, so `switch (expr.kind)` narrowing and `assertNever`
  * exhaustiveness keep working (a base-class-typed value would not narrow).
  */
-// The non-generic value nodes are bound to `T` through their `type` property
-// (`GeoPointValue & { type: T }`): a bare `GeoPointValue` member would belong
-// to EVERY `Expression<T>` regardless of domain — accepting a geopoint where
-// a string operand is required, and collapsing operator type inference to the
-// wide fallback. The intersection makes membership conditional on the node's
-// descriptor fitting `T`, and lets inference read the descriptor off it.
+// Value nodes (GeoPointValue / VectorValue / DocRefValue) are NOT members:
+// they are VALUES, and the one way any value becomes an expression is
+// `constant()` — `constant(geoPointValue(1, 3))`, exactly like `constant(5)`
+// (and like the official SDK's `constant(new GeoPoint(...))`). Every member
+// therefore carries `type: T` natively, which is what scopes operand domains
+// and feeds operator type inference.
 export type Expression<T extends FieldType = FieldType> =
   | Field<T>
   | Constant<T>
-  | (GeoPointValue & { type: T })
-  | (VectorValue & { type: T })
-  | (DocRefValue & { type: T })
   | NullaryFunction<T>
   | UnaryFunction<T>
   | BinaryFunction<T>
@@ -145,39 +142,36 @@ export class Constant<T extends FieldType = FieldType> extends ExpressionBase {
 }
 
 /**
- * A geopoint value. A dedicated node (not a `Constant`): a geopoint has no JS
- * representation of its own — a plain `{ latitude, longitude }` object is
- * always a **map** constant — so the coordinates are explicit and executors
- * translate by `kind` with no payload ambiguity.
+ * A geopoint VALUE (not an expression — lift it with
+ * `constant(geoPointValue(...))`). A dedicated constructor because a geopoint
+ * has no JS representation of its own: a plain `{ latitude, longitude }`
+ * object is always a **map** constant.
  */
-export class GeoPointValue extends ExpressionBase {
-  readonly kind = 'geoPointValue';
+export class GeoPointValue {
   readonly type: GeoPointType = geoPoint();
   constructor(
     readonly latitude: number,
     readonly longitude: number,
-  ) {
-    super();
-  }
+  ) {}
 }
 
 /**
- * A vector value. A dedicated node (not a `Constant`): a `number[]` is always
- * an **array** constant, so vectors are constructed explicitly.
+ * A vector VALUE (not an expression — lift it with
+ * `constant(vectorValue(...))`). A dedicated constructor because a `number[]`
+ * is always an **array** constant.
  */
-export class VectorValue extends ExpressionBase {
-  readonly kind = 'vectorValue';
+export class VectorValue {
   readonly type: VectorType = vector();
   readonly values: readonly number[];
   constructor(values: readonly number[]) {
-    super();
     this.values = [...values];
   }
 }
 
 /**
- * A document-reference value. A dedicated node (not a `Constant`), for the
- * same classification rule as {@link GeoPointValue} / {@link VectorValue}: a
+ * A document-reference VALUE (not an expression — lift it with
+ * `constant(docRefValue(...))`). A dedicated constructor for the same
+ * classification rule as {@link GeoPointValue} / {@link VectorValue}: a
  * reference's plain-JS representation (`DocRef<T>`, an id tuple) is a string
  * array — always an **array** constant — and building the wire reference
  * needs the collection context anyway, so both come explicitly. This is the
@@ -186,14 +180,12 @@ export class VectorValue extends ExpressionBase {
  * (id / relative path / full resource path — all `false`), only against a
  * reference value.
  */
-export class DocRefValue<T extends Collection = Collection> extends ExpressionBase {
-  readonly kind = 'docRefValue';
+export class DocRefValue<T extends Collection = Collection> {
   readonly type: DocRefType<T>;
   constructor(
     readonly collection: T,
     readonly id: DocRef<T>,
   ) {
-    super();
     this.type = docRef(collection);
   }
 }

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -684,8 +684,8 @@ export const greaterThanOrEqual = <L extends FieldType, R extends FieldType>(
  *
  * The logical operators need this (probed — Kleene three-valued logic:
  * `and(true, null)` is `null` while `and(false, null)` is `false`, `or` and
- * `not` mirror it), and most value functions in later slices will too. The
- * comparison operators do NOT: they are total (never null).
+ * `not` mirror it), and so do most value functions. The comparison
+ * operators do NOT: they are total (never null).
  */
 type PropagateNull<Operands extends FieldType, T extends FieldType> = [
   Extract<Operands['firestoreType'], 'null'> | Extract<Operands, Optional>,
@@ -810,7 +810,8 @@ type StringOperand = Expression<Valued<'string'>>;
 // the honest numeric domain; per-operator integer/double refinement is a
 // deferred cross-cutting item — see the expressions plan). Error edges
 // (divide by zero, ln(0), sqrt of a negative) produce backend ERROR values,
-// not null — the error channel is handled by isError/ifError (slice 5).
+// not null — observable/recoverable only through the error-channel
+// functions (isError / ifError; not implemented yet).
 
 /** A uniformly distributed random double in [0, 1), regenerated per row. */
 export const rand = (): NullaryFunction<DoubleType> => new NullaryFunction('rand', double());
@@ -1074,8 +1075,6 @@ export const stringConcat = <
 ): VariadicFunction<PropagateNull<Ops[number]['type'], StringType>> =>
   new VariadicFunction('stringConcat', propagateNull(strings, string()), strings);
 
-// ---- string (slice 3) ----
-
 /** The 0-based index of the first occurrence of `substring`, or -1 if absent. */
 export const stringIndexOf = <L extends StringOperand, R extends StringOperand>(
   value: L,
@@ -1167,7 +1166,8 @@ export const like = <L extends StringOperand, R extends StringOperand>(
   new BinaryFunction('like', propagateNull([value, pattern], bool()), value, pattern);
 
 // ---- regex ----
-// An invalid pattern is a backend ERROR value (isError/ifError, slice 5).
+// An invalid pattern is a backend ERROR value (see the error-channel note
+// on the arithmetic section).
 
 /** Whether `value` contains a match of the RE2 `pattern`. */
 export const regexContains = <L extends StringOperand, R extends StringOperand>(

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -738,7 +738,6 @@ const mayBeNull = (t: FieldType & { optional?: boolean }): boolean => {
     case 'bytes':
     case 'geoPoint':
     case 'vector':
-    case 'reference':
     case 'map':
     case 'array':
       return false;

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -13,6 +13,8 @@ import {
   type GeoPointType,
   int64,
   type Int64Type,
+  literal,
+  type LiteralType,
   map,
   type MapType,
   nullable,
@@ -49,6 +51,7 @@ export type Expression<T extends FieldType = FieldType> =
   | NullaryFunction<T>
   | UnaryFunction<T>
   | BinaryFunction<T>
+  | TernaryFunction<T>
   | VariadicFunction<T>;
 
 /**
@@ -401,7 +404,11 @@ export type UnaryFunctionName =
   | 'stringReverse'
   | 'trim'
   | 'ltrim'
-  | 'rtrim';
+  | 'rtrim'
+  | 'documentId'
+  | 'collectionId'
+  | 'type'
+  | 'vectorLength';
 
 /** A function call with exactly two operands. */
 export class BinaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -435,7 +442,34 @@ export type BinaryFunctionName =
   | 'rtrim'
   | 'startsWith'
   | 'endsWith'
-  | 'stringContains';
+  | 'stringContains'
+  | 'stringIndexOf'
+  | 'stringRepeat'
+  | 'substring'
+  | 'like'
+  | 'regexContains'
+  | 'regexMatch'
+  | 'regexFind'
+  | 'regexFindAll'
+  | 'isType'
+  | 'cosineDistance'
+  | 'dotProduct'
+  | 'euclideanDistance';
+
+/** A function call with exactly three operands. */
+export class TernaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'ternaryFunction';
+  constructor(
+    readonly name: TernaryFunctionName,
+    readonly type: T,
+    readonly first: Expression,
+    readonly second: Expression,
+    readonly third: Expression,
+  ) {
+    super();
+  }
+}
+export type TernaryFunctionName = 'stringReplaceAll' | 'stringReplaceOne' | 'substring';
 
 /** A function call with two or more uniform operands. */
 export class VariadicFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -660,6 +694,7 @@ const mayBeNull = (t: FieldType & { optional?: boolean }): boolean => {
     case 'bytes':
     case 'geoPoint':
     case 'vector':
+    case 'reference':
     case 'map':
     case 'array':
       return false;
@@ -667,6 +702,30 @@ const mayBeNull = (t: FieldType & { optional?: boolean }): boolean => {
       return assertNever(t);
   }
 };
+
+/**
+ * Absence-only variant of {@link PropagateNull}, for the TYPE-OBSERVING
+ * functions (`type` / `isType`): probed, a `null` VALUE is observed as the
+ * `'null'` type (not propagated), while an ABSENT operand still nulls the
+ * result — so only the `Optional` marker triggers the nullable widening.
+ */
+type PropagateAbsence<Operands extends FieldType, T extends FieldType> = [
+  Extract<Operands, Optional>,
+] extends [never]
+  ? T
+  : UnionType<[T, NullType]>;
+
+/** Runtime counterpart of {@link PropagateAbsence} (same bridge shape as `propagateNull`). */
+function propagateAbsence<Ops extends readonly Expression[], T extends FieldType>(
+  operands: Ops,
+  type: T,
+): PropagateAbsence<Ops[number]['type'], T>;
+function propagateAbsence(operands: readonly Expression[], type: FieldType): FieldType {
+  return operands.some((operand) => mayBeAbsent(operand.type)) ? nullable(type) : type;
+}
+
+/** Runtime twin of `Extract<Operands, Optional>`: the marker only. */
+const mayBeAbsent = (t: FieldType & { optional?: boolean }): boolean => t.optional === true;
 
 /** Logical conjunction of two or more boolean expressions (Kleene: null operands propagate). */
 export const and = <
@@ -971,3 +1030,261 @@ export const stringConcat = <
   ...strings: Ops
 ): VariadicFunction<PropagateNull<Ops[number]['type'], StringType>> =>
   new VariadicFunction('stringConcat', propagateNull(strings, string()), strings);
+
+// ---- string (slice 3) ----
+
+/** The 0-based index of the first occurrence of `substring`, or -1 if absent. */
+export const stringIndexOf = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  substring: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], Int64Type>> =>
+  new BinaryFunction('stringIndexOf', propagateNull([value, substring], int64()), value, substring);
+
+/** Repeats a string `count` times. */
+export const stringRepeat = <L extends StringOperand, R extends NumericOperand>(
+  value: L,
+  count: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], StringType>> =>
+  new BinaryFunction('stringRepeat', propagateNull([value, count], string()), value, count);
+
+/** Replaces every occurrence of `find` with `replacement`. */
+export const stringReplaceAll = <
+  L extends StringOperand,
+  M extends StringOperand,
+  R extends StringOperand,
+>(
+  value: L,
+  find: M,
+  replacement: R,
+): TernaryFunction<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
+  new TernaryFunction(
+    'stringReplaceAll',
+    propagateNull([value, find, replacement], string()),
+    value,
+    find,
+    replacement,
+  );
+
+/** Replaces the first occurrence of `find` with `replacement`. */
+export const stringReplaceOne = <
+  L extends StringOperand,
+  M extends StringOperand,
+  R extends StringOperand,
+>(
+  value: L,
+  find: M,
+  replacement: R,
+): TernaryFunction<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
+  new TernaryFunction(
+    'stringReplaceOne',
+    propagateNull([value, find, replacement], string()),
+    value,
+    find,
+    replacement,
+  );
+
+/**
+ * The substring from the 0-based `position`, spanning `length` characters or
+ * (omitted) to the end of the string.
+ */
+export function substring<Op extends StringOperand, P extends NumericOperand>(
+  value: Op,
+  position: P,
+): BinaryFunction<PropagateNull<Op['type'] | P['type'], StringType>>;
+export function substring<
+  Op extends StringOperand,
+  P extends NumericOperand,
+  Len extends NumericOperand,
+>(
+  value: Op,
+  position: P,
+  length: Len,
+): TernaryFunction<PropagateNull<Op['type'] | P['type'] | Len['type'], StringType>>;
+export function substring(
+  value: Expression,
+  position: Expression,
+  length?: Expression,
+): BinaryFunction | TernaryFunction {
+  return length === undefined
+    ? new BinaryFunction('substring', propagateNull([value, position], string()), value, position)
+    : new TernaryFunction(
+        'substring',
+        propagateNull([value, position, length], string()),
+        value,
+        position,
+        length,
+      );
+}
+
+/** SQL LIKE match (`%` any sequence, `_` any single character). */
+export const like = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  pattern: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('like', propagateNull([value, pattern], bool()), value, pattern);
+
+// ---- regex ----
+// An invalid pattern is a backend ERROR value (isError/ifError, slice 5).
+
+/** Whether `value` contains a match of the RE2 `pattern`. */
+export const regexContains = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  pattern: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('regexContains', propagateNull([value, pattern], bool()), value, pattern);
+
+/** Whether `value` ENTIRELY matches the RE2 `pattern`. */
+export const regexMatch = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  pattern: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new BinaryFunction('regexMatch', propagateNull([value, pattern], bool()), value, pattern);
+
+/**
+ * The first match of the RE2 `pattern`, or `null` when there is none — the
+ * result is ALWAYS nullable (probed), independent of operand nullability.
+ */
+export const regexFind = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  pattern: R,
+): BinaryFunction<UnionType<[StringType, NullType]>> =>
+  new BinaryFunction('regexFind', nullable(string()), value, pattern);
+
+/** Every match of the RE2 `pattern` (empty array when there is none). */
+export const regexFindAll = <L extends StringOperand, R extends StringOperand>(
+  value: L,
+  pattern: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], ArrayType<StringType>>> =>
+  new BinaryFunction(
+    'regexFindAll',
+    propagateNull([value, pattern], array(string())),
+    value,
+    pattern,
+  );
+
+// ---- reference ----
+
+/** A reference-domain operand: a `docRef(...)` field or the reserved `'__name__'`. */
+type ReferenceOperand = Expression<Valued<'reference'>>;
+
+/** The document id (the path's last segment) of a reference. */
+export const documentId = <Op extends ReferenceOperand>(
+  reference: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
+  new UnaryFunction('documentId', propagateNull([reference], string()), reference);
+
+/** The id of the collection containing the referenced document. */
+export const collectionId = <Op extends ReferenceOperand>(
+  reference: Op,
+): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
+  new UnaryFunction('collectionId', propagateNull([reference], string()), reference);
+
+// ---- type ----
+
+/**
+ * The backend's type-name vocabulary (`type()` results / `isType()`'s `type`
+ * argument, per the SDK contract). Note this is the BACKEND's naming
+ * (`'int64'` / `'float64'` / `'geo_point'`), not the `firestoreType` tag
+ * axis; `'number'` matches both numeric types.
+ */
+export type FirestoreTypeName =
+  | 'null'
+  | 'boolean'
+  | 'string'
+  | 'bytes'
+  | 'number'
+  | 'int32'
+  | 'int64'
+  | 'float64'
+  | 'decimal128'
+  | 'timestamp'
+  | 'geo_point'
+  | 'reference'
+  | 'array'
+  | 'map'
+  | 'vector'
+  | 'max_key'
+  | 'min_key'
+  | 'object_id'
+  | 'regex'
+  | 'request_timestamp';
+
+/**
+ * The backend type name of the operand's value. Type-OBSERVING: a `null`
+ * value yields `'null'` (not a null result), so only ABSENCE propagates —
+ * see {@link PropagateAbsence}.
+ */
+export const type = <Op extends Expression>(
+  value: Op,
+): UnaryFunction<PropagateAbsence<Op['type'], LiteralType<FirestoreTypeName[]>>> =>
+  new UnaryFunction('type', propagateAbsence([value], typeNameLiteral()), value);
+
+/**
+ * Whether the operand's value is of the named backend type. The name must be
+ * a compile-time literal (the backend requires a constant — probed), lifted
+ * into a constant operand wire-faithfully. Type-observing like {@link type}:
+ * only absence propagates.
+ */
+export const isType = <Op extends Expression>(
+  value: Op,
+  typeName: FirestoreTypeName,
+): BinaryFunction<PropagateAbsence<Op['type'], BoolType>> =>
+  new BinaryFunction('isType', propagateAbsence([value], bool()), value, Constant.of(typeName));
+
+/** The `type()` return descriptor: the closed backend type-name vocabulary. */
+const typeNameLiteral = (): LiteralType<FirestoreTypeName[]> =>
+  literal(
+    'null',
+    'boolean',
+    'string',
+    'bytes',
+    'number',
+    'int32',
+    'int64',
+    'float64',
+    'decimal128',
+    'timestamp',
+    'geo_point',
+    'reference',
+    'array',
+    'map',
+    'vector',
+    'max_key',
+    'min_key',
+    'object_id',
+    'regex',
+    'request_timestamp',
+  );
+
+// ---- vector ----
+// Distance functions over mismatched dimensions are backend ERROR values.
+
+/** A vector-domain operand: a `vector()` field or a `vectorValue(...)` node. */
+type VectorOperand = Expression<Valued<'vector'>>;
+
+/** The cosine distance between two vectors. */
+export const cosineDistance = <L extends VectorOperand, R extends VectorOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('cosineDistance', propagateNull([left, right], double()), left, right);
+
+/** The dot product of two vectors. */
+export const dotProduct = <L extends VectorOperand, R extends VectorOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('dotProduct', propagateNull([left, right], double()), left, right);
+
+/** The euclidean distance between two vectors. */
+export const euclideanDistance = <L extends VectorOperand, R extends VectorOperand>(
+  left: L,
+  right: R,
+): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new BinaryFunction('euclideanDistance', propagateNull([left, right], double()), left, right);
+
+/** The number of dimensions of a vector. */
+export const vectorLength = <Op extends VectorOperand>(
+  vector: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('vectorLength', propagateNull([vector], int64()), vector);

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -430,8 +430,12 @@ export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBa
 // A name appearing in two shape unions (round/trunc/trim/ltrim/rtrim) is the
 // dual-arity pattern: the factory overloads to a unary and a binary form and
 // each executor table translates its own arity.
+// The name unions are ordered by function CATEGORY (matching the factory
+// sections below), not by anything historical.
 export type UnaryFunctionName =
+  // logical
   | 'not'
+  // arithmetic
   | 'abs'
   | 'ceil'
   | 'floor'
@@ -441,6 +445,7 @@ export type UnaryFunctionName =
   | 'exp'
   | 'ln'
   | 'log10'
+  // string
   | 'charLength'
   | 'byteLength'
   | 'toLower'
@@ -449,9 +454,12 @@ export type UnaryFunctionName =
   | 'trim'
   | 'ltrim'
   | 'rtrim'
+  // reference
   | 'documentId'
   | 'collectionId'
+  // type
   | 'type'
+  // vector
   | 'vectorLength';
 
 /** A function call with exactly two operands. */
@@ -467,12 +475,14 @@ export class BinaryFunction<T extends FieldType = FieldType> extends ExpressionB
   }
 }
 export type BinaryFunctionName =
+  // comparison
   | 'equal'
   | 'notEqual'
   | 'lessThan'
   | 'lessThanOrEqual'
   | 'greaterThan'
   | 'greaterThanOrEqual'
+  // arithmetic
   | 'add'
   | 'subtract'
   | 'multiply'
@@ -481,6 +491,7 @@ export type BinaryFunctionName =
   | 'pow'
   | 'round'
   | 'trunc'
+  // string
   | 'trim'
   | 'ltrim'
   | 'rtrim'
@@ -491,11 +502,14 @@ export type BinaryFunctionName =
   | 'stringRepeat'
   | 'substring'
   | 'like'
+  // regex
   | 'regexContains'
   | 'regexMatch'
   | 'regexFind'
   | 'regexFindAll'
+  // type
   | 'isType'
+  // vector
   | 'cosineDistance'
   | 'dotProduct'
   | 'euclideanDistance';
@@ -526,7 +540,12 @@ export class VariadicFunction<T extends FieldType = FieldType> extends Expressio
     super();
   }
 }
-export type VariadicFunctionName = 'and' | 'or' | 'stringConcat';
+export type VariadicFunctionName =
+  // logical
+  | 'and'
+  | 'or'
+  // string
+  | 'stringConcat';
 
 /**
  * The value-domain predicate: descriptors whose `firestoreType` tags fit the

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -1,3 +1,4 @@
+import type { DocRef } from '../repository.js';
 import {
   array,
   type ArrayType,
@@ -5,6 +6,9 @@ import {
   type BoolType,
   bytes,
   type BytesType,
+  type Collection,
+  docRef,
+  type DocRefType,
   double,
   type DoubleType,
   type FieldType,
@@ -43,11 +47,18 @@ import { assertNever } from '../util.js';
  * public type, so `switch (expr.kind)` narrowing and `assertNever`
  * exhaustiveness keep working (a base-class-typed value would not narrow).
  */
+// The non-generic value nodes are bound to `T` through their `type` property
+// (`GeoPointValue & { type: T }`): a bare `GeoPointValue` member would belong
+// to EVERY `Expression<T>` regardless of domain — accepting a geopoint where
+// a string operand is required, and collapsing operator type inference to the
+// wide fallback. The intersection makes membership conditional on the node's
+// descriptor fitting `T`, and lets inference read the descriptor off it.
 export type Expression<T extends FieldType = FieldType> =
   | Field<T>
   | Constant<T>
-  | GeoPointValue
-  | VectorValue
+  | (GeoPointValue & { type: T })
+  | (VectorValue & { type: T })
+  | (DocRefValue & { type: T })
   | NullaryFunction<T>
   | UnaryFunction<T>
   | BinaryFunction<T>
@@ -165,23 +176,50 @@ export class VectorValue extends ExpressionBase {
 }
 
 /**
+ * A document-reference value. A dedicated node (not a `Constant`), for the
+ * same classification rule as {@link GeoPointValue} / {@link VectorValue}: a
+ * reference's plain-JS representation (`DocRef<T>`, an id tuple) is a string
+ * array — always an **array** constant — and building the wire reference
+ * needs the collection context anyway, so both come explicitly. This is the
+ * comparand that makes reference comparisons meaningful: probed, the
+ * pipeline backend never matches `__name__` against ANY string form
+ * (id / relative path / full resource path — all `false`), only against a
+ * reference value.
+ */
+export class DocRefValue<T extends Collection = Collection> extends ExpressionBase {
+  readonly kind = 'docRefValue';
+  readonly type: DocRefType<T>;
+  constructor(
+    readonly collection: T,
+    readonly id: DocRef<T>,
+  ) {
+    super();
+    this.type = docRef(collection);
+  }
+}
+
+/** Builds a document-reference value — see {@link DocRefValue}. */
+export const docRefValue = <T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T> =>
+  new DocRefValue(collection, id);
+
+/**
  * The value domain `constant()` accepts — everything with an unambiguous
  * plain-JS representation: scalars, arrays and plain-object maps,
  * recursively. Firestore types WITHOUT their own JS representation get
  * explicit constructors instead — a plain object is always a **map** constant
- * (use {@link geoPointValue} for geopoints) and a `number[]` is always an
- * **array** constant (use {@link vectorValue} for vectors). Document refs
- * need collection context and stay deferred.
+ * (use {@link geoPointValue} for geopoints), a `number[]` is always an
+ * **array** constant (use {@link vectorValue} for vectors), and a `string[]`
+ * id tuple likewise (use {@link docRefValue} for document references).
  */
 export type ConstantValue = ConstantScalar | ConstantLeafNode | ConstantArray | ConstantMap;
 export type ConstantScalar = string | number | boolean | null | Date | Uint8Array;
 /**
- * Value nodes usable as composite leaves: Firestore values may hold geopoints
- * and vectors at any depth, and since those have no plain-JS representation of
- * their own, their explicit nodes stand in —
- * `constant({ spot: geoPointValue(1, 3) })`.
+ * Value nodes usable as composite leaves: Firestore values may hold
+ * geopoints, vectors, and document references at any depth, and since those
+ * have no plain-JS representation of their own, their explicit nodes stand
+ * in — `constant({ spot: geoPointValue(1, 3) })`.
  */
-export type ConstantLeafNode = GeoPointValue | VectorValue;
+export type ConstantLeafNode = GeoPointValue | VectorValue | DocRefValue;
 /**
  * Non-empty (an empty literal has no element to infer a descriptor from) and
  * non-nested: directly nested arrays (`constant([1, [2, 3]])`) are excluded
@@ -207,21 +245,23 @@ export type ConstantTypeOf<V extends ConstantValue> = ConstantValue extends V
       ? TimestampType
       : V extends Uint8Array
         ? BytesType
-        : V extends GeoPointValue
-          ? GeoPointType
-          : V extends VectorValue
-            ? VectorType
-            : V extends string
-              ? StringType
-              : V extends number
-                ? DoubleType
-                : V extends boolean
-                  ? BoolType
-                  : V extends ConstantArray
-                    ? ArrayConstantTypeOf<V>
-                    : V extends ConstantMap
-                      ? MapType<{ -readonly [K in keyof V & string]: ConstantTypeOf<V[K]> }>
-                      : never;
+        : V extends DocRefValue<infer C>
+          ? DocRefType<C>
+          : V extends GeoPointValue
+            ? GeoPointType
+            : V extends VectorValue
+              ? VectorType
+              : V extends string
+                ? StringType
+                : V extends number
+                  ? DoubleType
+                  : V extends boolean
+                    ? BoolType
+                    : V extends ConstantArray
+                      ? ArrayConstantTypeOf<V>
+                      : V extends ConstantMap
+                        ? MapType<{ -readonly [K in keyof V & string]: ConstantTypeOf<V[K]> }>
+                        : never;
 
 /**
  * The element descriptor is derived by walking the TUPLE (not the union of
@@ -278,7 +318,11 @@ function constantTypeOf(value: ConstantValue): FieldType {
   if (value instanceof Uint8Array) {
     return bytes();
   }
-  if (value instanceof GeoPointValue || value instanceof VectorValue) {
+  if (
+    value instanceof GeoPointValue ||
+    value instanceof VectorValue ||
+    value instanceof DocRefValue
+  ) {
     return value.type;
   }
   if (isConstantArray(value)) {

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../__test__/specification.js';
 import type { DocRef } from '../repository.js';
 import type { StringType } from '../schema.js';
-import { equal } from './expression.js';
+import { documentId, equal } from './expression.js';
 import { collection, type Pipeline, type PipelineResult } from './index.js';
 import { asc } from './ordering.js';
 
@@ -88,7 +88,12 @@ describe('pipeline', () => {
     base.removeFields('__name__');
     base.removeFields('name'); // real data field: ok
 
-    // `__name__` stays usable in `where` (goes through `FieldProvider`, not `Selection`)
+    // `__name__` stays usable in `where` (goes through `FieldProvider`, not
+    // `Selection`). Its value is a REFERENCE (probed: type(__name__) is
+    // "reference"), so it does not compare against strings directly —
+    // documentId() bridges it into the string domain.
+    base.where((field) => equal(documentId(field('__name__')), field('name')));
+    // @ts-expect-error -- a reference does not compare against a string field
     base.where((field) => equal(field('__name__'), field('name')));
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -286,9 +286,6 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'field':
       return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
     case 'constant':
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -288,6 +288,7 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -291,6 +291,7 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
+    case 'ternaryFunction':
     case 'variadicFunction':
       return pathToSchema(alias, expression.type);
     default:

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -34,6 +34,8 @@ import {
   optional,
   type Optional,
   type PickPaths,
+  referenceType,
+  type ReferenceType,
   rootCollection,
   subCollection,
   ServerTimestamp,
@@ -405,7 +407,7 @@ describe('document', () => {
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optional'>>().toExtend<LiteralType<['foo', 'bar']>>();
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optionalMap.f'>>().toEqualTypeOf<StringType>();
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optionalMap.g'>>().toExtend<Int64Type>();
-    expectTypeOf<FieldTypeOfPath<Schema, '__name__'>>().toEqualTypeOf<StringType>();
+    expectTypeOf<FieldTypeOfPath<Schema, '__name__'>>().toEqualTypeOf<ReferenceType>();
   });
 
   // Comprehensive runtime tests for `fieldTypeOfPath` — its return type is bridged
@@ -472,9 +474,9 @@ describe('document', () => {
       expectTypeOf(fieldTypeOfPath(s, 'om.z')).toEqualTypeOf<StringType>();
     });
 
-    it('resolves the reserved __name__ to a StringType', () => {
-      expect(fieldTypeOfPath(schema, '__name__')).toStrictEqual(string());
-      expectTypeOf(fieldTypeOfPath(schema, '__name__')).toEqualTypeOf<StringType>();
+    it('resolves the reserved __name__ to the reference pseudo-descriptor', () => {
+      expect(fieldTypeOfPath(schema, '__name__')).toStrictEqual(referenceType());
+      expectTypeOf(fieldTypeOfPath(schema, '__name__')).toEqualTypeOf<ReferenceType>();
     });
 
     it('throws for a path that does not exist at runtime (defensive guard)', () => {

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -10,6 +10,7 @@ import {
   bytes,
   docRef,
   double,
+  type DocRefType,
   type DoubleType,
   type DocumentSchema,
   type DocFieldPath,
@@ -34,8 +35,6 @@ import {
   optional,
   type Optional,
   type PickPaths,
-  referenceType,
-  type ReferenceType,
   rootCollection,
   subCollection,
   ServerTimestamp,
@@ -407,7 +406,7 @@ describe('document', () => {
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optional'>>().toExtend<LiteralType<['foo', 'bar']>>();
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optionalMap.f'>>().toEqualTypeOf<StringType>();
     expectTypeOf<FieldTypeOfPath<Schema, 'b.optionalMap.g'>>().toExtend<Int64Type>();
-    expectTypeOf<FieldTypeOfPath<Schema, '__name__'>>().toEqualTypeOf<ReferenceType>();
+    expectTypeOf<FieldTypeOfPath<Schema, '__name__'>>().toEqualTypeOf<DocRefType<'unknown'>>();
   });
 
   // Comprehensive runtime tests for `fieldTypeOfPath` — its return type is bridged
@@ -474,9 +473,9 @@ describe('document', () => {
       expectTypeOf(fieldTypeOfPath(s, 'om.z')).toEqualTypeOf<StringType>();
     });
 
-    it('resolves the reserved __name__ to the reference pseudo-descriptor', () => {
-      expect(fieldTypeOfPath(schema, '__name__')).toStrictEqual(referenceType());
-      expectTypeOf(fieldTypeOfPath(schema, '__name__')).toEqualTypeOf<ReferenceType>();
+    it('resolves the reserved __name__ to the context-free reference descriptor', () => {
+      expect(fieldTypeOfPath(schema, '__name__')).toStrictEqual(docRef());
+      expectTypeOf(fieldTypeOfPath(schema, '__name__')).toEqualTypeOf<DocRefType<'unknown'>>();
     });
 
     it('throws for a path that does not exist at runtime (defensive guard)', () => {

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -96,6 +96,12 @@ describe('schema', () => {
       expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<DocRef<TestCollection>>();
     });
 
+    it('docRef (context-free flavor): relative path strings both ways', () => {
+      const type = docRef();
+      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<string>();
+      expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<string>();
+    });
+
     it('bytes', () => {
       const type = bytes();
       expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<Uint8Array>();

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -115,12 +115,11 @@ export type FieldType =
   | Int64Type
   | DoubleType
   | TimestampType
-  | DocRefType<Collection>
+  | DocRefType
   | BytesType
   | GeoPointType
   | VectorType
   | NullType
-  | ReferenceType
   | AnyMapType
   | AnyArrayType
   | AnyUnionType
@@ -151,12 +150,28 @@ export type TimestampType = {
   input: Date | ServerTimestamp;
   output: Date;
 };
-export type DocRefType<T extends Collection> = {
+/**
+ * A document-reference descriptor. `T` is the referenced collection when the
+ * schema knows it (a `docRef(collection)` data field), or the `'unknown'`
+ * sentinel when it does not — the reserved `'__name__'` key resolves to
+ * `DocRefType<'unknown'>` (probed: `type(__name__)` is `"reference"`, and
+ * reference-domain functions accept it while rejecting strings). The sentinel
+ * is a visible plain value, like the `Optional` marker, rather than
+ * `undefined` ("the collection is unknown", not "there is no collection").
+ *
+ * The value representation follows the context: a known collection
+ * round-trips `DocRef<T>` id tuples, while a context-free reference is never
+ * writable (`input: never`) and reads as its relative path string — also the
+ * core query API's id-filter contract (`where(eq('__name__', id))`).
+ * Pipeline operator compatibility keys on the shared `'reference'` tag, so
+ * both flavors compare with each other and with `docRefValue(...)` constants.
+ */
+export type DocRefType<T extends Collection | 'unknown' = Collection | 'unknown'> = {
   type: 'docRef';
   firestoreType: 'reference';
   collection: T;
-  input: DocRef<T>;
-  output: DocRef<T>;
+  input: T extends Collection ? DocRef<T> : never;
+  output: T extends Collection ? DocRef<T> : string;
 };
 export type BytesType = {
   type: 'bytes';
@@ -177,26 +192,6 @@ export type VectorType = {
   output: number[];
 };
 export type NullType = { type: 'null'; firestoreType: 'null'; input: null; output: null };
-/**
- * A bare document reference with no schema-known collection — the descriptor
- * of the reserved `'__name__'` key (probed: `type(__name__)` is
- * `"reference"`, and reference-domain functions like `documentId` accept it
- * while rejecting strings). NOT a schema factory: schema data fields with a
- * known collection use {@link DocRefType}; this descriptor exists for
- * expression and filter contexts only — it is never writable
- * (`input: never`) nor decodable as document data (the codecs reject it).
- * Its `output` is `string`: the core query API filters the key against plain
- * document-id strings (`where(eq('__name__', id))`), and `output` is the
- * axis filter operands are typed from. Pipeline operator compatibility keys
- * on the `firestoreType` tag instead, where `'reference'` keeps it apart
- * from genuine strings.
- */
-export type ReferenceType = {
-  type: 'reference';
-  firestoreType: 'reference';
-  input: never;
-  output: string;
-};
 /**
  * The widest map/array/union descriptors — the recursive members of the
  * closed {@link FieldType} union. Each concrete `MapType<T>` /
@@ -365,8 +360,12 @@ export const string = (): StringType => buildType({ type: 'string' });
 export const int64 = (): Int64Type => buildType({ type: 'int64' });
 export const double = (): DoubleType => buildType({ type: 'double' });
 export const timestamp = (): TimestampType => buildType({ type: 'timestamp' });
-export const docRef = <T extends Collection>(collection: T): DocRefType<T> =>
-  buildType({ type: 'docRef', collection });
+export function docRef<T extends Collection>(collection: T): DocRefType<T>;
+/** The context-free flavor — the `'__name__'` pseudo-descriptor; not for schema data fields. */
+export function docRef(): DocRefType<'unknown'>;
+export function docRef(collection?: Collection): FieldType {
+  return buildType<DocRefType>({ type: 'docRef', collection: collection ?? 'unknown' });
+}
 export const bytes = (): BytesType => buildType({ type: 'bytes' });
 export const geoPoint = (): GeoPointType => buildType({ type: 'geoPoint' });
 export const vector = (): VectorType => buildType({ type: 'vector' });
@@ -379,8 +378,6 @@ export const array = <T extends FieldType>(elementType: T): ArrayType<T> =>
 export const union = <T extends FieldType[]>(...elements: T): UnionType<T> =>
   buildType({ type: 'union', elements });
 export const nullType = (): NullType => buildType({ type: 'null' });
-/** Builds the `'__name__'` pseudo-descriptor — see {@link ReferenceType}; not for schemas. */
-export const referenceType = (): ReferenceType => buildType({ type: 'reference' });
 
 export const literal = <const T extends (string | number | boolean | null)[]>(
   ...values: T
@@ -444,13 +441,13 @@ export type FieldTypeOfPath<T extends DocumentSchema, U extends DocFieldPath<T>>
         : never
       : never
     : U extends '__name__'
-      ? ReferenceType
+      ? DocRefType<'unknown'>
       : never;
 
 /**
  * Runtime counterpart of {@link FieldTypeOfPath}: resolves the `FieldType`
  * descriptor stored in `schema` at `path` (dotted for nested maps; `'__name__'`
- * resolves to a `ReferenceType`, mirroring the type).
+ * resolves to a context-free `DocRefType<'unknown'>`, mirroring the type).
  */
 export const fieldTypeOfPath = <T extends DocumentSchema, U extends DocFieldPath<T>>(
   schema: T,
@@ -459,7 +456,7 @@ export const fieldTypeOfPath = <T extends DocumentSchema, U extends DocFieldPath
   const dot = path.indexOf('.');
   let resolved: FieldType;
   if (path === '__name__') {
-    resolved = referenceType();
+    resolved = docRef();
   } else if (dot < 0) {
     resolved = requireField(schema, path);
   } else {

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -120,6 +120,7 @@ export type FieldType =
   | GeoPointType
   | VectorType
   | NullType
+  | ReferenceType
   | AnyMapType
   | AnyArrayType
   | AnyUnionType
@@ -176,6 +177,26 @@ export type VectorType = {
   output: number[];
 };
 export type NullType = { type: 'null'; firestoreType: 'null'; input: null; output: null };
+/**
+ * A bare document reference with no schema-known collection — the descriptor
+ * of the reserved `'__name__'` key (probed: `type(__name__)` is
+ * `"reference"`, and reference-domain functions like `documentId` accept it
+ * while rejecting strings). NOT a schema factory: schema data fields with a
+ * known collection use {@link DocRefType}; this descriptor exists for
+ * expression and filter contexts only — it is never writable
+ * (`input: never`) nor decodable as document data (the codecs reject it).
+ * Its `output` is `string`: the core query API filters the key against plain
+ * document-id strings (`where(eq('__name__', id))`), and `output` is the
+ * axis filter operands are typed from. Pipeline operator compatibility keys
+ * on the `firestoreType` tag instead, where `'reference'` keeps it apart
+ * from genuine strings.
+ */
+export type ReferenceType = {
+  type: 'reference';
+  firestoreType: 'reference';
+  input: never;
+  output: string;
+};
 /**
  * The widest map/array/union descriptors — the recursive members of the
  * closed {@link FieldType} union. Each concrete `MapType<T>` /
@@ -358,6 +379,8 @@ export const array = <T extends FieldType>(elementType: T): ArrayType<T> =>
 export const union = <T extends FieldType[]>(...elements: T): UnionType<T> =>
   buildType({ type: 'union', elements });
 export const nullType = (): NullType => buildType({ type: 'null' });
+/** Builds the `'__name__'` pseudo-descriptor — see {@link ReferenceType}; not for schemas. */
+export const referenceType = (): ReferenceType => buildType({ type: 'reference' });
 
 export const literal = <const T extends (string | number | boolean | null)[]>(
   ...values: T
@@ -421,13 +444,13 @@ export type FieldTypeOfPath<T extends DocumentSchema, U extends DocFieldPath<T>>
         : never
       : never
     : U extends '__name__'
-      ? StringType
+      ? ReferenceType
       : never;
 
 /**
  * Runtime counterpart of {@link FieldTypeOfPath}: resolves the `FieldType`
  * descriptor stored in `schema` at `path` (dotted for nested maps; `'__name__'`
- * resolves to a `StringType`, mirroring the type).
+ * resolves to a `ReferenceType`, mirroring the type).
  */
 export const fieldTypeOfPath = <T extends DocumentSchema, U extends DocFieldPath<T>>(
   schema: T,
@@ -436,7 +459,7 @@ export const fieldTypeOfPath = <T extends DocumentSchema, U extends DocFieldPath
   const dot = path.indexOf('.');
   let resolved: FieldType;
   if (path === '__name__') {
-    resolved = string();
+    resolved = referenceType();
   } else if (dot < 0) {
     resolved = requireField(schema, path);
   } else {

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -161,11 +161,17 @@ export type TimestampType = {
  *
  * The value representation follows the context: a known collection
  * round-trips `DocRef<T>` id tuples, while the context-free flavor reads AND
- * writes relative path strings (`'authors/a1'`) — the one reference
- * representation that needs no collection context, and also the core query
- * API's id-filter contract (`where(eq('__name__', id))`). Pipeline operator
- * compatibility keys on the shared `'reference'` tag, so both flavors
- * compare with each other and with `docRefValue(...)` constants.
+ * writes relative path strings (`'authors/a1'`). NOT a `string[]`: a
+ * `DocRef` tuple holds ONLY ids (`['authorId', 'postId']` — the collection
+ * names live in the schema and `documentPath` interleaves them), so a
+ * context-free array would have to carry path SEGMENTS
+ * (`['authors', 'a1']`) — a same-typed but differently-meaning shape,
+ * indistinguishable from an id tuple in TS. The path string avoids that
+ * collision, is the ecosystem's own context-free form (`ref.path` /
+ * `db.doc(path)`), and is the core query API's id-filter contract
+ * (`where(eq('__name__', id))`). Pipeline operator compatibility keys on the
+ * shared `'reference'` tag, so both flavors compare with each other and
+ * with `docRefValue(...)` constants.
  */
 export type DocRefType<T extends Collection | 'unknown' = Collection | 'unknown'> = {
   type: 'docRef';

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -160,17 +160,18 @@ export type TimestampType = {
  * `undefined` ("the collection is unknown", not "there is no collection").
  *
  * The value representation follows the context: a known collection
- * round-trips `DocRef<T>` id tuples, while a context-free reference is never
- * writable (`input: never`) and reads as its relative path string — also the
- * core query API's id-filter contract (`where(eq('__name__', id))`).
- * Pipeline operator compatibility keys on the shared `'reference'` tag, so
- * both flavors compare with each other and with `docRefValue(...)` constants.
+ * round-trips `DocRef<T>` id tuples, while the context-free flavor reads AND
+ * writes relative path strings (`'authors/a1'`) — the one reference
+ * representation that needs no collection context, and also the core query
+ * API's id-filter contract (`where(eq('__name__', id))`). Pipeline operator
+ * compatibility keys on the shared `'reference'` tag, so both flavors
+ * compare with each other and with `docRefValue(...)` constants.
  */
 export type DocRefType<T extends Collection | 'unknown' = Collection | 'unknown'> = {
   type: 'docRef';
   firestoreType: 'reference';
   collection: T;
-  input: T extends Collection ? DocRef<T> : never;
+  input: T extends Collection ? DocRef<T> : string;
   output: T extends Collection ? DocRef<T> : string;
 };
 export type BytesType = {
@@ -361,7 +362,11 @@ export const int64 = (): Int64Type => buildType({ type: 'int64' });
 export const double = (): DoubleType => buildType({ type: 'double' });
 export const timestamp = (): TimestampType => buildType({ type: 'timestamp' });
 export function docRef<T extends Collection>(collection: T): DocRefType<T>;
-/** The context-free flavor — the `'__name__'` pseudo-descriptor; not for schema data fields. */
+/**
+ * The context-free flavor: a reference to no one particular collection —
+ * usable as a schema data field (round-tripping relative path strings), and
+ * the descriptor the reserved `'__name__'` resolves to.
+ */
 export function docRef(): DocRefType<'unknown'>;
 export function docRef(collection?: Collection): FieldType {
   return buildType<DocRefType>({ type: 'docRef', collection: collection ?? 'unknown' });

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -39,15 +39,6 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
-    case 'reference':
-      // The '__name__' pseudo-descriptor: a projected raw key decodes to its
-      // relative path string — the context-free representation its `output`
-      // declares (there is no schema-known collection to build a DocRef id
-      // tuple from).
-      return z
-        .unknown()
-        .refine(isDocumentReference)
-        .transform((ref) => ref.path);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -69,6 +60,16 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
         .refine(isVectorValue)
         .transform((vv) => vv.toArray());
     case 'docRef':
+      if (fieldType.collection === 'unknown') {
+        // The context-free flavor (the '__name__' pseudo-descriptor): with no
+        // schema-known collection to build a DocRef id tuple from, a
+        // projected raw key decodes to its relative path string — the
+        // representation its `output` declares.
+        return z
+          .unknown()
+          .refine(isDocumentReference)
+          .transform((ref) => ref.path);
+      }
       return z
         .unknown()
         .refine(isDocumentReference)
@@ -124,9 +125,6 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
   switch (fieldType.type) {
     case 'string':
       return z.string();
-    case 'reference':
-      // The '__name__' pseudo-descriptor is never writable (input: never).
-      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'null':
@@ -157,9 +155,14 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
           .transform(() => FieldValue.serverTimestamp()),
       ]);
     case 'docRef': {
+      if (fieldType.collection === 'unknown') {
+        // The context-free flavor is never writable (input: never).
+        throw new Error('unsupported schema field type: context-free docRef');
+      }
+      const { collection } = fieldType;
       return z.array(z.string()).transform((ref) =>
         // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        db.doc(documentPath(fieldType.collection, ref as DocRef<Collection>)),
+        db.doc(documentPath(collection, ref as DocRef<Collection>)),
       );
     }
     case 'map': {

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -40,9 +40,14 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
     case 'string':
       return z.string();
     case 'reference':
-      // The '__name__' pseudo-descriptor — an expression-context type that
-      // never appears in document data.
-      throw new Error(`unsupported schema field type: ${fieldType.type}`);
+      // The '__name__' pseudo-descriptor: a projected raw key decodes to its
+      // relative path string — the context-free representation its `output`
+      // declares (there is no schema-known collection to build a DocRef id
+      // tuple from).
+      return z
+        .unknown()
+        .refine(isDocumentReference)
+        .transform((ref) => ref.path);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -120,8 +125,7 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
     case 'string':
       return z.string();
     case 'reference':
-      // The '__name__' pseudo-descriptor — an expression-context type that
-      // never appears in document data.
+      // The '__name__' pseudo-descriptor is never writable (input: never).
       throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -156,8 +156,9 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
       ]);
     case 'docRef': {
       if (fieldType.collection === 'unknown') {
-        // The context-free flavor is never writable (input: never).
-        throw new Error('unsupported schema field type: context-free docRef');
+        // The context-free flavor writes a relative path string — the one
+        // reference representation that needs no collection context.
+        return z.string().transform((path) => db.doc(path));
       }
       const { collection } = fieldType;
       return z.array(z.string()).transform((ref) =>

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -39,6 +39,10 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
   switch (fieldType.type) {
     case 'string':
       return z.string();
+    case 'reference':
+      // The '__name__' pseudo-descriptor — an expression-context type that
+      // never appears in document data.
+      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'int64':
@@ -115,6 +119,10 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
   switch (fieldType.type) {
     case 'string':
       return z.string();
+    case 'reference':
+      // The '__name__' pseudo-descriptor — an expression-context type that
+      // never appears in document data.
+      throw new Error(`unsupported schema field type: ${fieldType.type}`);
     case 'bool':
       return z.boolean();
     case 'null':

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -8,7 +8,9 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type BinaryFunction,
   type NullaryFunctionName,
+  type TernaryFunctionName,
   UnaryFunctionName,
   VariadicFunctionName,
 } from 'firestore-repository/pipelines/expression';
@@ -157,6 +159,13 @@ const toSdkExpression = (expression: Expression): Pipelines.Expression => {
       return binaryFns[expression.name](
         toSdkExpression(expression.left),
         toSdkExpression(expression.right),
+        expression,
+      );
+    case 'ternaryFunction':
+      return ternaryFns[expression.name](
+        toSdkExpression(expression.first),
+        toSdkExpression(expression.second),
+        toSdkExpression(expression.third),
       );
     case 'variadicFunction': {
       const [first, second, ...rest] = expression.operands;
@@ -249,11 +258,18 @@ const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines
   trim: Pipelines.trim,
   ltrim: (o) => o.ltrim(),
   rtrim: (o) => o.rtrim(),
+  documentId: Pipelines.documentId,
+  collectionId: Pipelines.collectionId,
+  type: Pipelines.type,
+  vectorLength: Pipelines.vectorLength,
 };
 
+// Entries receive the raw AST node too: functions with backend-mandated
+// LITERAL arguments (isType's type name) must hand the SDK helper the plain
+// string, which is unrecoverable from the translated constant expression.
 const binaryFns: Record<
   BinaryFunctionName,
-  (l: Pipelines.Expression, r: Pipelines.Expression) => Pipelines.Expression
+  (l: Pipelines.Expression, r: Pipelines.Expression, node: BinaryFunction) => Pipelines.Expression
 > = {
   equal: Pipelines.equal,
   notEqual: Pipelines.notEqual,
@@ -275,6 +291,62 @@ const binaryFns: Record<
   startsWith: Pipelines.startsWith,
   endsWith: Pipelines.endsWith,
   stringContains: Pipelines.stringContains,
+  // stringIndexOf/stringRepeat (and the ternary stringReplace* below) exist
+  // at runtime but the SDK's namespace typings only declare their fluent
+  // forms — translate through those.
+  stringIndexOf: (l, r) => l.stringIndexOf(r),
+  stringRepeat: (l, r) => l.stringRepeat(r),
+  substring: (l, r) => Pipelines.substring(l, r),
+  like: Pipelines.like,
+  regexContains: Pipelines.regexContains,
+  regexMatch: Pipelines.regexMatch,
+  regexFind: Pipelines.regexFind,
+  regexFindAll: Pipelines.regexFindAll,
+  isType: (l, _r, node) => Pipelines.isType(l, literalStringOperand(node.right)),
+  cosineDistance: Pipelines.cosineDistance,
+  dotProduct: Pipelines.dotProduct,
+  euclideanDistance: Pipelines.euclideanDistance,
+};
+
+const ternaryFns: Record<
+  TernaryFunctionName,
+  (
+    a: Pipelines.Expression,
+    b: Pipelines.Expression,
+    c: Pipelines.Expression,
+  ) => Pipelines.Expression
+> = {
+  stringReplaceAll: (a, b, c) => a.stringReplaceAll(b, c),
+  stringReplaceOne: (a, b, c) => a.stringReplaceOne(b, c),
+  substring: Pipelines.substring,
+};
+
+/**
+ * Recovers the literal string a factory lifted into a constant operand
+ * (e.g. `isType`'s type name): the backend requires the wire argument to be
+ * a constant, and the SDK helper takes it as a plain string.
+ */
+const literalStringOperand = (operand: Expression): string => {
+  switch (operand.kind) {
+    case 'constant': {
+      const { value } = operand;
+      if (typeof value === 'string') {
+        return value;
+      }
+      throw new Error('expected a literal string constant operand');
+    }
+    case 'field':
+    case 'geoPointValue':
+    case 'vectorValue':
+    case 'nullaryFunction':
+    case 'unaryFunction':
+    case 'binaryFunction':
+    case 'ternaryFunction':
+    case 'variadicFunction':
+      throw new Error(`expected a constant operand, got ${operand.kind}`);
+    default:
+      return assertNever(operand);
+  }
 };
 
 const variadicFns: Record<
@@ -305,6 +377,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
+    case 'ternaryFunction':
     case 'variadicFunction':
       throw new Error(
         'google-cloud pipeline executor: only field orderings are supported in sort yet',

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -156,12 +156,6 @@ const toSdkExpression = (db: Firestore, expression: Expression): Pipelines.Expre
       return Pipelines.field(expression.path);
     case 'constant':
       return toSdkConstant(db, expression.value);
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
-      // Value nodes also appear as constant-composite leaves; toSdkConstant
-      // is the single home for their translation.
-      return toSdkConstant(db, expression);
     case 'nullaryFunction':
       return nullaryFns[expression.name]();
     case 'unaryFunction':
@@ -350,9 +344,6 @@ const literalStringOperand = (operand: Expression): string => {
       throw new Error('expected a literal string constant operand');
     }
     case 'field':
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
@@ -387,9 +378,6 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'geoPointValue':
-    case 'vectorValue':
-    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -1,10 +1,11 @@
 import { FieldValue, type Firestore, GeoPoint, Pipelines } from '@google-cloud/firestore';
-import { collectionPath } from 'firestore-repository/path';
+import { collectionPath, documentPath } from 'firestore-repository/path';
 import {
   type BinaryFunctionName,
   type Constant,
   type ConstantArray,
   type Expression,
+  DocRefValue,
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
@@ -62,7 +63,7 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
         return assertNever(input);
     }
     for (const stage of transforms) {
-      sdk = applyStage(sdk, stage);
+      sdk = applyStage(db, sdk, stage);
     }
 
     const { fromFirestore } = buildFirestoreUtilities(db, collection);
@@ -80,14 +81,18 @@ export const executor = (db: Firestore): PipelineQueryExecutor => {
   return { execute };
 };
 
-const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.Pipeline => {
+const applyStage = (
+  db: Firestore,
+  sdk: Pipelines.Pipeline,
+  stage: TransformStage,
+): Pipelines.Pipeline => {
   switch (stage.kind) {
     case 'sort': {
       const [first, ...rest] = stage.orderings.map(toSdkOrdering);
       return first === undefined ? sdk : sdk.sort(first, ...rest);
     }
     case 'select': {
-      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      const [first, ...rest] = stage.selections.map((selection) => toSdkSelectable(db, selection));
       if (first === undefined) {
         throw new Error('google-cloud pipeline executor: select requires at least one selection');
       }
@@ -101,7 +106,7 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
       return sdk.removeFields(first, ...rest);
     }
     case 'addFields': {
-      const [first, ...rest] = stage.selections.map(toSdkSelectable);
+      const [first, ...rest] = stage.selections.map((selection) => toSdkSelectable(db, selection));
       if (first === undefined) {
         throw new Error('google-cloud pipeline executor: addFields requires at least one field');
       }
@@ -110,7 +115,7 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
-      return sdk.where(toSdkExpression(stage.condition).asBoolean());
+      return sdk.where(toSdkExpression(db, stage.condition).asBoolean());
     case 'limit':
       return sdk.limit(stage.limit);
     case 'offset':
@@ -136,43 +141,49 @@ const applyStage = (sdk: Pipelines.Pipeline, stage: TransformStage): Pipelines.P
  * with its own path as the alias — the same wire proto as the SDK's string
  * handling for `select`, in the form `addFields` also accepts.
  */
-const toSdkSelectable = (s: string | ExpressionWithAlias): Pipelines.Selectable =>
-  typeof s === 'string' ? Pipelines.field(s) : toSdkExpression(s.expression).as(s.alias);
+const toSdkSelectable = (db: Firestore, s: string | ExpressionWithAlias): Pipelines.Selectable =>
+  typeof s === 'string' ? Pipelines.field(s) : toSdkExpression(db, s.expression).as(s.alias);
 
-/** Translates the repository expression AST into an SDK expression. */
-const toSdkExpression = (expression: Expression): Pipelines.Expression => {
+/**
+ * Translates the repository expression AST into an SDK expression. Threads
+ * `db` for the one value kind whose SDK form needs it: a document-reference
+ * constant is built via `db.doc(...)` (the codec's `buildEncodeField`
+ * precedent).
+ */
+const toSdkExpression = (db: Firestore, expression: Expression): Pipelines.Expression => {
   switch (expression.kind) {
     case 'field':
       return Pipelines.field(expression.path);
     case 'constant':
-      return toSdkConstant(expression.value);
+      return toSdkConstant(db, expression.value);
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
       // Value nodes also appear as constant-composite leaves; toSdkConstant
       // is the single home for their translation.
-      return toSdkConstant(expression);
+      return toSdkConstant(db, expression);
     case 'nullaryFunction':
       return nullaryFns[expression.name]();
     case 'unaryFunction':
-      return unaryFns[expression.name](toSdkExpression(expression.operand));
+      return unaryFns[expression.name](toSdkExpression(db, expression.operand));
     case 'binaryFunction':
       return binaryFns[expression.name](
-        toSdkExpression(expression.left),
-        toSdkExpression(expression.right),
+        toSdkExpression(db, expression.left),
+        toSdkExpression(db, expression.right),
         expression,
       );
     case 'ternaryFunction':
       return ternaryFns[expression.name](
-        toSdkExpression(expression.first),
-        toSdkExpression(expression.second),
-        toSdkExpression(expression.third),
+        toSdkExpression(db, expression.first),
+        toSdkExpression(db, expression.second),
+        toSdkExpression(db, expression.third),
       );
     case 'variadicFunction': {
       const [first, second, ...rest] = expression.operands;
       return variadicFns[expression.name](
-        toSdkExpression(first),
-        toSdkExpression(second),
-        ...rest.map(toSdkExpression),
+        toSdkExpression(db, first),
+        toSdkExpression(db, second),
+        ...rest.map((operand) => toSdkExpression(db, operand)),
       );
     }
     default:
@@ -187,7 +198,7 @@ const toSdkExpression = (expression: Expression): Pipelines.Expression => {
  * and vectors are dedicated nodes, so an array is always an array constant
  * and a plain object always a map constant.
  */
-const toSdkConstant = (value: Constant['value']): Pipelines.Expression => {
+const toSdkConstant = (db: Firestore, value: Constant['value']): Pipelines.Expression => {
   if (value === null) {
     return Pipelines.constant(null);
   }
@@ -203,8 +214,11 @@ const toSdkConstant = (value: Constant['value']): Pipelines.Expression => {
   if (value instanceof VectorValue) {
     return Pipelines.constant(FieldValue.vector([...value.values]));
   }
+  if (value instanceof DocRefValue) {
+    return Pipelines.constant(db.doc(documentPath(value.collection, value.id)));
+  }
   if (isConstantArrayValue(value)) {
-    return Pipelines.array(value.map(toSdkConstant));
+    return Pipelines.array(value.map((element) => toSdkConstant(db, element)));
   }
   switch (typeof value) {
     case 'string':
@@ -215,7 +229,7 @@ const toSdkConstant = (value: Constant['value']): Pipelines.Expression => {
       return Pipelines.constant(value);
     case 'object':
       return Pipelines.map(
-        Object.fromEntries(Object.entries(value).map(([k, v]) => [k, toSdkConstant(v)])),
+        Object.fromEntries(Object.entries(value).map(([k, v]) => [k, toSdkConstant(db, v)])),
       );
     case 'bigint':
     case 'symbol':
@@ -338,6 +352,7 @@ const literalStringOperand = (operand: Expression): string => {
     case 'field':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':
@@ -374,6 +389,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'constant':
     case 'geoPointValue':
     case 'vectorValue':
+    case 'docRefValue':
     case 'nullaryFunction':
     case 'unaryFunction':
     case 'binaryFunction':


### PR DESCRIPTION
## Summary

Expressions rollout slice 3, introducing **`TernaryFunction`** (stringReplaceAll/stringReplaceOne; `substring` reuses the dual-arity pattern with its optional length).

- **String rest**: `stringIndexOf` `stringRepeat` `stringReplaceAll` `stringReplaceOne` `substring` `like` (`split`/`join` deferred to the array slice — their typing IS array typing)
- **Regex**: `regexContains` `regexMatch` `regexFind` `regexFindAll`
- **Reference**: `documentId` `collectionId`
- **Type**: `type` `isType`
- **Vector**: `cosineDistance` `dotProduct` `euclideanDistance` `vectorLength`

## Probed findings (recorded in the research docs)

- **`regexFind` is null on no match** → its return descriptor is *always* nullable, independent of operands; `regexFindAll` returns `[]` and stays plain. Invalid patterns / vector dimension mismatches are backend ERROR values.
- **`type()`/`isType()` are type-observing**: a `null` value yields the name `'null'` — only ABSENCE nulls the result. New `PropagateAbsence` variant (+ runtime twin) models this. `type()` distinguishes `int64`/`float64` **per value** (the honest `'integer' | 'double'` tag at work); its return is `LiteralType<FirestoreTypeName[]>` over the backend's 20-name vocabulary.
- **`isType`'s name must be a wire-literal**: the factory takes the literal union and lifts it into a constant operand; executor binary tables now also receive the raw AST node so `isType` can hand the SDK helper the plain string it requires.

## `__name__` is a reference — `ReferenceType`

`type(__name__)` is `"reference"`, and `documentId` accepts `__name__` while rejecting strings. `FieldTypeOfPath` now resolves `'__name__'` to the new **`ReferenceType`** pseudo-descriptor:

- tag `'reference'` — comparing `__name__` against strings is now correctly rejected (was an always-false comparison); `documentId(field('__name__'))` bridges into the string domain
- `output: string` — the core query API's id-filter contract (`where(eq('__name__', id))`) keeps working
- `input: never`, and both codecs reject it as document data (it is not a schema factory)

## `docRefValue` — reference comparisons made true (follow-up commits)

Probed: the pipeline backend matches `__name__` against **no string form** (bare id / relative path / full resource path — all `false`); only a genuine reference value matches. The core query API accepting a string id is an SDK convenience backed by the query's collection context, which a pipeline lacks.

- **`docRefValue(collection, id)`** joins `geoPointValue`/`vectorValue` as the third dedicated value node under the same classification rule (an id tuple is a plain `string[]` = an array constant) and doubles as a composite constant leaf. `equal(field('__name__'), docRefValue(...))` type-checks (`'reference'` overlap) and matches live. Executors thread `db` through the translation (the codec's `buildEncodeField` precedent).
- **`Expression<T>` now binds its non-generic value nodes through their `type` property** (`GeoPointValue & { type: T }`) — previously a bare member belonged to every `Expression<T>`, so every value node inhabited every operand domain (`toUpper(geoPointValue(...))` type-checked) and first-operand inference collapsed to the wide fallback. Closed for all three nodes, pinned in tests.
- **`ReferenceType` decode now honors its declared `output`**: a projected raw `__name__` materializes as a `DocumentReference` and decodes to its relative path string; encode keeps rejecting (`input: never`). The identity research doc's earlier "path str" note is corrected and the comparison probe table recorded.
- The design principles at work (systemic consistency over ad-hoc fixes; deferring parts OK, deviating structures NG) are codified in `docs/coding-guideline.md`.

## Tests

- 7 new unit test groups (233 total): shapes, domains (incl. vector-vs-`array(double())` rejection via the tag axis), `PropagateAbsence` behavior, `regexFind` always-nullable, `isType` literal-union rejection.
- Catalog grows 3 families / 25 pinned evaluations (incl. per-value `int64`/`float64` observation and `documentId`/`collectionId` end-to-end over a sorted row); **59 live cases pass against the Enterprise DB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
