### PR TITLE
Unify reference values as RefPath segment paths

### DIFF
--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -69,6 +69,13 @@ string[])` → `RefPath<T>`; the codecs' decode → read-space values).
 - Every remaining assertion MUST carry an `oxlint-disable-next-line
 typescript/no-unsafe-type-assertion` comment stating the specific compiler
   limitation that makes it unavoidable.
+- **A function containing a type assertion MUST have exhaustive unit tests.**
+  An assertion is a claim the compiler no longer checks, so the tests carry
+  the proof instead: cover every input shape the function's contract admits
+  (each collection depth for path helpers, each operator for operand
+  encoders, each flavor of a descriptor) and the failure modes, not just one
+  happy path. Precedent: `path.test.ts` for `refPath` / `parseRefPath` /
+  `toDocRef`, `codec.test.ts` for `buildEncodeFilterValue`.
 
 ## Union / enum-like value handling
 

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -44,7 +44,7 @@ Follow the project's linting and formatting rules enforced by `pnpm check`.
   corollaries:
   - Data of uncertain validity (untyped/context-free values, wire data)
     enters the typed world only through a dedicated **narrowing function
-    that validates and returns the precise type** (`asRefPath(collection,
+    that validates and returns the precise type** (`parseRefPath(collection,
 string[])` → `RefPath<T>`; the codecs' decode → read-space values).
     Validation lives there, once.
   - **Do not widen a function's parameter to also accept possibly-invalid

--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -7,8 +7,9 @@
 - **Record non-obvious design decisions (the WHY) — and route them by
   audience.** A rationale that affects how the API is USED (why a value is
   represented this way, why an input is rejected, why two similar-looking
-  types are distinct — e.g. why the context-free `DocRefType` reads/writes a
-  path string rather than a `string[]`) belongs in the **JSDoc**, where a
+  types are distinct — e.g. why a reference VALUE (`RefPath`) carries its
+  collection names while the repository's `DocRef` address does not) belongs
+  in the **JSDoc**, where a
   consumer hovering the symbol sees it. A rationale that only matters to
   maintainers (compiler workarounds, why an implementation shape was chosen
   over an alternative, probe references) stays a **plain comment** inside the
@@ -37,6 +38,21 @@ Follow the project's linting and formatting rules enforced by `pnpm check`.
   acceptable — a missing limb is recoverable, a wrong skeleton is not.
   Likewise, do not dismiss a consistent-but-rare case as "low practical
   utility"; uniformity of the system is itself the utility.
+- **Always-valid domain model ("parse, don't validate").** A value carrying a
+  precise type must be valid by construction — holding a `RefPath<Posts>`
+  means the segment path IS a Posts path, no re-checking downstream. Two
+  corollaries:
+  - Data of uncertain validity (untyped/context-free values, wire data)
+    enters the typed world only through a dedicated **narrowing function
+    that validates and returns the precise type** (`asRefPath(collection,
+string[])` → `RefPath<T>`; the codecs' decode → read-space values).
+    Validation lives there, once.
+  - **Do not widen a function's parameter to also accept possibly-invalid
+    input for convenience** (e.g. `RefPath<T> | string[]`): the wide arm
+    swallows the precise one and silently downgrades compile-time checking
+    to runtime for every caller. Keep the function's contract precise and
+    let callers narrow first — the call site then documents where the
+    validity claim is made.
 
 ## Type assertions
 

--- a/docs/pipeline-query-identity-research.md
+++ b/docs/pipeline-query-identity-research.md
@@ -87,11 +87,13 @@ always-false — a trap, not an error.
 Comparison semantics (probed 2026-07): the pipeline backend never converts —
 `equal(__name__, <string>)` is `false` for EVERY string form (the bare id,
 the relative path, the full resource path), and only a reference constant
-matches (`constant(db.doc(...))` in the SDK / `docRefValue(collection, id)`
-in this library). The core query API's `where(eq('__name__', '1'))` accepting
-a string is an SDK convenience: the core query has a collection context to
+matches (`constant(db.doc(...))` in the SDK / `docRefValue(refPath)` in this
+library). The raw core query API's `where(eq('__name__', '1'))` accepting a
+string is an SDK convenience: the core query has a collection context to
 convert the string into a reference before it hits the wire; a pipeline has
-none, so the raw type shows through.
+none, so the raw type shows through. (This library encodes core-query
+`__name__` operands — `RefPath` segment paths — to references itself, so the
+convenience and its scope-dependent traps do not surface in its API.)
 
 A projected raw key (`field("__name__").as("k")`) materializes in the SDK as
 a `DocumentReference` instance (NOT a path string — an earlier note here was
@@ -104,12 +106,12 @@ the schema knows it, or the `'unknown'` sentinel when it does not) with the
 `'reference'` firestoreType tag, so string comparisons and string functions
 over the raw key are rejected at the type level; `documentId(field('__name__'))` /
 `collectionId(...)` bridge it into the string domain, and
-`docRefValue(collection, id)` is the matching comparand. The context-free
-flavor's `output` is `string`: the core query API's id-filter contract, and
-the decode of a projected raw key (the codecs decode the
-`DocumentReference` to its relative path string; a schema-known
-`docRef(collection)` field decodes to a `DocRef` id tuple as usual), and its
-`input` is likewise the relative path string (encoded via `db.doc(path)`).
+`docRefValue(refPath)` is the matching comparand. Both flavors' value
+representation is the `RefPath` segment path (`['Authors', 'a1']`) — the
+context-free flavor's is an untyped `string[]`, a schema-known
+`docRef(collection)` field's a tuple with literal collection-name positions —
+decoded from a projected raw key via `ref.path.split('/')` and encoded via
+`db.doc(segments.join('/'))`.
 
 ### Core query `__name__` string filters
 

--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -263,9 +263,9 @@ both executors and the basic backend semantics in one round trip per family.
       identity ratchet drops (deferred; `documentId` covers today's uses) — `documentId(field('__name__'))` bridges it
       into the string domain, and comparing `__name__` against strings is
       now correctly rejected (probed: the backend matches NO string form —
-      only a reference value). `docRefValue(collection, id)` joins
+      only a reference value). `docRefValue(refPath)` joins
       `geoPointValue` / `vectorValue` as the third dedicated value node
-      (same classification rule: an id tuple is a plain `string[]` = an
+      (same classification rule: a segment path is a plain `string[]` = an
       array constant) and is the matching comparand; executors thread `db`
       to build the wire reference (the codec's `buildEncodeField`
       precedent). Value nodes are NOT expressions: `constant()` is the one

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -362,7 +362,12 @@ Deferred to a later iteration (still tracked here, not currently in scope):
     FEASIBLE (the length parity 2n vs n disambiguates ids from segments once
     names are literal) and deliberately deferred.
   - `docRefValue(path)` takes the segment path (one signature, typed
-    `DocRefType<'unknown'>`; comparisons key on the `'reference'` tag).
+    `DocRefType<'unknown'>`; comparisons key on the `'reference'` tag — a
+    segment tuple alone cannot recover the `Collection` type, and no operator
+    needs the precision). Decided (2026-07): the shorthand layer SHOULD add
+    the collection+address form `docRefValue(authors, ['a1'])` typed
+    `DocRefType<Authors>` — receiving the collection definition itself is
+    what makes the known-collection typing possible.
   - Cursor constraints (`startAt` etc.) remain untyped raw pass-through
     (`Cursor` is `unknown[]`) — a reference cursor value would need the same
     encoding once cursors get typed.

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -335,30 +335,37 @@ Deferred to a later iteration (still tracked here, not currently in scope):
   - Settle whether `Ordering` is imported as a value or `import type` in
     `pipeline.ts` (it is currently a value import of a type).
 
-## Reference values: segment-path unification (next up, own PR)
+## Reference values: segment-path unification
 
-Agreed direction (2026-07): unify the reference VALUE representation across
-the known-collection and context-free flavors as a **segment path including
-collection names** — `['authors', <id>]`, `['authors', <id>, 'posts', <id>]`
-— typed with LITERAL collection-name positions when the collection is known
-and `string[]` when it is not, so known/unknown becomes purely a gradient of
-tuple precision (this also dissolves the ids-tuple vs segments ambiguity
-that previously forced the context-free flavor onto a path string).
-
-Constraints / scope:
-
-- **The repository API keeps its ids-only interface** (`get(['a1'])`,
-  `Doc.id`, `DocRef<T>` as-is): a repository is already collection-bound, so
-  making callers repeat the collection name is pure ceremony. The segment
-  form is a SEPARATE type for reference VALUES (a `docRef(...)` field's
-  read/write value, `DocRefType<'unknown'>`'s value, `docRefValue`'s
-  payload), converting to/from ids at the repository boundary.
-- Prerequisite: `Collection` must capture `name` / `parent` as LITERAL types
-  (`const` type parameters) for the precise tuples.
-- Ripples: both codecs' docRef decode (collect names from the ref walk —
-  already available), `documentPath` (becomes ~a join), the core query's
-  docRef filter encoding (today's raw pass-through needs revisiting),
-  `docRefValue`'s argument shape, specs and README examples.
+- [x] **Done (2026-07).** Reference VALUES are uniformly `RefPath<T>` segment
+      paths (`['Authors', <id>]`, `['Authors', <id>, 'Posts', <id>]`) — literal
+      collection-name positions when the collection is known, `string[]` for the
+      `'unknown'` flavor, so known/unknown is purely a gradient of tuple
+      precision. The ids-only ADDRESS (`DocRef<T>`) survives only in the
+      repository interface (`get`/`set`/`Doc.id`), with `refPath()` /
+      `toDocRef()` (`path.ts`) converting at that one boundary.
+  - `Collection` captures `name` as a literal (`const Name` on the
+    factories; `parent` already was).
+  - Both codecs: decode is a single arm (`ref.path.split('/')`); encode
+    validates the segment shape per flavor (`refPathSchema`) and builds
+    `db.doc(segments.join('/'))`.
+  - Core query `__name__` (and docRef-field) filter operands are RefPath and
+    the adapters encode them to `DocumentReference` values
+    (`encodeFilterValue` in each codec, recursing into
+    array/map/union-nested references), so every scope — collection,
+    subcollection, collection group — takes the same operand form and the
+    SDK's scope-dependent string conventions (plain id vs full path — see
+    docs/querying-by-document-id.md) no longer surface. The old "plain id
+    for a collection query" convenience is gone; a typed shorthand layer
+    ("address accepted where a static context exists": bare id / `DocRef`
+    tuple at surfaces whose collection is statically known) was judged
+    FEASIBLE (the length parity 2n vs n disambiguates ids from segments once
+    names are literal) and deliberately deferred.
+  - `docRefValue(path)` takes the segment path (one signature, typed
+    `DocRefType<'unknown'>`; comparisons key on the `'reference'` tag).
+  - Cursor constraints (`startAt` etc.) remain untyped raw pass-through
+    (`Cursor` is `unknown[]`) — a reference cursor value would need the same
+    encoding once cursors get typed.
 
 ## Expressions — remaining gaps
 

--- a/docs/querying-by-document-id.md
+++ b/docs/querying-by-document-id.md
@@ -1,84 +1,50 @@
 # Querying by Document ID (`__name__`)
 
 `__name__` is a reserved field path that refers to a document's identifier. This library exposes
-it as a regular field path (`FieldPath<T>`), so it can be used in `where`, `orderBy`, and cursor
-constraints just like any schema field. Its value type is always `string`.
-
-The library passes `__name__` straight through to the underlying Firestore SDK without any special
-handling. As a result, the convention for what string to pass is dictated entirely by Firestore,
-and — importantly — **it differs depending on the query scope**.
+it as a regular field path, so it can be used in `where`, `orderBy`, and cursor constraints just
+like any schema field. Its value type is a **`RefPath` segment path** — the full path of the
+document as alternating collection names and ids (`['Authors', 'author1']`,
+`['Authors', 'author1', 'Posts', '1']`) — the same representation every document reference uses in
+this library.
 
 ## Convention
 
-|                    | Single collection / subcollection (`parent` given)         | Collection group (`group: true`)                                  |
-| ------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------- |
-| Value to pass      | A **plain document ID** relative to the queried collection | A **fully-qualified document path** relative to the database root |
-| Example value      | `'1'`                                                      | `'Authors/author1/Posts/1'`                                       |
-| `/` in the value   | Not allowed (must be a plain ID)                           | Required (path separators)                                        |
-| Segment count      | 1 (the ID)                                                 | Even (`col/doc/col/doc/...`)                                      |
-| Passing a plain ID | ✓                                                          | ✗ — rejected with `odd number of segments`                        |
-
-The reason for the difference: `__name__` values are resolved as a path relative to the query's
-scope. A single-collection or subcollection query is already scoped to one concrete collection path
-(e.g. `Authors/author1/Posts`), so only the remaining document ID is needed. A collection group
-query spans **every** collection of that name across the database (e.g. both `Authors/author1/Posts`
-and `Authors/author2/Posts`), so the value must carry the full path from the root to identify a
-document unambiguously.
-
-Note that for a subcollection query the parent id is **not** part of the `__name__` value — it is
-specified separately via `parent`. Only the leaf document ID goes into `__name__`, and it must not
-contain a `/`.
-
-A few additional properties of this contract (verified empirically):
-
-- **Validation is client-side.** An invalid string form throws synchronously in the SDK at query
-  construction time (inside `where()`), before any request is sent. The server never sees it.
-- **The convention applies to every operator**, not just `eq` — inequality/range filters
-  (`gt('__name__', '1')`, etc.) resolve the string the same way, per the query scope.
-- **A `DocumentReference` works in every scope** at the SDK level. The string forms are client-side
-  conveniences: the SDK resolves the string against the query's static scope and compiles it to a
-  reference before it hits the wire. The reference value is the single wire-level concept — which is
-  also why Pipeline queries (which have no such scope) accept only references; see below. This
-  library's `__name__` contract is the string form; the raw-reference form is not part of its API.
-
-## Single collection / subcollection
-
-Pass a plain document ID. The parent (for a subcollection) is given via `parent`, not in the value.
+The operand is the same `RefPath` **in every query scope** — root collection, subcollection, and
+collection group. Build it from a repository-side id with the `refPath` helper, which interleaves
+the collection names from the collection definition:
 
 ```ts
+import { refPath } from 'firestore-repository/path';
+
 // root collection
-query({ collection: authors }, where(eq('__name__', '1')));
+query({ collection: authors }, where(eq('__name__', refPath(authors, ['author1']))));
 query({ collection: authors }, orderBy('__name__', 'asc'));
 
-// subcollection — value is the leaf id only ('1'), parent is separate
-query({ collection: posts, parent: ['author1'] }, where(eq('__name__', '1')));
-query({ collection: posts, parent: ['author1'] }, orderBy('__name__', 'asc'));
-```
-
-## Collection group
-
-Pass the fully-qualified document path relative to the database root. The `documentPath` helper
-builds this path from a `DocRef`, which keeps the query in sync with your collection definition
-(including any parent segments):
-
-```ts
-import { documentPath } from 'firestore-repository/path';
-
+// subcollection — the address carries the parent id, refPath expands the names
 query(
-  { collection: posts, group: true },
-  where(eq('__name__', documentPath(posts, ['author1', '1']))), // 'Authors/author1/Posts/1'
+  { collection: posts, parent: ['author1'] },
+  where(eq('__name__', refPath(posts, ['author1', '1']))), // ['Authors', 'author1', 'Posts', '1']
 );
 
-query({ collection: posts, group: true }, orderBy('__name__', 'asc'));
+// collection group — the SAME operand form
+query({ collection: posts, group: true }, where(eq('__name__', refPath(posts, ['author1', '1']))));
 ```
 
-Passing a plain document ID to a collection group query throws, because a single segment does not
-resolve to a valid (even-segment) document path:
+The adapters encode the segment path to a `DocumentReference` value before it reaches the SDK.
+This matters because a reference value is the one operand form the raw SDKs accept uniformly; the
+SDKs' own _string_ conventions for `__name__` are scope-dependent traps (verified empirically):
 
-```ts
-// Throws: "... odd number of segments ..."
-query({ collection: posts, group: true }, where(eq('__name__', '1')));
-```
+|                            | Single collection / subcollection                          | Collection group                                                  |
+| -------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| String the raw SDK expects | A **plain document ID** relative to the queried collection | A **fully-qualified document path** relative to the database root |
+| Example value              | `'1'`                                                      | `'Authors/author1/Posts/1'`                                       |
+| The other form             | ✗ — client-side throw (`contains a slash`)                 | ✗ — client-side throw (`odd number of segments`)                  |
+| A `DocumentReference`      | ✓                                                          | ✓                                                                 |
+
+The string forms are client-side conveniences resolved against the query's static scope, compiled
+to a reference before hitting the wire; the reference value is the single wire-level concept. By
+always sending the reference, this library keeps one operand type across scopes — the invalid
+combinations above are simply not expressible.
 
 ## What `__name__` returns
 
@@ -90,7 +56,9 @@ query({ collection: posts, group: true }, where(eq('__name__', '1')));
 
 The behavior described here is verified against both SDK implementations
 (`@google-cloud/firestore` and `@firebase/firestore`) in the shared specification tests
-(`packages/firestore-repository/src/__test__/specification.ts`).
+(`packages/firestore-repository/src/__test__/specification.ts`). Note: cursor constraints
+(`startAt` etc.) are currently untyped pass-through, so a `__name__` cursor value must be given in
+the form the raw SDK expects.
 
 ## Pipeline queries
 

--- a/packages/firebase-js-sdk/src/codec.test.ts
+++ b/packages/firebase-js-sdk/src/codec.test.ts
@@ -1,8 +1,9 @@
 import { initializeApp } from '@firebase/app';
 import { Bytes, doc, getFirestore } from '@firebase/firestore';
+import { array, docRef, int64, map, rootCollection, string } from 'firestore-repository/schema';
 import { describe, expect, it } from 'vitest';
 
-import { isBytes, isDocumentReference } from './codec.js';
+import { buildEncodeFilterValue, isBytes, isDocumentReference } from './codec.js';
 
 const db = getFirestore(initializeApp({ projectId: 'codec-guard-test' }, 'codec-guard-test'));
 const ref = doc(db, 'col/id');
@@ -40,5 +41,70 @@ describe('isDocumentReference', () => {
   ];
   it.each(others)('returns false for %s', (_label, value) => {
     expect(isDocumentReference(value)).toBe(false);
+  });
+});
+
+describe('buildEncodeFilterValue', () => {
+  const authors = rootCollection({ name: 'Authors', schema: { name: string() } });
+  const schema = {
+    rank: int64(),
+    author: docRef(authors),
+    anyRef: docRef(),
+    reviewers: array(docRef(authors)),
+    meta: map({ editor: docRef(authors) }),
+  };
+  const encode = buildEncodeFilterValue(schema, db);
+  const refDoc = (path: string) => doc(db, path);
+
+  it('passes non-reference operands through', () => {
+    expect(encode('rank', '==', 1)).toBe(1);
+    expect(encode('rank', 'in', [1, 2])).toStrictEqual([1, 2]);
+  });
+
+  it('encodes a reference operand to a DocumentReference (every comparison op)', () => {
+    for (const op of ['==', '!=', '<', '<=', '>', '>='] as const) {
+      expect(encode('author', op, ['Authors', 'a1'])).toStrictEqual(refDoc('Authors/a1'));
+    }
+  });
+
+  it('encodes the context-free flavor (__name__ / docRef()) the same way', () => {
+    expect(encode('__name__', '==', ['SomeCollection', 'x1'])).toStrictEqual(
+      refDoc('SomeCollection/x1'),
+    );
+    expect(encode('anyRef', '==', ['SomeCollection', 'x1'])).toStrictEqual(
+      refDoc('SomeCollection/x1'),
+    );
+  });
+
+  it('resolves operand arity per operator', () => {
+    expect(
+      encode('author', 'in', [
+        ['Authors', 'a1'],
+        ['Authors', 'a2'],
+      ]),
+    ).toStrictEqual([refDoc('Authors/a1'), refDoc('Authors/a2')]);
+
+    expect(encode('reviewers', 'array-contains', ['Authors', 'a1'])).toStrictEqual(
+      refDoc('Authors/a1'),
+    );
+
+    expect(
+      encode('reviewers', 'array-contains-any', [
+        ['Authors', 'a1'],
+        ['Authors', 'a2'],
+      ]),
+    ).toStrictEqual([refDoc('Authors/a1'), refDoc('Authors/a2')]);
+  });
+
+  it('recurses into container operands', () => {
+    expect(encode('reviewers', '==', [['Authors', 'a1']])).toStrictEqual([refDoc('Authors/a1')]);
+    expect(encode('meta', '==', { editor: ['Authors', 'a1'] })).toStrictEqual({
+      editor: refDoc('Authors/a1'),
+    });
+  });
+
+  it('rejects a segment path that does not match the field descriptor', () => {
+    expect(() => encode('author', '==', ['Posts', 'p1'])).toThrow();
+    expect(() => encode('anyRef', '==', ['odd-length'])).toThrow();
   });
 });

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -12,7 +12,7 @@ import {
   serverTimestamp as firestoreServerTimestamp,
   vector,
 } from '@firebase/firestore';
-import type { WhereFilterOp } from 'firestore-repository/query';
+import { filterOperand, type WhereFilterOp } from 'firestore-repository/query';
 import {
   type Collection,
   type DocFieldPath,
@@ -198,9 +198,9 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
  * `where()` compares correctly. Sending references as `DocumentReference`
  * values also keeps `__name__` filters free of the SDK's scope-dependent
  * string conventions (see docs/querying-by-document-id.md): a reference
- * works in every scope. Only the operand arity is resolved here — `in`/
- * `not-in` take a list of field values and `array-contains(-any)` take
- * element values.
+ * works in every scope. The operand's shape per operator (`in` takes a list
+ * of field values, `array-contains` an element, ...) comes from
+ * `filterOperand`, the runtime counterpart of the `FilterOperand` type.
  */
 export function buildEncodeFilterValue(
   schema: DocumentSchema,
@@ -211,42 +211,15 @@ export function buildEncodeFilterValue(
     const key = `${opStr}:${fieldPath}`;
     let operandSchema = operandSchemas.get(key);
     if (operandSchema === undefined) {
-      operandSchema = buildOperandSchema(schema, fieldPath, opStr, db);
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
+      const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
+      operandSchema = buildEncodeField(filterOperand(fieldType, opStr), db);
       operandSchemas.set(key, operandSchema);
     }
     return operandSchema.parse(value);
   };
 }
 
-function buildOperandSchema(
-  schema: DocumentSchema,
-  fieldPath: string,
-  opStr: WhereFilterOp,
-  db: Firestore,
-): ZodAny {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
-  const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
-  switch (opStr) {
-    case 'in':
-    case 'not-in':
-      return z.array(buildEncodeField(fieldType, db));
-    case 'array-contains':
-      return fieldType.type === 'array' ? buildEncodeField(fieldType.dynamicPart, db) : z.unknown();
-    case 'array-contains-any':
-      return fieldType.type === 'array'
-        ? z.array(buildEncodeField(fieldType.dynamicPart, db))
-        : z.unknown();
-    case '==':
-    case '!=':
-    case '<':
-    case '<=':
-    case '>':
-    case '>=':
-      return buildEncodeField(fieldType, db);
-    default:
-      return assertNever(opStr);
-  }
-}
 /**
  * A zod schema for a `RefPath` segment path. A known collection's tuple shape
  * is exact — literal collection names at the even positions — while the

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -12,9 +12,14 @@ import {
   serverTimestamp as firestoreServerTimestamp,
   vector,
 } from '@firebase/firestore';
-import { documentPath } from 'firestore-repository/path';
-import type { DocRef } from 'firestore-repository/repository';
-import type { Collection, DocumentSchema, FieldType } from 'firestore-repository/schema';
+import type { WhereFilterOp } from 'firestore-repository/query';
+import {
+  type Collection,
+  type DocFieldPath,
+  type DocumentSchema,
+  type FieldType,
+  fieldTypeOfPath,
+} from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -66,29 +71,12 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
     case 'vector':
       return z.instanceof(FirestoreVectorValue).transform((vv) => vv.toArray());
     case 'docRef':
-      if (fieldType.collection === 'unknown') {
-        // The context-free flavor (the '__name__' pseudo-descriptor): with no
-        // schema-known collection to build a DocRef id tuple from, a
-        // projected raw key decodes to its relative path string — the
-        // representation its `output` declares.
-        return z
-          .unknown()
-          .refine(isDocumentReference)
-          .transform((ref) => ref.path);
-      }
+      // Both flavors decode to the RefPath segment path — known/unknown is a
+      // gradient of tuple precision, not a change of shape.
       return z
         .unknown()
         .refine(isDocumentReference)
-        .transform((ref) => {
-          const ids: string[] = [];
-          let current: FirestoreDocumentReference | null = ref;
-          while (current != null) {
-            ids.push(current.id);
-            current = current.parent.parent;
-          }
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-          return ids.reverse() as DocRef<Collection>;
-        });
+        .transform((ref) => ref.path.split('/'));
     case 'map': {
       return z.object(
         Object.fromEntries(
@@ -161,15 +149,8 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
           .transform(() => firestoreServerTimestamp()),
       ]);
     case 'docRef': {
-      if (fieldType.collection === 'unknown') {
-        // The context-free flavor writes a relative path string — the one
-        // reference representation that needs no collection context.
-        return z.string().transform((path) => doc(db, path));
-      }
-      const { collection } = fieldType;
-      return z.array(z.string()).transform((ref) =>
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        doc(db, documentPath(collection, ref as DocRef<Collection>)),
+      return refPathSchema(fieldType.collection).transform((segments) =>
+        doc(db, segments.join('/')),
       );
     }
     case 'map': {
@@ -204,6 +185,119 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
     default:
       return assertNever(fieldType);
   }
+}
+
+/**
+ * Encodes a single filter condition's operand into what the SDK's `where()`
+ * accepts. Only document references need conversion: they appear in
+ * conditions as `RefPath` segment paths (a field's READ representation) and
+ * are sent as `DocumentReference` values — the one representation the
+ * backend compares. This also keeps `__name__` filters free of the SDK's
+ * scope-dependent string conventions (a plain id for a collection query, a
+ * full root-relative path for a collection group — see
+ * docs/querying-by-document-id.md): a reference works in every scope.
+ * `in`/`not-in` take a list of operands and `array-contains(-any)` take
+ * element operands, so the arity/element type is resolved per operator.
+ */
+export function encodeFilterValue(
+  schema: DocumentSchema,
+  fieldPath: string,
+  opStr: WhereFilterOp,
+  value: unknown,
+  db: Firestore,
+): unknown {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
+  const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
+  switch (opStr) {
+    case 'in':
+    case 'not-in':
+      return Array.isArray(value) ? value.map((v) => encodeFilterOperand(fieldType, v, db)) : value;
+    case 'array-contains':
+      return fieldType.type === 'array'
+        ? encodeFilterOperand(fieldType.dynamicPart, value, db)
+        : value;
+    case 'array-contains-any':
+      return fieldType.type === 'array' && Array.isArray(value)
+        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+        : value;
+    case '==':
+    case '!=':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      return encodeFilterOperand(fieldType, value, db);
+    default:
+      return assertNever(opStr);
+  }
+}
+
+function encodeFilterOperand(fieldType: FieldType, value: unknown, db: Firestore): unknown {
+  switch (fieldType.type) {
+    case 'docRef': {
+      const parsed = refPathSchema(fieldType.collection).safeParse(value);
+      return parsed.success ? doc(db, parsed.data.join('/')) : value;
+    }
+    case 'array':
+      return Array.isArray(value)
+        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+        : value;
+    case 'map':
+      return typeof value === 'object' && value !== null
+        ? Object.fromEntries(
+            Object.entries(value).map(([k, v]) => {
+              const f = fieldType.fields[k];
+              return [k, f === undefined ? v : encodeFilterOperand(f, v, db)];
+            }),
+          )
+        : value;
+    case 'union': {
+      // A reference is the only member type needing conversion, so a value is
+      // converted iff it matches a docRef member's segment-path shape.
+      for (const e of fieldType.elements) {
+        if (e.type === 'docRef' && refPathSchema(e.collection).safeParse(value).success) {
+          return encodeFilterOperand(e, value, db);
+        }
+      }
+      return value;
+    }
+    case 'string':
+    case 'bool':
+    case 'int64':
+    case 'double':
+    case 'timestamp':
+    case 'bytes':
+    case 'geoPoint':
+    case 'vector':
+    case 'null':
+    case 'const':
+      return value;
+    default:
+      return assertNever(fieldType);
+  }
+}
+
+/**
+ * A zod schema for a `RefPath` segment path. A known collection's tuple shape
+ * is exact — literal collection names at the even positions — while the
+ * context-free flavor accepts any even-length segment path.
+ */
+function refPathSchema(collection: Collection | 'unknown'): z.ZodType<string[]> {
+  if (collection === 'unknown') {
+    return z
+      .array(z.string())
+      .refine((segments) => segments.length >= 2 && segments.length % 2 === 0, {
+        message: 'a reference path must have an even number of segments',
+      });
+  }
+  const names = [...collection.parent, collection.name];
+  return z
+    .array(z.string())
+    .refine(
+      (segments) =>
+        segments.length === names.length * 2 && names.every((name, i) => segments[i * 2] === name),
+      { message: `not a reference path of collection '${collection.name}'` },
+    );
 }
 
 function zodUnion(schemas: ZodAny[]): ZodAny {

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -188,46 +188,61 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
 }
 
 /**
- * Encodes a single filter condition's operand into what the SDK's `where()`
- * accepts, by reusing the write codec (`buildEncodeField`): a field's READ
- * representation is a subset of its write `input` for every descriptor, and
- * the write conversions (`RefPath` -> `DocumentReference`, `Date` ->
- * `Timestamp`, geopoint/bytes/vector to their SDK classes) are exactly the
- * operand forms `where()` compares correctly. Sending references as
- * `DocumentReference` values also keeps `__name__` filters free of the SDK's
- * scope-dependent string conventions (see docs/querying-by-document-id.md):
- * a reference works in every scope. Only the operand arity is resolved here —
- * `in`/`not-in` take a list of field values and `array-contains(-any)` take
+ * Builds the encoder for filter-condition operands, memoizing the operand
+ * schema per (field path, operator) like `buildEncodeSchema` builds the
+ * write schema once per collection. The operand schema reuses the write
+ * codec (`buildEncodeField`): a field's READ representation is a subset of
+ * its write `input` for every descriptor, and the write conversions
+ * (`RefPath` -> `DocumentReference`, `Date` -> `Timestamp`,
+ * geopoint/bytes/vector to their SDK classes) are exactly the operand forms
+ * `where()` compares correctly. Sending references as `DocumentReference`
+ * values also keeps `__name__` filters free of the SDK's scope-dependent
+ * string conventions (see docs/querying-by-document-id.md): a reference
+ * works in every scope. Only the operand arity is resolved here — `in`/
+ * `not-in` take a list of field values and `array-contains(-any)` take
  * element values.
  */
-export function encodeFilterValue(
+export function buildEncodeFilterValue(
+  schema: DocumentSchema,
+  db: Firestore,
+): (fieldPath: string, opStr: WhereFilterOp, value: unknown) => unknown {
+  const operandSchemas = new Map<string, ZodAny>();
+  return (fieldPath, opStr, value) => {
+    const key = `${opStr}:${fieldPath}`;
+    let operandSchema = operandSchemas.get(key);
+    if (operandSchema === undefined) {
+      operandSchema = buildOperandSchema(schema, fieldPath, opStr, db);
+      operandSchemas.set(key, operandSchema);
+    }
+    return operandSchema.parse(value);
+  };
+}
+
+function buildOperandSchema(
   schema: DocumentSchema,
   fieldPath: string,
   opStr: WhereFilterOp,
-  value: unknown,
   db: Firestore,
-): unknown {
+): ZodAny {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
   const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
   switch (opStr) {
     case 'in':
     case 'not-in':
-      return z.array(buildEncodeField(fieldType, db)).parse(value);
+      return z.array(buildEncodeField(fieldType, db));
     case 'array-contains':
-      return fieldType.type === 'array'
-        ? buildEncodeField(fieldType.dynamicPart, db).parse(value)
-        : value;
+      return fieldType.type === 'array' ? buildEncodeField(fieldType.dynamicPart, db) : z.unknown();
     case 'array-contains-any':
       return fieldType.type === 'array'
-        ? z.array(buildEncodeField(fieldType.dynamicPart, db)).parse(value)
-        : value;
+        ? z.array(buildEncodeField(fieldType.dynamicPart, db))
+        : z.unknown();
     case '==':
     case '!=':
     case '<':
     case '<=':
     case '>':
     case '>=':
-      return buildEncodeField(fieldType, db).parse(value);
+      return buildEncodeField(fieldType, db);
     default:
       return assertNever(opStr);
   }

--- a/packages/firebase-js-sdk/src/codec.ts
+++ b/packages/firebase-js-sdk/src/codec.ts
@@ -189,15 +189,16 @@ function buildEncodeField(fieldType: FieldType, db: Firestore): ZodAny {
 
 /**
  * Encodes a single filter condition's operand into what the SDK's `where()`
- * accepts. Only document references need conversion: they appear in
- * conditions as `RefPath` segment paths (a field's READ representation) and
- * are sent as `DocumentReference` values — the one representation the
- * backend compares. This also keeps `__name__` filters free of the SDK's
- * scope-dependent string conventions (a plain id for a collection query, a
- * full root-relative path for a collection group — see
- * docs/querying-by-document-id.md): a reference works in every scope.
- * `in`/`not-in` take a list of operands and `array-contains(-any)` take
- * element operands, so the arity/element type is resolved per operator.
+ * accepts, by reusing the write codec (`buildEncodeField`): a field's READ
+ * representation is a subset of its write `input` for every descriptor, and
+ * the write conversions (`RefPath` -> `DocumentReference`, `Date` ->
+ * `Timestamp`, geopoint/bytes/vector to their SDK classes) are exactly the
+ * operand forms `where()` compares correctly. Sending references as
+ * `DocumentReference` values also keeps `__name__` filters free of the SDK's
+ * scope-dependent string conventions (see docs/querying-by-document-id.md):
+ * a reference works in every scope. Only the operand arity is resolved here —
+ * `in`/`not-in` take a list of field values and `array-contains(-any)` take
+ * element values.
  */
 export function encodeFilterValue(
   schema: DocumentSchema,
@@ -211,14 +212,14 @@ export function encodeFilterValue(
   switch (opStr) {
     case 'in':
     case 'not-in':
-      return Array.isArray(value) ? value.map((v) => encodeFilterOperand(fieldType, v, db)) : value;
+      return z.array(buildEncodeField(fieldType, db)).parse(value);
     case 'array-contains':
       return fieldType.type === 'array'
-        ? encodeFilterOperand(fieldType.dynamicPart, value, db)
+        ? buildEncodeField(fieldType.dynamicPart, db).parse(value)
         : value;
     case 'array-contains-any':
-      return fieldType.type === 'array' && Array.isArray(value)
-        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+      return fieldType.type === 'array'
+        ? z.array(buildEncodeField(fieldType.dynamicPart, db)).parse(value)
         : value;
     case '==':
     case '!=':
@@ -226,57 +227,11 @@ export function encodeFilterValue(
     case '<=':
     case '>':
     case '>=':
-      return encodeFilterOperand(fieldType, value, db);
+      return buildEncodeField(fieldType, db).parse(value);
     default:
       return assertNever(opStr);
   }
 }
-
-function encodeFilterOperand(fieldType: FieldType, value: unknown, db: Firestore): unknown {
-  switch (fieldType.type) {
-    case 'docRef': {
-      const parsed = refPathSchema(fieldType.collection).safeParse(value);
-      return parsed.success ? doc(db, parsed.data.join('/')) : value;
-    }
-    case 'array':
-      return Array.isArray(value)
-        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
-        : value;
-    case 'map':
-      return typeof value === 'object' && value !== null
-        ? Object.fromEntries(
-            Object.entries(value).map(([k, v]) => {
-              const f = fieldType.fields[k];
-              return [k, f === undefined ? v : encodeFilterOperand(f, v, db)];
-            }),
-          )
-        : value;
-    case 'union': {
-      // A reference is the only member type needing conversion, so a value is
-      // converted iff it matches a docRef member's segment-path shape.
-      for (const e of fieldType.elements) {
-        if (e.type === 'docRef' && refPathSchema(e.collection).safeParse(value).success) {
-          return encodeFilterOperand(e, value, db);
-        }
-      }
-      return value;
-    }
-    case 'string':
-    case 'bool':
-    case 'int64':
-    case 'double':
-    case 'timestamp':
-    case 'bytes':
-    case 'geoPoint':
-    case 'vector':
-    case 'null':
-    case 'const':
-      return value;
-    default:
-      return assertNever(fieldType);
-  }
-}
-
 /**
  * A zod schema for a `RefPath` segment path. A known collection's tuple shape
  * is exact — literal collection names at the even positions — while the

--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -57,7 +57,7 @@ import {
 import type { Collection, RootCollection, SubCollection } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
-import { buildDecodeSchema, buildEncodeSchema, encodeFilterValue } from './codec.js';
+import { buildDecodeSchema, buildEncodeFilterValue, buildEncodeSchema } from './codec.js';
 
 /** Platform-specific environment types for Firebase JS SDK */
 export type Env = { transaction: Transaction; writeBatch: WriteBatch; query: FirestoreQuery };
@@ -219,6 +219,7 @@ export const repositoryWithMapper = <T extends Collection, Model extends AppMode
 
 export const buildFirestoreUtilities = <T extends Collection>(db: Firestore, coll: T) => {
   const decodeSchema = buildDecodeSchema(coll.schema);
+  const encodeFilterValue = buildEncodeFilterValue(coll.schema, db);
   const encodeSchema = buildEncodeSchema(coll.schema, db);
 
   const toFirestore = {
@@ -301,7 +302,7 @@ export const buildFirestoreUtilities = <T extends Collection>(db: Firestore, col
           return where(
             expr.fieldPath,
             expr.opStr,
-            encodeFilterValue(coll.schema, expr.fieldPath, expr.opStr, expr.value, db),
+            encodeFilterValue(expr.fieldPath, expr.opStr, expr.value),
           );
         case 'and':
           return and(...expr.filters.map(toFirestore.filter));

--- a/packages/firebase-js-sdk/src/index.ts
+++ b/packages/firebase-js-sdk/src/index.ts
@@ -57,7 +57,7 @@ import {
 import type { Collection, RootCollection, SubCollection } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
-import { buildDecodeSchema, buildEncodeSchema } from './codec.js';
+import { buildDecodeSchema, buildEncodeSchema, encodeFilterValue } from './codec.js';
 
 /** Platform-specific environment types for Firebase JS SDK */
 export type Env = { transaction: Transaction; writeBatch: WriteBatch; query: FirestoreQuery };
@@ -298,7 +298,11 @@ export const buildFirestoreUtilities = <T extends Collection>(db: Firestore, col
     filter: (expr: FilterExpression<T['schema']>): FirestoreQueryFilterConstraint => {
       switch (expr.kind) {
         case 'fieldValueCondition':
-          return where(expr.fieldPath, expr.opStr, expr.value);
+          return where(
+            expr.fieldPath,
+            expr.opStr,
+            encodeFilterValue(coll.schema, expr.fieldPath, expr.opStr, expr.value, db),
+          );
         case 'and':
           return and(...expr.filters.map(toFirestore.filter));
         case 'or':

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -64,7 +64,7 @@ import {
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
 } from '@firebase/firestore/pipelines';
-import { collectionPath, documentPath } from 'firestore-repository/path';
+import { collectionPath } from 'firestore-repository/path';
 import {
   type BinaryFunctionName,
   type Constant,
@@ -271,7 +271,7 @@ const toSdkConstant = (db: Firestore, value: Constant['value']): SdkExpression =
     return sdkConstant(vector([...value.values]));
   }
   if (value instanceof DocRefValue) {
-    return sdkConstant(doc(db, documentPath(value.collection, value.id)));
+    return sdkConstant(doc(db, value.path.join('/')));
   }
   if (isConstantArrayValue(value)) {
     return sdkArray(value.map((element) => toSdkConstant(db, element)));

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1,5 +1,6 @@
 import { assert, beforeEach, describe, expect, it } from 'vitest';
 
+import { refPath } from '../path.js';
 import {
   abs,
   add,
@@ -556,26 +557,28 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         // genuine reference value.
         await expectPipeline(
           source().where((field) =>
-            equal(field('__name__'), constant(docRefValue(liveCollection(), ['a1']))),
+            equal(field('__name__'), constant(docRefValue(refPath(liveCollection(), ['a1'])))),
           ),
           [a1],
         );
       });
 
-      it('reference: a projected raw __name__ decodes to its path string', async () => {
+      it('reference: a projected raw __name__ decodes to its segment path', async () => {
         await expectPipeline(
           source()
             .sort((field) => [asc(field('rank'))])
             .limit(1)
             .select((field) => [field('__name__').as('key'), 'name']),
-          [{ data: { key: `${collectionName()}/a1`, name: 'alice' } }],
+          [{ data: { key: [collectionName(), 'a1'], name: 'alice' } }],
         );
       });
 
-      it('reference: a docRefValue inside a constant map decodes to a DocRef id tuple', async () => {
+      it('reference: a docRefValue inside a constant map decodes to a RefPath', async () => {
         await expectPipeline(
-          one().select(() => [constant({ author: docRefValue(liveCollection(), ['a2']) }).as('m')]),
-          [{ data: { m: { author: ['a2'] } } }],
+          one().select(() => [
+            constant({ author: docRefValue(refPath(liveCollection(), ['a2'])) }).as('m'),
+          ]),
+          [{ data: { m: { author: [collectionName(), 'a2'] } } }],
         );
       });
 

--- a/packages/firestore-repository/src/__test__/specification.ts
+++ b/packages/firestore-repository/src/__test__/specification.ts
@@ -1,7 +1,7 @@
 import { assert, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
 import { average, count, sum } from '../aggregate.js';
-import { documentPath } from '../path.js';
+import { refPath } from '../path.js';
 import {
   and,
   arrayContains,
@@ -607,11 +607,17 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
 
           it('filter by id', async () => {
             await expectQuery(
-              query({ collection: repository.collection }, where(eq('__name__', '1'))),
+              query(
+                { collection: repository.collection },
+                where(eq('__name__', refPath(repository.collection, ['1']))),
+              ),
               [items[0]],
             );
             await expectQuery(
-              query({ collection: repository.collection }, where(eq('__name__', '2'))),
+              query(
+                { collection: repository.collection },
+                where(eq('__name__', refPath(repository.collection, ['2']))),
+              ),
               [items[1]],
             );
           });
@@ -977,20 +983,18 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
             );
           });
 
-          // In a subcollection query the `__name__` value is a plain document id relative to
-          // the queried subcollection (the parent id is NOT part of the value).
           it('filter by id', async () => {
             await expectQuery(
               query(
                 { collection: repository.collection, parent: ['author1'] },
-                where(eq('__name__', '1')),
+                where(eq('__name__', refPath(repository.collection, ['author1', '1']))),
               ),
               [items[0]],
             );
             await expectQuery(
               query(
                 { collection: repository.collection, parent: ['author1'] },
-                where(eq('__name__', '2')),
+                where(eq('__name__', refPath(repository.collection, ['author1', '2']))),
               ),
               [items[1]],
             );
@@ -1019,36 +1023,25 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
             );
           });
 
-          // In a collection group query the `__name__` value must be the fully-qualified document
-          // path relative to the database root (e.g. `Authors/author1/Posts/1`), unlike a plain
-          // collection/subcollection query which takes a plain document id. A plain id is rejected
-          // by Firestore because it does not resolve to a valid (even-segment) document path.
+          // The `__name__` operand is the same `RefPath` in every scope — the
+          // adapters encode it to a reference value, which (unlike the SDK's
+          // scope-dependent string conventions) works uniformly for
+          // collection, subcollection, and collection group queries.
           it('filter by id', async () => {
             await expectQuery(
               query(
                 { collection: repository.collection, group: true },
-                where(eq('__name__', documentPath(repository.collection, ['author1', '1']))),
+                where(eq('__name__', refPath(repository.collection, ['author1', '1']))),
               ),
               [items[0]],
             );
             await expectQuery(
               query(
                 { collection: repository.collection, group: true },
-                where(eq('__name__', documentPath(repository.collection, ['author2', '3']))),
+                where(eq('__name__', refPath(repository.collection, ['author2', '3']))),
               ),
               [items[2]],
             );
-          });
-
-          it('filter by id rejects a plain document id', async () => {
-            await expect(
-              repository.list(
-                query(
-                  { collection: repository.collection, group: true },
-                  where(eq('__name__', '1')),
-                ),
-              ),
-            ).rejects.toThrowError(/odd number of segments/);
           });
 
           it('orderBy id', async () => {
@@ -1076,7 +1069,7 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
           null: nullType(),
           docRef: docRef(authorsCollection),
           // The context-free flavor: a reference to no one particular
-          // collection, round-tripping relative path strings.
+          // collection, round-tripping untyped segment paths.
           anyRef: docRef(),
           str: string(),
           vector: vector(),
@@ -1101,8 +1094,8 @@ export const defineRepositorySpecificationTests = <Env extends FirestoreEnvironm
             geoPoint: { latitude: 12.3, longitude: 45.6 },
             map: { a: 123, b: ['foo', 'bar'], nested: { c: 7 } },
             null: null,
-            docRef: [randomString()],
-            anyRef: 'SomeOtherCollection/some-doc-id',
+            docRef: refPath(authorsCollection, [randomString()]),
+            anyRef: ['SomeOtherCollection', 'some-doc-id'],
             str: randomString(),
             vector: [1, 2, 3, 4, 5],
             literalStr: 'foo',

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -60,15 +60,15 @@ describe('path', () => {
 
     it('takes typed paths only: a path of the wrong collection is a compile error', () => {
       // @ts-expect-error -- 4 segments cannot be a Users path
-      expect(() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow();
+      void (() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1']));
       // @ts-expect-error -- a Comments segment cannot appear in a Posts path
-      expect(() => toDocRef(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow();
+      void (() => toDocRef(posts, ['Users', 'user1', 'Comments', 'c1']));
       const postsPath = refPath(posts, ['user1', 'post1']);
       // @ts-expect-error -- a typed RefPath of another collection is rejected
-      expect(() => toDocRef(users, postsPath)).toThrow();
+      void (() => toDocRef(users, postsPath));
       const untyped: string[] = ['Users', 'user1'];
       // @ts-expect-error -- an untyped string[] must be narrowed with parseRefPath first
-      expect(toDocRef(users, untyped)).toStrictEqual(['user1']);
+      void (() => toDocRef(users, untyped));
     });
   });
 

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -56,6 +56,19 @@ describe('path', () => {
         'user1',
         'post1',
       ]);
+      expect(
+        toDocRef(comments, ['Users', 'user1', 'Posts', 'post1', 'Comments', 'comment1']),
+      ).toStrictEqual(['user1', 'post1', 'comment1']);
+      expectTypeOf(toDocRef(posts, refPath(posts, ['user1', 'post1']))).toEqualTypeOf<
+        [string, string]
+      >();
+    });
+
+    it('fails loudly on a lying type assertion instead of yielding wrong ids', () => {
+      const wide: string[] = ['Posts', 'post1'];
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- deliberately lying, to exercise the guard
+      const lying = wide as RefPath<typeof users>;
+      expect(() => toDocRef(users, lying)).toThrow(/segment 0 is 'Posts', expected 'Users'/);
     });
 
     it('takes typed paths only: a path of the wrong collection is a compile error', () => {
@@ -74,18 +87,37 @@ describe('path', () => {
 
   describe('parseRefPath', () => {
     it('narrows an untyped (context-free) segment path after runtime validation', () => {
-      const untyped: string[] = ['Users', 'user1', 'Posts', 'post1'];
-      const narrowed = parseRefPath(posts, untyped);
-      expectTypeOf(narrowed).toEqualTypeOf<['Users', string, 'Posts', string]>();
-      expect(toDocRef(posts, narrowed)).toStrictEqual(['user1', 'post1']);
+      const rootPath: string[] = ['Users', 'user1'];
+      const root = parseRefPath(users, rootPath);
+      expectTypeOf(root).toEqualTypeOf<['Users', string]>();
+      expect(root).toStrictEqual(['Users', 'user1']);
+
+      const subPath: string[] = ['Users', 'user1', 'Posts', 'post1'];
+      const sub = parseRefPath(posts, subPath);
+      expectTypeOf(sub).toEqualTypeOf<['Users', string, 'Posts', string]>();
+      expect(sub).toStrictEqual(['Users', 'user1', 'Posts', 'post1']);
+
+      const deepPath: string[] = ['Users', 'user1', 'Posts', 'post1', 'Comments', 'comment1'];
+      expect(parseRefPath(comments, deepPath)).toStrictEqual(deepPath);
     });
 
-    it('rejects a path that does not belong to the collection', () => {
+    it('rejects a wrong segment count', () => {
       expect(() => parseRefPath(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
         /expected 2 segments/,
       );
+      expect(() => parseRefPath(posts, ['post1'])).toThrow(/expected 4 segments/);
+      expect(() => parseRefPath(users, [])).toThrow(/expected 2 segments/);
+    });
+
+    it('rejects a wrong collection name at any name position', () => {
+      expect(() => parseRefPath(users, ['Posts', 'user1'])).toThrow(
+        /segment 0 is 'Posts', expected 'Users'/,
+      );
       expect(() => parseRefPath(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
         /segment 2 is 'Comments', expected 'Posts'/,
+      );
+      expect(() => parseRefPath(comments, ['Users', 'u1', 'Posts', 'p1', 'Likes', 'l1'])).toThrow(
+        /segment 4 is 'Likes', expected 'Comments'/,
       );
     });
   });

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -63,13 +63,21 @@ describe('path', () => {
       expect(toDocRef(posts, untyped)).toStrictEqual(['user1', 'post1']);
     });
 
-    it('rejects a path that does not belong to the collection', () => {
-      expect(() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
-        /expected 2 segments/,
-      );
-      expect(() => toDocRef(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
-        /segment 2 is 'Comments', expected 'Posts'/,
-      );
+    it('rejects a tuple-shaped path of the wrong collection at compile time', () => {
+      // @ts-expect-error -- 4 segments cannot be a Users path
+      expect(() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow();
+      // @ts-expect-error -- a Comments segment cannot appear in a Posts path
+      expect(() => toDocRef(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow();
+      const postsPath = refPath(posts, ['user1', 'post1']);
+      // @ts-expect-error -- a typed RefPath of another collection is rejected
+      expect(() => toDocRef(users, postsPath)).toThrow();
+    });
+
+    it('rejects an untyped path that does not belong to the collection at runtime', () => {
+      const tooLong: string[] = ['Users', 'user1', 'Posts', 'post1'];
+      expect(() => toDocRef(users, tooLong)).toThrow(/expected 2 segments/);
+      const wrongName: string[] = ['Users', 'user1', 'Comments', 'c1'];
+      expect(() => toDocRef(posts, wrongName)).toThrow(/segment 2 is 'Comments', expected 'Posts'/);
     });
   });
 

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { collectionPath, documentPath, refPath, toDocRef } from './path.js';
+import { asRefPath, collectionPath, documentPath, refPath, toDocRef } from './path.js';
 import { type RefPath, rootCollection, string, subCollection } from './schema.js';
 
 describe('path', () => {
@@ -58,12 +58,7 @@ describe('path', () => {
       ]);
     });
 
-    it('accepts an untyped (context-free) segment path after runtime validation', () => {
-      const untyped: string[] = ['Users', 'user1', 'Posts', 'post1'];
-      expect(toDocRef(posts, untyped)).toStrictEqual(['user1', 'post1']);
-    });
-
-    it('rejects a tuple-shaped path of the wrong collection at compile time', () => {
+    it('takes typed paths only: a path of the wrong collection is a compile error', () => {
       // @ts-expect-error -- 4 segments cannot be a Users path
       expect(() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow();
       // @ts-expect-error -- a Comments segment cannot appear in a Posts path
@@ -71,13 +66,27 @@ describe('path', () => {
       const postsPath = refPath(posts, ['user1', 'post1']);
       // @ts-expect-error -- a typed RefPath of another collection is rejected
       expect(() => toDocRef(users, postsPath)).toThrow();
+      const untyped: string[] = ['Users', 'user1'];
+      // @ts-expect-error -- an untyped string[] must be narrowed with asRefPath first
+      expect(toDocRef(users, untyped)).toStrictEqual(['user1']);
+    });
+  });
+
+  describe('asRefPath', () => {
+    it('narrows an untyped (context-free) segment path after runtime validation', () => {
+      const untyped: string[] = ['Users', 'user1', 'Posts', 'post1'];
+      const narrowed = asRefPath(posts, untyped);
+      expectTypeOf(narrowed).toEqualTypeOf<['Users', string, 'Posts', string]>();
+      expect(toDocRef(posts, narrowed)).toStrictEqual(['user1', 'post1']);
     });
 
-    it('rejects an untyped path that does not belong to the collection at runtime', () => {
-      const tooLong: string[] = ['Users', 'user1', 'Posts', 'post1'];
-      expect(() => toDocRef(users, tooLong)).toThrow(/expected 2 segments/);
-      const wrongName: string[] = ['Users', 'user1', 'Comments', 'c1'];
-      expect(() => toDocRef(posts, wrongName)).toThrow(/segment 2 is 'Comments', expected 'Posts'/);
+    it('rejects a path that does not belong to the collection', () => {
+      expect(() => asRefPath(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
+        /expected 2 segments/,
+      );
+      expect(() => asRefPath(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
+        /segment 2 is 'Comments', expected 'Posts'/,
+      );
     });
   });
 

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { asRefPath, collectionPath, documentPath, refPath, toDocRef } from './path.js';
+import { parseRefPath, collectionPath, documentPath, refPath, toDocRef } from './path.js';
 import { type RefPath, rootCollection, string, subCollection } from './schema.js';
 
 describe('path', () => {
@@ -67,24 +67,24 @@ describe('path', () => {
       // @ts-expect-error -- a typed RefPath of another collection is rejected
       expect(() => toDocRef(users, postsPath)).toThrow();
       const untyped: string[] = ['Users', 'user1'];
-      // @ts-expect-error -- an untyped string[] must be narrowed with asRefPath first
+      // @ts-expect-error -- an untyped string[] must be narrowed with parseRefPath first
       expect(toDocRef(users, untyped)).toStrictEqual(['user1']);
     });
   });
 
-  describe('asRefPath', () => {
+  describe('parseRefPath', () => {
     it('narrows an untyped (context-free) segment path after runtime validation', () => {
       const untyped: string[] = ['Users', 'user1', 'Posts', 'post1'];
-      const narrowed = asRefPath(posts, untyped);
+      const narrowed = parseRefPath(posts, untyped);
       expectTypeOf(narrowed).toEqualTypeOf<['Users', string, 'Posts', string]>();
       expect(toDocRef(posts, narrowed)).toStrictEqual(['user1', 'post1']);
     });
 
     it('rejects a path that does not belong to the collection', () => {
-      expect(() => asRefPath(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
+      expect(() => parseRefPath(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
         /expected 2 segments/,
       );
-      expect(() => asRefPath(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
+      expect(() => parseRefPath(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
         /segment 2 is 'Comments', expected 'Posts'/,
       );
     });

--- a/packages/firestore-repository/src/path.test.ts
+++ b/packages/firestore-repository/src/path.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { collectionPath, documentPath } from './path.js';
-import { rootCollection, string, subCollection } from './schema.js';
+import { collectionPath, documentPath, refPath, toDocRef } from './path.js';
+import { type RefPath, rootCollection, string, subCollection } from './schema.js';
 
 describe('path', () => {
   // Test collections
@@ -18,6 +18,58 @@ describe('path', () => {
       expect(collectionPath(users, [])).toBe('Users');
       expect(collectionPath(posts, ['user1'])).toBe('Users/user1/Posts');
       expect(collectionPath(comments, ['user1', 'post1'])).toBe('Users/user1/Posts/post1/Comments');
+    });
+  });
+
+  describe('refPath', () => {
+    it('interleaves collection names into the segment path', () => {
+      expect(refPath(users, ['user1'])).toStrictEqual(['Users', 'user1']);
+      expect(refPath(posts, ['user1', 'post1'])).toStrictEqual([
+        'Users',
+        'user1',
+        'Posts',
+        'post1',
+      ]);
+      expect(refPath(comments, ['user1', 'post1', 'comment1'])).toStrictEqual([
+        'Users',
+        'user1',
+        'Posts',
+        'post1',
+        'Comments',
+        'comment1',
+      ]);
+    });
+
+    it('types collection-name positions as literals', () => {
+      expectTypeOf(refPath(users, ['user1'])).toEqualTypeOf<['Users', string]>();
+      expectTypeOf(refPath(posts, ['user1', 'post1'])).toEqualTypeOf<
+        ['Users', string, 'Posts', string]
+      >();
+      expectTypeOf<RefPath<'unknown'>>().toEqualTypeOf<string[]>();
+    });
+  });
+
+  describe('toDocRef', () => {
+    it('extracts the ids-only address from a segment path', () => {
+      expect(toDocRef(users, ['Users', 'user1'])).toStrictEqual(['user1']);
+      expect(toDocRef(posts, ['Users', 'user1', 'Posts', 'post1'])).toStrictEqual([
+        'user1',
+        'post1',
+      ]);
+    });
+
+    it('accepts an untyped (context-free) segment path after runtime validation', () => {
+      const untyped: string[] = ['Users', 'user1', 'Posts', 'post1'];
+      expect(toDocRef(posts, untyped)).toStrictEqual(['user1', 'post1']);
+    });
+
+    it('rejects a path that does not belong to the collection', () => {
+      expect(() => toDocRef(users, ['Users', 'user1', 'Posts', 'post1'])).toThrow(
+        /expected 2 segments/,
+      );
+      expect(() => toDocRef(posts, ['Users', 'user1', 'Comments', 'c1'])).toThrow(
+        /segment 2 is 'Comments', expected 'Posts'/,
+      );
     });
   });
 

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -44,12 +44,15 @@ export const parseRefPath = <T extends Collection>(collection: T, path: string[]
  * ADDRESS (`DocRef`) of the given collection, so a reference read from a
  * document field can be passed to that collection's repository. Takes the
  * typed `RefPath<T>` only — narrow a context-free `string[]` with
- * {@link parseRefPath} first. (Validation still runs, via `parseRefPath`, as a
- * guard for assertion-carrying callers.)
+ * {@link parseRefPath} first. A `RefPath<T>` is valid by construction, so no
+ * re-validation happens here; the ids are simply the odd positions. The
+ * collection argument is not read at runtime — it anchors `T`, which cannot
+ * be inferred from the structural segment tuple alone, and makes passing a
+ * path of the wrong collection a compile error.
  */
-export const toDocRef = <T extends Collection>(collection: T, path: RefPath<T>): DocRef<T> =>
+export const toDocRef = <T extends Collection>(_collection: T, path: RefPath<T>): DocRef<T> =>
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
-  parseRefPath(collection, path).filter((_, i) => i % 2 === 1) as DocRef<T>;
+  path.filter((_, i) => i % 2 === 1) as DocRef<T>;
 /**
  * Returns the fully-qualified path of a document
  */

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -21,7 +21,7 @@ export const refPath = <T extends Collection>(collection: T, docRef: DocRef<T>):
  * is validated at runtime — segment count and every collection-name
  * position — since the input carries no static shape.
  */
-export const asRefPath = <T extends Collection>(collection: T, path: string[]): RefPath<T> => {
+export const parseRefPath = <T extends Collection>(collection: T, path: string[]): RefPath<T> => {
   const names = [...collection.parent, collection.name];
   if (path.length !== names.length * 2) {
     throw new Error(
@@ -44,12 +44,12 @@ export const asRefPath = <T extends Collection>(collection: T, path: string[]): 
  * ADDRESS (`DocRef`) of the given collection, so a reference read from a
  * document field can be passed to that collection's repository. Takes the
  * typed `RefPath<T>` only — narrow a context-free `string[]` with
- * {@link asRefPath} first. (Validation still runs, via `asRefPath`, as a
+ * {@link parseRefPath} first. (Validation still runs, via `parseRefPath`, as a
  * guard for assertion-carrying callers.)
  */
 export const toDocRef = <T extends Collection>(collection: T, path: RefPath<T>): DocRef<T> =>
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
-  asRefPath(collection, path).filter((_, i) => i % 2 === 1) as DocRef<T>;
+  parseRefPath(collection, path).filter((_, i) => i % 2 === 1) as DocRef<T>;
 /**
  * Returns the fully-qualified path of a document
  */

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -44,15 +44,17 @@ export const parseRefPath = <T extends Collection>(collection: T, path: string[]
  * ADDRESS (`DocRef`) of the given collection, so a reference read from a
  * document field can be passed to that collection's repository. Takes the
  * typed `RefPath<T>` only — narrow a context-free `string[]` with
- * {@link parseRefPath} first. A `RefPath<T>` is valid by construction, so no
- * re-validation happens here; the ids are simply the odd positions. The
- * collection argument is not read at runtime — it anchors `T`, which cannot
- * be inferred from the structural segment tuple alone, and makes passing a
- * path of the wrong collection a compile error.
+ * {@link parseRefPath} first; the ids are the odd positions. A `RefPath<T>`
+ * is valid by construction, so the `parseRefPath` pass here never throws for
+ * a type-checked caller — it exists so that a lying type assertion upstream
+ * fails loudly instead of silently yielding the wrong ids. The collection
+ * argument also anchors `T`, which cannot be inferred from the structural
+ * segment tuple alone, making a path of the wrong collection a compile
+ * error.
  */
-export const toDocRef = <T extends Collection>(_collection: T, path: RefPath<T>): DocRef<T> =>
+export const toDocRef = <T extends Collection>(collection: T, path: RefPath<T>): DocRef<T> =>
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
-  path.filter((_, i) => i % 2 === 1) as DocRef<T>;
+  parseRefPath(collection, path).filter((_, i) => i % 2 === 1) as DocRef<T>;
 /**
  * Returns the fully-qualified path of a document
  */

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -1,20 +1,53 @@
 import { DocRef, ParentDocRef } from './repository.js';
-import type { Collection } from './schema.js';
+import type { Collection, RefPath } from './schema.js';
+
+/**
+ * Converts an ids-only ADDRESS (`DocRef`, the repository interface's id
+ * representation) into a reference VALUE (`RefPath` segment path) by
+ * interleaving the collection names from the collection definition:
+ * `refPath(posts, ['a1', 'p1'])` -> `['Authors', 'a1', 'Posts', 'p1']`.
+ */
+export const refPath = <T extends Collection>(collection: T, docRef: DocRef<T>): RefPath<T> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- flatMap cannot preserve the interleaved tuple shape
+  [...collection.parent, collection.name].flatMap((name, i) => [
+    name,
+    docRef[i] as string,
+  ]) as RefPath<T>;
+
+/**
+ * Converts a reference VALUE (`RefPath` segment path) back into the ids-only
+ * ADDRESS (`DocRef`) of the given collection, so a reference read from a
+ * document field can be passed to that collection's repository. Validates at
+ * runtime that the path actually belongs to the collection (segment count
+ * and every collection-name position), since a context-free `RefPath` is
+ * just a `string[]`.
+ */
+export const toDocRef = <T extends Collection>(
+  collection: T,
+  path: RefPath<T> | RefPath<'unknown'>,
+): DocRef<T> => {
+  const names = [...collection.parent, collection.name];
+  if (path.length !== names.length * 2) {
+    throw new Error(
+      `reference path [${path.join(', ')}] does not belong to collection '${collection.name}': expected ${names.length * 2} segments`,
+    );
+  }
+  names.forEach((name, i) => {
+    if (path[i * 2] !== name) {
+      throw new Error(
+        `reference path [${path.join(', ')}] does not belong to collection '${collection.name}': segment ${i * 2} is '${path[i * 2]}', expected '${name}'`,
+      );
+    }
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
+  return path.filter((_, i) => i % 2 === 1) as DocRef<T>;
+};
 
 /**
  * Returns the fully-qualified path of a document
  */
-export const documentPath = <T extends Collection>(collection: T, docRef: DocRef<T>): string => {
-  let path = '';
-
-  // parent document path
-  for (let i = 0; i < collection.parent.length; i++) {
-    path += `${collection.parent[i]}/${docRef[i]}/`;
-  }
-
-  path += `${collection.name}/${docRef.at(-1)}`;
-  return path;
-};
+export const documentPath = <T extends Collection>(collection: T, docRef: DocRef<T>): string =>
+  refPath(collection, docRef).join('/');
 
 /**
  * Returns the fully-qualified path of a collection

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -17,15 +17,26 @@ export const refPath = <T extends Collection>(collection: T, docRef: DocRef<T>):
 /**
  * Converts a reference VALUE (`RefPath` segment path) back into the ids-only
  * ADDRESS (`DocRef`) of the given collection, so a reference read from a
- * document field can be passed to that collection's repository. Validates at
- * runtime that the path actually belongs to the collection (segment count
- * and every collection-name position), since a context-free `RefPath` is
- * just a `string[]`.
+ * document field can be passed to that collection's repository.
+ *
+ * Two patterns, statically separated by the argument's precision:
+ *
+ * - A tuple-shaped path (an inline literal, or a value typed `RefPath<T>`)
+ *   must match the collection's `RefPath` at COMPILE time — a path of the
+ *   wrong collection is rejected by the first overload, and the second
+ *   overload's conditional turns back into `RefPath<T>` for any non-wide
+ *   tuple, so it cannot fall through to the permissive signature.
+ * - A wide `string[]` (a context-free `RefPath<'unknown'>` read from a
+ *   `docRef()` field or a raw `__name__` key) carries no static shape, so it
+ *   is accepted as-is and checked at RUNTIME instead (segment count and
+ *   every collection-name position).
  */
-export const toDocRef = <T extends Collection>(
+export function toDocRef<T extends Collection>(collection: T, path: RefPath<T>): DocRef<T>;
+export function toDocRef<T extends Collection, const P extends string[]>(
   collection: T,
-  path: RefPath<T> | RefPath<'unknown'>,
-): DocRef<T> => {
+  path: string[] extends P ? P : RefPath<T>,
+): DocRef<T>;
+export function toDocRef<T extends Collection>(collection: T, path: string[]): DocRef<T> {
   const names = [...collection.parent, collection.name];
   if (path.length !== names.length * 2) {
     throw new Error(
@@ -41,7 +52,7 @@ export const toDocRef = <T extends Collection>(
   });
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
   return path.filter((_, i) => i % 2 === 1) as DocRef<T>;
-};
+}
 
 /**
  * Returns the fully-qualified path of a document

--- a/packages/firestore-repository/src/path.ts
+++ b/packages/firestore-repository/src/path.ts
@@ -15,28 +15,13 @@ export const refPath = <T extends Collection>(collection: T, docRef: DocRef<T>):
   ]) as RefPath<T>;
 
 /**
- * Converts a reference VALUE (`RefPath` segment path) back into the ids-only
- * ADDRESS (`DocRef`) of the given collection, so a reference read from a
- * document field can be passed to that collection's repository.
- *
- * Two patterns, statically separated by the argument's precision:
- *
- * - A tuple-shaped path (an inline literal, or a value typed `RefPath<T>`)
- *   must match the collection's `RefPath` at COMPILE time — a path of the
- *   wrong collection is rejected by the first overload, and the second
- *   overload's conditional turns back into `RefPath<T>` for any non-wide
- *   tuple, so it cannot fall through to the permissive signature.
- * - A wide `string[]` (a context-free `RefPath<'unknown'>` read from a
- *   `docRef()` field or a raw `__name__` key) carries no static shape, so it
- *   is accepted as-is and checked at RUNTIME instead (segment count and
- *   every collection-name position).
+ * Narrows a context-free reference value (`RefPath<'unknown'>`, a plain
+ * `string[]` read from a `docRef()` field or a raw `__name__` key) into the
+ * typed `RefPath` of a collection the caller knows it belongs to. The claim
+ * is validated at runtime — segment count and every collection-name
+ * position — since the input carries no static shape.
  */
-export function toDocRef<T extends Collection>(collection: T, path: RefPath<T>): DocRef<T>;
-export function toDocRef<T extends Collection, const P extends string[]>(
-  collection: T,
-  path: string[] extends P ? P : RefPath<T>,
-): DocRef<T>;
-export function toDocRef<T extends Collection>(collection: T, path: string[]): DocRef<T> {
+export const asRefPath = <T extends Collection>(collection: T, path: string[]): RefPath<T> => {
   const names = [...collection.parent, collection.name];
   if (path.length !== names.length * 2) {
     throw new Error(
@@ -50,10 +35,21 @@ export function toDocRef<T extends Collection>(collection: T, path: string[]): D
       );
     }
   });
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
-  return path.filter((_, i) => i % 2 === 1) as DocRef<T>;
-}
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the loop above verified exactly the shape RefPath<T> declares
+  return path as RefPath<T>;
+};
 
+/**
+ * Converts a reference VALUE (`RefPath` segment path) back into the ids-only
+ * ADDRESS (`DocRef`) of the given collection, so a reference read from a
+ * document field can be passed to that collection's repository. Takes the
+ * typed `RefPath<T>` only — narrow a context-free `string[]` with
+ * {@link asRefPath} first. (Validation still runs, via `asRefPath`, as a
+ * guard for assertion-carrying callers.)
+ */
+export const toDocRef = <T extends Collection>(collection: T, path: RefPath<T>): DocRef<T> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- filter cannot preserve the tuple shape
+  asRefPath(collection, path).filter((_, i) => i % 2 === 1) as DocRef<T>;
 /**
  * Returns the fully-qualified path of a document
  */

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import { refPath } from '../path.js';
 import {
   array,
   bool,
@@ -761,15 +762,15 @@ describe('reference / type / vector operators', () => {
 describe('document-reference values', () => {
   const authors = rootCollection({ name: 'authors', schema: { name: string() } });
 
-  it('docRefValue is a dedicated node carrying its collection and id', () => {
-    const ref = docRefValue(authors, ['a1']);
-    expect(ref).toStrictEqual(new DocRefValue(authors, ['a1']));
-    expect(ref.type).toStrictEqual(docRef(authors));
-    expectTypeOf(ref.type).toEqualTypeOf(docRef(authors));
+  it('docRefValue is a dedicated node carrying a RefPath segment path', () => {
+    const ref = docRefValue(refPath(authors, ['a1']));
+    expect(ref).toStrictEqual(new DocRefValue(['authors', 'a1']));
+    expect(ref.type).toStrictEqual(docRef());
+    expectTypeOf(ref.type).toEqualTypeOf(docRef());
   });
 
   it('compares against reference operands only (probed: strings never match)', () => {
-    const ref = constant(docRefValue(authors, ['a1']));
+    const ref = constant(docRefValue(refPath(authors, ['a1'])));
     equal(field(docRef(), '__name__'), ref);
     equal(field(docRef(authors), 'ref'), ref);
     // @ts-expect-error -- a reference never equals a string (always-false on the backend)
@@ -794,8 +795,8 @@ describe('document-reference values', () => {
   });
 
   it('doubles as a composite constant leaf, like geopoint/vector nodes', () => {
-    const c = constant({ author: docRefValue(authors, ['a1']) });
-    const oracle = map({ author: docRef(authors) });
+    const c = constant({ author: docRefValue(refPath(authors, ['a1'])) });
+    const oracle = map({ author: docRef() });
     expect(c.type).toStrictEqual(oracle);
     expectTypeOf(c.type).toEqualTypeOf(oracle);
   });

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -1,4 +1,3 @@
-import type { DocRef } from '../repository.js';
 import {
   array,
   type ArrayType,
@@ -6,7 +5,6 @@ import {
   type BoolType,
   bytes,
   type BytesType,
-  type Collection,
   docRef,
   type DocRefType,
   double,
@@ -172,27 +170,25 @@ export class VectorValue {
  * A document-reference VALUE (not an expression — lift it with
  * `constant(docRefValue(...))`). A dedicated constructor for the same
  * classification rule as {@link GeoPointValue} / {@link VectorValue}: a
- * reference's plain-JS representation (`DocRef<T>`, an id tuple) is a string
- * array — always an **array** constant — and building the wire reference
- * needs the collection context anyway, so both come explicitly. This is the
- * comparand that makes reference comparisons meaningful: probed, the
- * pipeline backend never matches `__name__` against ANY string form
- * (id / relative path / full resource path — all `false`), only against a
- * reference value.
+ * reference's plain-JS representation (`RefPath`, a segment path) is a
+ * string array — always an **array** constant — so the reference
+ * interpretation must be explicit. This is the comparand that makes
+ * reference comparisons meaningful: probed, the pipeline backend never
+ * matches `__name__` against ANY string form (id / relative path / full
+ * resource path — all `false`), only against a reference value. Build the
+ * segment path from a repository-side id with `refPath(collection, id)`
+ * (`path.js`).
  */
-export class DocRefValue<T extends Collection = Collection> {
-  readonly type: DocRefType<T>;
-  constructor(
-    readonly collection: T,
-    readonly id: DocRef<T>,
-  ) {
-    this.type = docRef(collection);
+export class DocRefValue {
+  readonly type: DocRefType<'unknown'> = docRef();
+  readonly path: readonly string[];
+  constructor(path: readonly string[]) {
+    this.path = [...path];
   }
 }
 
 /** Builds a document-reference value — see {@link DocRefValue}. */
-export const docRefValue = <T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T> =>
-  new DocRefValue(collection, id);
+export const docRefValue = (path: readonly string[]): DocRefValue => new DocRefValue(path);
 
 /**
  * The value domain `constant()` accepts — everything with an unambiguous
@@ -201,7 +197,7 @@ export const docRefValue = <T extends Collection>(collection: T, id: DocRef<T>):
  * explicit constructors instead — a plain object is always a **map** constant
  * (use {@link geoPointValue} for geopoints), a `number[]` is always an
  * **array** constant (use {@link vectorValue} for vectors), and a `string[]`
- * id tuple likewise (use {@link docRefValue} for document references).
+ * segment path likewise (use {@link docRefValue} for document references).
  */
 export type ConstantValue = ConstantScalar | ConstantLeafNode | ConstantArray | ConstantMap;
 export type ConstantScalar = string | number | boolean | null | Date | Uint8Array;
@@ -237,8 +233,8 @@ export type ConstantTypeOf<V extends ConstantValue> = ConstantValue extends V
       ? TimestampType
       : V extends Uint8Array
         ? BytesType
-        : V extends DocRefValue<infer C>
-          ? DocRefType<C>
+        : V extends DocRefValue
+          ? DocRefType<'unknown'>
           : V extends GeoPointValue
             ? GeoPointType
             : V extends VectorValue

--- a/packages/firestore-repository/src/query.test.ts
+++ b/packages/firestore-repository/src/query.test.ts
@@ -1,8 +1,17 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { authorsCollection, postsCollection } from './__test__/specification.js';
-import { type FilterOperand, limit, orderBy, query } from './query.js';
-import { ArrayType, Int64Type, NullType, StringType, UnionType } from './schema.js';
+import { type FilterOperand, filterOperand, limit, orderBy, query } from './query.js';
+import {
+  type ArrayType,
+  array,
+  type Int64Type,
+  int64,
+  type NullType,
+  type StringType,
+  string,
+  type UnionType,
+} from './schema.js';
 
 describe('query', () => {
   describe('query function argument', () => {
@@ -67,5 +76,17 @@ describe('query', () => {
     expectTypeOf<FilterOperand<ArrayType<StringType>, 'array-contains-any'>>().toEqualTypeOf<
       ArrayType<StringType>
     >();
+  });
+
+  it('filterOperand (runtime counterpart of FilterOperand)', () => {
+    const int = int64();
+    expect(filterOperand(int, '==')).toStrictEqual(int);
+    expect(filterOperand(int, '>')).toStrictEqual(int);
+    expect(filterOperand(int, 'in')).toStrictEqual(array(int));
+    expect(filterOperand(int, 'not-in')).toStrictEqual(array(int));
+    expect(filterOperand(array(string()), 'array-contains')).toStrictEqual(string());
+    expect(filterOperand(array(string()), 'array-contains-any')).toStrictEqual(array(string()));
+    // type-level never — at runtime an explicit error
+    expect(() => filterOperand(int, 'array-contains')).toThrow(/requires an array field/);
   });
 });

--- a/packages/firestore-repository/src/query.ts
+++ b/packages/firestore-repository/src/query.ts
@@ -1,13 +1,15 @@
 import { ParentDocRef } from './repository.js';
-import type {
-  ArrayType,
-  Collection,
-  DocumentSchema,
-  DocFieldPath,
-  FieldType,
-  FieldTypeOfPath,
-  FieldValue,
+import {
+  type ArrayType,
+  array,
+  type Collection,
+  type DocumentSchema,
+  type DocFieldPath,
+  type FieldType,
+  type FieldTypeOfPath,
+  type FieldValue,
 } from './schema.js';
+import { assertNever } from './util.js';
 
 /**
  * A universal query definition
@@ -348,6 +350,36 @@ export type FilterOperand<T extends FieldType, U extends WhereFilterOp> = {
   'array-contains': T extends ArrayType<infer A> ? A : never;
   'array-contains-any': T extends ArrayType<infer A> ? ArrayType<A> : never;
 }[U];
+
+/**
+ * Runtime counterpart of {@link FilterOperand} (same operator mapping):
+ * resolves the `FieldType` describing a single operand of a filter condition
+ * on a field — the field's own type for comparisons, a list of it for
+ * `in`/`not-in`, the array's element type for `array-contains(-any)`.
+ */
+export const filterOperand = (fieldType: FieldType, opStr: WhereFilterOp): FieldType => {
+  switch (opStr) {
+    case '<':
+    case '<=':
+    case '==':
+    case '!=':
+    case '>=':
+    case '>':
+      return fieldType;
+    case 'in':
+    case 'not-in':
+      return array(fieldType);
+    case 'array-contains':
+    case 'array-contains-any': {
+      if (fieldType.type !== 'array') {
+        throw new Error(`operator "${opStr}" requires an array field`);
+      }
+      return opStr === 'array-contains' ? fieldType.dynamicPart : array(fieldType.dynamicPart);
+    }
+    default:
+      return assertNever(opStr);
+  }
+};
 
 /**
  * A filter condition operator

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { DocRef } from './repository.js';
 import {
   type AnyMapType,
   array,
@@ -11,6 +10,7 @@ import {
   docRef,
   double,
   type DocRefType,
+  type RefPath,
   type DoubleType,
   type DocumentSchema,
   type DocFieldPath,
@@ -92,14 +92,15 @@ describe('schema', () => {
       type TestCollection = typeof testCollection;
 
       const type = docRef(testCollection);
-      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<DocRef<TestCollection>>();
-      expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<DocRef<TestCollection>>();
+      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<RefPath<TestCollection>>();
+      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<['TestCollection', string]>();
+      expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<RefPath<TestCollection>>();
     });
 
-    it('docRef (context-free flavor): relative path strings both ways', () => {
+    it('docRef (context-free flavor): untyped segment paths both ways', () => {
       const type = docRef();
-      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<string>();
-      expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<string>();
+      expectTypeOf<FieldValue<typeof type, 'read'>>().toEqualTypeOf<string[]>();
+      expectTypeOf<FieldValue<typeof type, 'write'>>().toEqualTypeOf<string[]>();
     });
 
     it('bytes', () => {
@@ -391,7 +392,7 @@ describe('document', () => {
     expectTypeOf<FieldValueOfPath<Schema, 'b.optional'>>().toEqualTypeOf<'foo' | 'bar'>();
     expectTypeOf<FieldValueOfPath<Schema, 'b.optionalMap.f'>>().toEqualTypeOf<string>();
     expectTypeOf<FieldValueOfPath<Schema, 'b.optionalMap.g'>>().toEqualTypeOf<number>();
-    expectTypeOf<FieldValueOfPath<Schema, '__name__'>>().toEqualTypeOf<string>();
+    expectTypeOf<FieldValueOfPath<Schema, '__name__'>>().toEqualTypeOf<string[]>();
   });
 
   it('FieldTypeOfPath', () => {

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -170,7 +170,8 @@ export type TimestampType = {
  * same shape at different tuple precision (`RefPath<Posts>` is
  * `['Authors', string, 'Posts', string]`; `RefPath<'unknown'>` degrades to
  * `string[]`), instead of two unrelated representations. Convert between the
- * two with `refPath()` / `toDocRef()` (`path.js`).
+ * two with `refPath()` / `toDocRef()`, and narrow a context-free `string[]`
+ * into a typed `RefPath` with `asRefPath()` (`path.js`).
  */
 export type RefPath<T extends Collection | 'unknown' = Collection | 'unknown'> =
   T extends Collection ? SegmentTuple<[...T['parent'], T['name']]> : string[];

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -171,7 +171,7 @@ export type TimestampType = {
  * `['Authors', string, 'Posts', string]`; `RefPath<'unknown'>` degrades to
  * `string[]`), instead of two unrelated representations. Convert between the
  * two with `refPath()` / `toDocRef()`, and narrow a context-free `string[]`
- * into a typed `RefPath` with `asRefPath()` (`path.js`).
+ * into a typed `RefPath` with `parseRefPath()` (`path.js`).
  */
 export type RefPath<T extends Collection | 'unknown' = Collection | 'unknown'> =
   T extends Collection ? SegmentTuple<[...T['parent'], T['name']]> : string[];

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -1,29 +1,33 @@
-import { DocRef } from './repository.js';
-
 /**
  * A definition of a Firestore collection
  */
 export type Collection<
   Schema extends DocumentSchema = DocumentSchema,
+  Name extends string = string,
   Parent extends string[] = string[],
-> = { name: string; schema: Schema; parent: Parent };
+> = { name: Name; schema: Schema; parent: Parent };
 
 /** A root collection definition (no parent document) */
-export type RootCollection<Schema extends DocumentSchema = DocumentSchema> = Collection<Schema, []>;
+export type RootCollection<
+  Schema extends DocumentSchema = DocumentSchema,
+  Name extends string = string,
+> = Collection<Schema, Name, []>;
 
 /** A subcollection definition (nested under a parent document) */
 export type SubCollection<
   Schema extends DocumentSchema = DocumentSchema,
+  Name extends string = string,
   Parent extends [...string[], string] = [...string[], string],
-> = Collection<Schema, Parent>;
+> = Collection<Schema, Name, Parent>;
 
 /** Creates a root collection definition */
 export const rootCollection = <
   Schema extends DocumentSchema & WithoutDottedFieldNames<Schema>,
+  const Name extends string,
 >(params: {
-  name: string;
+  name: Name;
   schema: Schema;
-}): Collection<Schema, []> => {
+}): Collection<Schema, Name, []> => {
   assertNoDottedFieldNames(params.schema);
   return { ...params, parent: [] };
 };
@@ -31,12 +35,13 @@ export const rootCollection = <
 /** Creates a subcollection definition */
 export const subCollection = <
   Schema extends DocumentSchema & WithoutDottedFieldNames<Schema>,
+  const Name extends string,
   const Parent extends [...string[], string],
 >(params: {
-  name: string;
+  name: Name;
   schema: Schema;
   parent: Parent;
-}): SubCollection<Schema, Parent> => {
+}): SubCollection<Schema, Name, Parent> => {
   assertNoDottedFieldNames(params.schema);
   return params;
 };
@@ -151,6 +156,41 @@ export type TimestampType = {
   output: Date;
 };
 /**
+ * A document reference as a VALUE: the full segment path alternating
+ * collection names and document ids (`['Authors', 'a1']`,
+ * `['Authors', 'a1', 'Posts', 'p1']`). This is the one representation of a
+ * reference wherever it appears as data — a `docRef(...)` field's read/write
+ * value, a raw `'__name__'` key, a `docRefValue(...)` pipeline constant.
+ *
+ * It is deliberately distinct from `DocRef` (`repository.js`), the ids-only ADDRESS
+ * (`['a1', 'p1']`) used by the repository interface, where the collection is
+ * already fixed and repeating its name would be pure ceremony. Values carry
+ * their collection names because nothing in the surrounding context supplies
+ * them: this is what makes the known-collection and context-free flavors the
+ * same shape at different tuple precision (`RefPath<Posts>` is
+ * `['Authors', string, 'Posts', string]`; `RefPath<'unknown'>` degrades to
+ * `string[]`), instead of two unrelated representations. Convert between the
+ * two with `refPath()` / `toDocRef()` (`path.js`).
+ */
+export type RefPath<T extends Collection | 'unknown' = Collection | 'unknown'> =
+  T extends Collection ? SegmentTuple<[...T['parent'], T['name']]> : string[];
+
+/**
+ * Interleaves an id position after each collection-name position:
+ * `['Authors', 'Posts']` -> `['Authors', string, 'Posts', string]`. A
+ * non-tuple `string[]` input (a collection type whose names are not captured
+ * literally) degrades to `string[]`.
+ */
+type SegmentTuple<Names extends string[]> = Names extends [
+  infer H extends string,
+  ...infer Rest extends string[],
+]
+  ? [H, string, ...SegmentTuple<Rest>]
+  : Names extends []
+    ? []
+    : string[];
+
+/**
  * A document-reference descriptor. `T` is the referenced collection when the
  * schema knows it (a `docRef(collection)` data field), or the `'unknown'`
  * sentinel when it does not — the reserved `'__name__'` key resolves to
@@ -159,26 +199,20 @@ export type TimestampType = {
  * is a visible plain value, like the `Optional` marker, rather than
  * `undefined` ("the collection is unknown", not "there is no collection").
  *
- * The value representation follows the context: a known collection
- * round-trips `DocRef<T>` id tuples, while the context-free flavor reads AND
- * writes relative path strings (`'authors/a1'`). NOT a `string[]`: a
- * `DocRef` tuple holds ONLY ids (`['authorId', 'postId']` — the collection
- * names live in the schema and `documentPath` interleaves them), so a
- * context-free array would have to carry path SEGMENTS
- * (`['authors', 'a1']`) — a same-typed but differently-meaning shape,
- * indistinguishable from an id tuple in TS. The path string avoids that
- * collision, is the ecosystem's own context-free form (`ref.path` /
- * `db.doc(path)`), and is the core query API's id-filter contract
- * (`where(eq('__name__', id))`). Pipeline operator compatibility keys on the
- * shared `'reference'` tag, so both flavors compare with each other and
- * with `docRefValue(...)` constants.
+ * The value representation is a {@link RefPath} segment path in BOTH
+ * flavors: known/unknown is purely a gradient of tuple precision, not a
+ * change of shape. The ids-only `DocRef` address never appears as a field
+ * value — it belongs to the repository interface, whose collection context
+ * is fixed. Pipeline operator compatibility keys on the shared
+ * `'reference'` tag, so both flavors compare with each other and with
+ * `docRefValue(...)` constants.
  */
 export type DocRefType<T extends Collection | 'unknown' = Collection | 'unknown'> = {
   type: 'docRef';
   firestoreType: 'reference';
   collection: T;
-  input: T extends Collection ? DocRef<T> : string;
-  output: T extends Collection ? DocRef<T> : string;
+  input: RefPath<T>;
+  output: RefPath<T>;
 };
 export type BytesType = {
   type: 'bytes';

--- a/packages/google-cloud-firestore/src/codec.test.ts
+++ b/packages/google-cloud-firestore/src/codec.test.ts
@@ -1,7 +1,8 @@
 import { FieldValue, Firestore } from '@google-cloud/firestore';
+import { array, docRef, int64, map, rootCollection, string } from 'firestore-repository/schema';
 import { describe, expect, it } from 'vitest';
 
-import { isDocumentReference, isVectorValue } from './codec.js';
+import { buildEncodeFilterValue, isDocumentReference, isVectorValue } from './codec.js';
 
 const db = new Firestore({ projectId: 'codec-guard-test' });
 const ref = db.doc('col/id');
@@ -39,5 +40,69 @@ describe('isDocumentReference', () => {
   ];
   it.each(others)('returns false for %s', (_label, value) => {
     expect(isDocumentReference(value)).toBe(false);
+  });
+});
+
+describe('buildEncodeFilterValue', () => {
+  const authors = rootCollection({ name: 'Authors', schema: { name: string() } });
+  const schema = {
+    rank: int64(),
+    author: docRef(authors),
+    anyRef: docRef(),
+    reviewers: array(docRef(authors)),
+    meta: map({ editor: docRef(authors) }),
+  };
+  const encode = buildEncodeFilterValue(schema, db);
+
+  it('passes non-reference operands through', () => {
+    expect(encode('rank', '==', 1)).toBe(1);
+    expect(encode('rank', 'in', [1, 2])).toStrictEqual([1, 2]);
+  });
+
+  it('encodes a reference operand to a DocumentReference (every comparison op)', () => {
+    for (const op of ['==', '!=', '<', '<=', '>', '>='] as const) {
+      expect(encode('author', op, ['Authors', 'a1'])).toStrictEqual(db.doc('Authors/a1'));
+    }
+  });
+
+  it('encodes the context-free flavor (__name__ / docRef()) the same way', () => {
+    expect(encode('__name__', '==', ['SomeCollection', 'x1'])).toStrictEqual(
+      db.doc('SomeCollection/x1'),
+    );
+    expect(encode('anyRef', '==', ['SomeCollection', 'x1'])).toStrictEqual(
+      db.doc('SomeCollection/x1'),
+    );
+  });
+
+  it('resolves operand arity per operator', () => {
+    expect(
+      encode('author', 'in', [
+        ['Authors', 'a1'],
+        ['Authors', 'a2'],
+      ]),
+    ).toStrictEqual([db.doc('Authors/a1'), db.doc('Authors/a2')]);
+
+    expect(encode('reviewers', 'array-contains', ['Authors', 'a1'])).toStrictEqual(
+      db.doc('Authors/a1'),
+    );
+
+    expect(
+      encode('reviewers', 'array-contains-any', [
+        ['Authors', 'a1'],
+        ['Authors', 'a2'],
+      ]),
+    ).toStrictEqual([db.doc('Authors/a1'), db.doc('Authors/a2')]);
+  });
+
+  it('recurses into container operands', () => {
+    expect(encode('reviewers', '==', [['Authors', 'a1']])).toStrictEqual([db.doc('Authors/a1')]);
+    expect(encode('meta', '==', { editor: ['Authors', 'a1'] })).toStrictEqual({
+      editor: db.doc('Authors/a1'),
+    });
+  });
+
+  it('rejects a segment path that does not match the field descriptor', () => {
+    expect(() => encode('author', '==', ['Posts', 'p1'])).toThrow();
+    expect(() => encode('anyRef', '==', ['odd-length'])).toThrow();
   });
 });

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -6,9 +6,14 @@ import {
   Timestamp as FirestoreTimestamp,
   VectorValue as FirestoreVectorValue,
 } from '@google-cloud/firestore';
-import { documentPath } from 'firestore-repository/path';
-import type { DocRef } from 'firestore-repository/repository';
-import type { Collection, DocumentSchema, FieldType } from 'firestore-repository/schema';
+import type { WhereFilterOp } from 'firestore-repository/query';
+import {
+  type Collection,
+  type DocFieldPath,
+  type DocumentSchema,
+  type FieldType,
+  fieldTypeOfPath,
+} from 'firestore-repository/schema';
 import {
   isArrayRemove,
   isArrayUnion,
@@ -60,29 +65,12 @@ function buildDecodeField(fieldType: FieldType): ZodAny {
         .refine(isVectorValue)
         .transform((vv) => vv.toArray());
     case 'docRef':
-      if (fieldType.collection === 'unknown') {
-        // The context-free flavor (the '__name__' pseudo-descriptor): with no
-        // schema-known collection to build a DocRef id tuple from, a
-        // projected raw key decodes to its relative path string — the
-        // representation its `output` declares.
-        return z
-          .unknown()
-          .refine(isDocumentReference)
-          .transform((ref) => ref.path);
-      }
+      // Both flavors decode to the RefPath segment path — known/unknown is a
+      // gradient of tuple precision, not a change of shape.
       return z
         .unknown()
         .refine(isDocumentReference)
-        .transform((ref) => {
-          const ids: string[] = [];
-          let current: firestore.DocumentReference | null = ref;
-          while (current != null) {
-            ids.push(current.id);
-            current = current.parent.parent;
-          }
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-          return ids.reverse() as DocRef<Collection>;
-        });
+        .transform((ref) => ref.path.split('/'));
     case 'map': {
       return z.object(
         Object.fromEntries(
@@ -155,15 +143,8 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
           .transform(() => FieldValue.serverTimestamp()),
       ]);
     case 'docRef': {
-      if (fieldType.collection === 'unknown') {
-        // The context-free flavor writes a relative path string — the one
-        // reference representation that needs no collection context.
-        return z.string().transform((path) => db.doc(path));
-      }
-      const { collection } = fieldType;
-      return z.array(z.string()).transform((ref) =>
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        db.doc(documentPath(collection, ref as DocRef<Collection>)),
+      return refPathSchema(fieldType.collection).transform((segments) =>
+        db.doc(segments.join('/')),
       );
     }
     case 'map': {
@@ -198,6 +179,123 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
     default:
       return assertNever(fieldType);
   }
+}
+
+/**
+ * Encodes a single filter condition's operand into what the SDK's `where()`
+ * accepts. Only document references need conversion: they appear in
+ * conditions as `RefPath` segment paths (a field's READ representation) and
+ * are sent as `DocumentReference` values — the one representation the
+ * backend compares. This also keeps `__name__` filters free of the SDK's
+ * scope-dependent string conventions (a plain id for a collection query, a
+ * full root-relative path for a collection group — see
+ * docs/querying-by-document-id.md): a reference works in every scope.
+ * `in`/`not-in` take a list of operands and `array-contains(-any)` take
+ * element operands, so the arity/element type is resolved per operator.
+ */
+export function encodeFilterValue(
+  schema: DocumentSchema,
+  fieldPath: string,
+  opStr: WhereFilterOp,
+  value: unknown,
+  db: firestore.Firestore,
+): unknown {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
+  const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
+  switch (opStr) {
+    case 'in':
+    case 'not-in':
+      return Array.isArray(value) ? value.map((v) => encodeFilterOperand(fieldType, v, db)) : value;
+    case 'array-contains':
+      return fieldType.type === 'array'
+        ? encodeFilterOperand(fieldType.dynamicPart, value, db)
+        : value;
+    case 'array-contains-any':
+      return fieldType.type === 'array' && Array.isArray(value)
+        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+        : value;
+    case '==':
+    case '!=':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      return encodeFilterOperand(fieldType, value, db);
+    default:
+      return assertNever(opStr);
+  }
+}
+
+function encodeFilterOperand(
+  fieldType: FieldType,
+  value: unknown,
+  db: firestore.Firestore,
+): unknown {
+  switch (fieldType.type) {
+    case 'docRef': {
+      const parsed = refPathSchema(fieldType.collection).safeParse(value);
+      return parsed.success ? db.doc(parsed.data.join('/')) : value;
+    }
+    case 'array':
+      return Array.isArray(value)
+        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+        : value;
+    case 'map':
+      return typeof value === 'object' && value !== null
+        ? Object.fromEntries(
+            Object.entries(value).map(([k, v]) => {
+              const f = fieldType.fields[k];
+              return [k, f === undefined ? v : encodeFilterOperand(f, v, db)];
+            }),
+          )
+        : value;
+    case 'union': {
+      // A reference is the only member type needing conversion, so a value is
+      // converted iff it matches a docRef member's segment-path shape.
+      for (const e of fieldType.elements) {
+        if (e.type === 'docRef' && refPathSchema(e.collection).safeParse(value).success) {
+          return encodeFilterOperand(e, value, db);
+        }
+      }
+      return value;
+    }
+    case 'string':
+    case 'bool':
+    case 'int64':
+    case 'double':
+    case 'timestamp':
+    case 'bytes':
+    case 'geoPoint':
+    case 'vector':
+    case 'null':
+    case 'const':
+      return value;
+    default:
+      return assertNever(fieldType);
+  }
+}
+
+/**
+ * A zod schema for a `RefPath` segment path. A known collection's tuple shape
+ * is exact — literal collection names at the even positions — while the
+ * context-free flavor accepts any even-length segment path.
+ */
+function refPathSchema(collection: Collection | 'unknown'): z.ZodType<string[]> {
+  if (collection === 'unknown') {
+    return z
+      .array(z.string())
+      .refine((segments) => segments.length >= 2 && segments.length % 2 === 0, {
+        message: 'a reference path must have an even number of segments',
+      });
+  }
+  const names = [...collection.parent, collection.name];
+  return z
+    .array(z.string())
+    .refine(
+      (segments) =>
+        segments.length === names.length * 2 && names.every((name, i) => segments[i * 2] === name),
+      { message: `not a reference path of collection '${collection.name}'` },
+    );
 }
 
 function zodUnion(schemas: ZodAny[]): ZodAny {

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -183,15 +183,16 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
 
 /**
  * Encodes a single filter condition's operand into what the SDK's `where()`
- * accepts. Only document references need conversion: they appear in
- * conditions as `RefPath` segment paths (a field's READ representation) and
- * are sent as `DocumentReference` values — the one representation the
- * backend compares. This also keeps `__name__` filters free of the SDK's
- * scope-dependent string conventions (a plain id for a collection query, a
- * full root-relative path for a collection group — see
- * docs/querying-by-document-id.md): a reference works in every scope.
- * `in`/`not-in` take a list of operands and `array-contains(-any)` take
- * element operands, so the arity/element type is resolved per operator.
+ * accepts, by reusing the write codec (`buildEncodeField`): a field's READ
+ * representation is a subset of its write `input` for every descriptor, and
+ * the write conversions (`RefPath` -> `DocumentReference`, `Date` ->
+ * `Timestamp`, geopoint/bytes/vector to their SDK classes) are exactly the
+ * operand forms `where()` compares correctly. Sending references as
+ * `DocumentReference` values also keeps `__name__` filters free of the SDK's
+ * scope-dependent string conventions (see docs/querying-by-document-id.md):
+ * a reference works in every scope. Only the operand arity is resolved here —
+ * `in`/`not-in` take a list of field values and `array-contains(-any)` take
+ * element values.
  */
 export function encodeFilterValue(
   schema: DocumentSchema,
@@ -205,14 +206,14 @@ export function encodeFilterValue(
   switch (opStr) {
     case 'in':
     case 'not-in':
-      return Array.isArray(value) ? value.map((v) => encodeFilterOperand(fieldType, v, db)) : value;
+      return z.array(buildEncodeField(fieldType, db)).parse(value);
     case 'array-contains':
       return fieldType.type === 'array'
-        ? encodeFilterOperand(fieldType.dynamicPart, value, db)
+        ? buildEncodeField(fieldType.dynamicPart, db).parse(value)
         : value;
     case 'array-contains-any':
-      return fieldType.type === 'array' && Array.isArray(value)
-        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
+      return fieldType.type === 'array'
+        ? z.array(buildEncodeField(fieldType.dynamicPart, db)).parse(value)
         : value;
     case '==':
     case '!=':
@@ -220,61 +221,11 @@ export function encodeFilterValue(
     case '<=':
     case '>':
     case '>=':
-      return encodeFilterOperand(fieldType, value, db);
+      return buildEncodeField(fieldType, db).parse(value);
     default:
       return assertNever(opStr);
   }
 }
-
-function encodeFilterOperand(
-  fieldType: FieldType,
-  value: unknown,
-  db: firestore.Firestore,
-): unknown {
-  switch (fieldType.type) {
-    case 'docRef': {
-      const parsed = refPathSchema(fieldType.collection).safeParse(value);
-      return parsed.success ? db.doc(parsed.data.join('/')) : value;
-    }
-    case 'array':
-      return Array.isArray(value)
-        ? value.map((v) => encodeFilterOperand(fieldType.dynamicPart, v, db))
-        : value;
-    case 'map':
-      return typeof value === 'object' && value !== null
-        ? Object.fromEntries(
-            Object.entries(value).map(([k, v]) => {
-              const f = fieldType.fields[k];
-              return [k, f === undefined ? v : encodeFilterOperand(f, v, db)];
-            }),
-          )
-        : value;
-    case 'union': {
-      // A reference is the only member type needing conversion, so a value is
-      // converted iff it matches a docRef member's segment-path shape.
-      for (const e of fieldType.elements) {
-        if (e.type === 'docRef' && refPathSchema(e.collection).safeParse(value).success) {
-          return encodeFilterOperand(e, value, db);
-        }
-      }
-      return value;
-    }
-    case 'string':
-    case 'bool':
-    case 'int64':
-    case 'double':
-    case 'timestamp':
-    case 'bytes':
-    case 'geoPoint':
-    case 'vector':
-    case 'null':
-    case 'const':
-      return value;
-    default:
-      return assertNever(fieldType);
-  }
-}
-
 /**
  * A zod schema for a `RefPath` segment path. A known collection's tuple shape
  * is exact — literal collection names at the even positions — while the

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -182,46 +182,61 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
 }
 
 /**
- * Encodes a single filter condition's operand into what the SDK's `where()`
- * accepts, by reusing the write codec (`buildEncodeField`): a field's READ
- * representation is a subset of its write `input` for every descriptor, and
- * the write conversions (`RefPath` -> `DocumentReference`, `Date` ->
- * `Timestamp`, geopoint/bytes/vector to their SDK classes) are exactly the
- * operand forms `where()` compares correctly. Sending references as
- * `DocumentReference` values also keeps `__name__` filters free of the SDK's
- * scope-dependent string conventions (see docs/querying-by-document-id.md):
- * a reference works in every scope. Only the operand arity is resolved here —
- * `in`/`not-in` take a list of field values and `array-contains(-any)` take
+ * Builds the encoder for filter-condition operands, memoizing the operand
+ * schema per (field path, operator) like `buildEncodeSchema` builds the
+ * write schema once per collection. The operand schema reuses the write
+ * codec (`buildEncodeField`): a field's READ representation is a subset of
+ * its write `input` for every descriptor, and the write conversions
+ * (`RefPath` -> `DocumentReference`, `Date` -> `Timestamp`,
+ * geopoint/bytes/vector to their SDK classes) are exactly the operand forms
+ * `where()` compares correctly. Sending references as `DocumentReference`
+ * values also keeps `__name__` filters free of the SDK's scope-dependent
+ * string conventions (see docs/querying-by-document-id.md): a reference
+ * works in every scope. Only the operand arity is resolved here — `in`/
+ * `not-in` take a list of field values and `array-contains(-any)` take
  * element values.
  */
-export function encodeFilterValue(
+export function buildEncodeFilterValue(
+  schema: DocumentSchema,
+  db: firestore.Firestore,
+): (fieldPath: string, opStr: WhereFilterOp, value: unknown) => unknown {
+  const operandSchemas = new Map<string, ZodAny>();
+  return (fieldPath, opStr, value) => {
+    const key = `${opStr}:${fieldPath}`;
+    let operandSchema = operandSchemas.get(key);
+    if (operandSchema === undefined) {
+      operandSchema = buildOperandSchema(schema, fieldPath, opStr, db);
+      operandSchemas.set(key, operandSchema);
+    }
+    return operandSchema.parse(value);
+  };
+}
+
+function buildOperandSchema(
   schema: DocumentSchema,
   fieldPath: string,
   opStr: WhereFilterOp,
-  value: unknown,
   db: firestore.Firestore,
-): unknown {
+): ZodAny {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
   const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
   switch (opStr) {
     case 'in':
     case 'not-in':
-      return z.array(buildEncodeField(fieldType, db)).parse(value);
+      return z.array(buildEncodeField(fieldType, db));
     case 'array-contains':
-      return fieldType.type === 'array'
-        ? buildEncodeField(fieldType.dynamicPart, db).parse(value)
-        : value;
+      return fieldType.type === 'array' ? buildEncodeField(fieldType.dynamicPart, db) : z.unknown();
     case 'array-contains-any':
       return fieldType.type === 'array'
-        ? z.array(buildEncodeField(fieldType.dynamicPart, db)).parse(value)
-        : value;
+        ? z.array(buildEncodeField(fieldType.dynamicPart, db))
+        : z.unknown();
     case '==':
     case '!=':
     case '<':
     case '<=':
     case '>':
     case '>=':
-      return buildEncodeField(fieldType, db).parse(value);
+      return buildEncodeField(fieldType, db);
     default:
       return assertNever(opStr);
   }

--- a/packages/google-cloud-firestore/src/codec.ts
+++ b/packages/google-cloud-firestore/src/codec.ts
@@ -6,7 +6,7 @@ import {
   Timestamp as FirestoreTimestamp,
   VectorValue as FirestoreVectorValue,
 } from '@google-cloud/firestore';
-import type { WhereFilterOp } from 'firestore-repository/query';
+import { filterOperand, type WhereFilterOp } from 'firestore-repository/query';
 import {
   type Collection,
   type DocFieldPath,
@@ -192,9 +192,9 @@ function buildEncodeField(fieldType: FieldType, db: firestore.Firestore): ZodAny
  * `where()` compares correctly. Sending references as `DocumentReference`
  * values also keeps `__name__` filters free of the SDK's scope-dependent
  * string conventions (see docs/querying-by-document-id.md): a reference
- * works in every scope. Only the operand arity is resolved here — `in`/
- * `not-in` take a list of field values and `array-contains(-any)` take
- * element values.
+ * works in every scope. The operand's shape per operator (`in` takes a list
+ * of field values, `array-contains` an element, ...) comes from
+ * `filterOperand`, the runtime counterpart of the `FilterOperand` type.
  */
 export function buildEncodeFilterValue(
   schema: DocumentSchema,
@@ -205,42 +205,15 @@ export function buildEncodeFilterValue(
     const key = `${opStr}:${fieldPath}`;
     let operandSchema = operandSchemas.get(key);
     if (operandSchema === undefined) {
-      operandSchema = buildOperandSchema(schema, fieldPath, opStr, db);
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
+      const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
+      operandSchema = buildEncodeField(filterOperand(fieldType, opStr), db);
       operandSchemas.set(key, operandSchema);
     }
     return operandSchema.parse(value);
   };
 }
 
-function buildOperandSchema(
-  schema: DocumentSchema,
-  fieldPath: string,
-  opStr: WhereFilterOp,
-  db: firestore.Firestore,
-): ZodAny {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `fieldPath` comes from a filter already typed against the schema
-  const fieldType = fieldTypeOfPath(schema, fieldPath as DocFieldPath<DocumentSchema>);
-  switch (opStr) {
-    case 'in':
-    case 'not-in':
-      return z.array(buildEncodeField(fieldType, db));
-    case 'array-contains':
-      return fieldType.type === 'array' ? buildEncodeField(fieldType.dynamicPart, db) : z.unknown();
-    case 'array-contains-any':
-      return fieldType.type === 'array'
-        ? z.array(buildEncodeField(fieldType.dynamicPart, db))
-        : z.unknown();
-    case '==':
-    case '!=':
-    case '<':
-    case '<=':
-    case '>':
-    case '>=':
-      return buildEncodeField(fieldType, db);
-    default:
-      return assertNever(opStr);
-  }
-}
 /**
  * A zod schema for a `RefPath` segment path. A known collection's tuple shape
  * is exact — literal collection names at the even positions — while the

--- a/packages/google-cloud-firestore/src/index.ts
+++ b/packages/google-cloud-firestore/src/index.ts
@@ -21,7 +21,7 @@ import {
 import type { Collection, RootCollection, SubCollection } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
-import { buildDecodeSchema, buildEncodeSchema, encodeFilterValue } from './codec.js';
+import { buildDecodeSchema, buildEncodeFilterValue, buildEncodeSchema } from './codec.js';
 
 /** Platform-specific environment types for Google Cloud Firestore */
 export type Env = {
@@ -253,6 +253,7 @@ export const buildFirestoreUtilities = <T extends Collection>(
 ) => {
   const decodeSchema = buildDecodeSchema(collection.schema);
   const encodeSchema = buildEncodeSchema(collection.schema, db);
+  const encodeFilterValue = buildEncodeFilterValue(collection.schema, db);
 
   const toFirestore = {
     docRef: (ref: DocRef<T>): firestore.DocumentReference => db.doc(documentPath(collection, ref)),
@@ -308,7 +309,7 @@ export const buildFirestoreUtilities = <T extends Collection>(
           return Filter.where(
             expr.fieldPath,
             expr.opStr,
-            encodeFilterValue(collection.schema, expr.fieldPath, expr.opStr, expr.value, db),
+            encodeFilterValue(expr.fieldPath, expr.opStr, expr.value),
           );
         case 'and':
           return Filter.and(...expr.filters.map(toFirestore.filter));

--- a/packages/google-cloud-firestore/src/index.ts
+++ b/packages/google-cloud-firestore/src/index.ts
@@ -21,7 +21,7 @@ import {
 import type { Collection, RootCollection, SubCollection } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
 
-import { buildDecodeSchema, buildEncodeSchema } from './codec.js';
+import { buildDecodeSchema, buildEncodeSchema, encodeFilterValue } from './codec.js';
 
 /** Platform-specific environment types for Google Cloud Firestore */
 export type Env = {
@@ -305,7 +305,11 @@ export const buildFirestoreUtilities = <T extends Collection>(
     filter: (expr: FilterExpression<T['schema']>): firestore.Filter => {
       switch (expr.kind) {
         case 'fieldValueCondition':
-          return Filter.where(expr.fieldPath, expr.opStr, expr.value);
+          return Filter.where(
+            expr.fieldPath,
+            expr.opStr,
+            encodeFilterValue(collection.schema, expr.fieldPath, expr.opStr, expr.value, db),
+          );
         case 'and':
           return Filter.and(...expr.filters.map(toFirestore.filter));
         case 'or':

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -1,5 +1,5 @@
 import { FieldValue, type Firestore, GeoPoint, Pipelines } from '@google-cloud/firestore';
-import { collectionPath, documentPath } from 'firestore-repository/path';
+import { collectionPath } from 'firestore-repository/path';
 import {
   type BinaryFunctionName,
   type Constant,
@@ -209,7 +209,7 @@ const toSdkConstant = (db: Firestore, value: Constant['value']): Pipelines.Expre
     return Pipelines.constant(FieldValue.vector([...value.values]));
   }
   if (value instanceof DocRefValue) {
-    return Pipelines.constant(db.doc(documentPath(value.collection, value.id)));
+    return Pipelines.constant(db.doc(value.path.join('/')));
   }
   if (isConstantArrayValue(value)) {
     return Pipelines.array(value.map((element) => toSdkConstant(db, element)));

--- a/packages/readme-example/src/index.test.ts
+++ b/packages/readme-example/src/index.test.ts
@@ -18,7 +18,7 @@ import {
   subcollectionRepository as googleCloudFirestoreSubcollectionRepository,
 } from '@firestore-repository/google-cloud-firestore';
 import { Firestore } from '@google-cloud/firestore';
-import { randomString } from 'firestore-repository/__test__/util';
+import { randomString, uniqueCollection } from 'firestore-repository/__test__/util';
 import { average, count, sum } from 'firestore-repository/aggregate';
 import { eq, gte, limit, query, where } from 'firestore-repository/query';
 import type {
@@ -314,7 +314,7 @@ describe('README example', () => {
       onlyGoogleCloudFirestore: (name, fn) => {
         const repo = googleCloudFirestoreRepositoryWithMapper(
           db,
-          { ...users, name: `${users.name}-${randomString()}` },
+          uniqueCollection(users),
           rootCollectionPlainMapper(users),
         );
         it(name, () => fn(repo));


### PR DESCRIPTION
## Summary

Implements the segment-path unification agreed in the plan doc: reference **values** are uniformly `RefPath<T>` — the full segment path alternating collection names and ids (`['Authors', 'a1', 'Posts', 'p1']`) — everywhere a reference appears as data. The ids-only **address** (`DocRef<T>`) survives only in the repository interface (`get`/`set`/`Doc.id`), with `refPath()` / `toDocRef()` converting at that single boundary.

Known/unknown collection becomes purely a gradient of tuple precision: `RefPath<Posts>` is `['Authors', string, 'Posts', string]` (literal name positions), `RefPath<'unknown'>` degrades to `string[]`. This dissolves the ids-vs-segments ambiguity that previously forced the context-free flavor onto a relative path string.

## Changes

- **schema.ts**: `Collection` captures `name` as a literal type (`const Name` on both factories); new `RefPath<T>` type; `DocRefType<T>`'s `input`/`output` are `RefPath<T>` in both flavors.
- **path.ts**: `refPath(collection, docRef)` (address → value) and `toDocRef(collection, path)` (value → address, with runtime validation that the path belongs to the collection); `documentPath` is now a join over `refPath`.
- **Both codecs**: reference decode is a single arm (`ref.path.split('/')`); encode validates the segment shape per flavor (`refPathSchema` — exact literal-name tuple for a known collection, even-length `string[]` for context-free) and builds `db.doc(segments.join('/'))`.
- **Core query filters**: new `encodeFilterValue` in each codec encodes reference operands — `__name__` included, and references nested in arrays/maps/unions, with per-operator arity (`in`/`array-contains`/…) — to `DocumentReference` values. Every scope (collection / subcollection / **collection group**) now takes the same `RefPath` operand; the SDK's scope-dependent string conventions (plain id vs full path, documented in docs/querying-by-document-id.md) no longer surface, and the previously-untyped group-query contract is closed at the type level.
- **Pipeline**: `docRefValue(path)` takes the segment path directly (one signature, `DocRefType<'unknown'>`; comparisons key on the `'reference'` tag); executors build `db.doc(path.join('/'))`.
- **Docs**: querying-by-document-id.md rewritten to the RefPath contract (SDK string conventions kept as background); plan/research docs updated.

Deliberately deferred (recorded in the plan doc): the typed shorthand layer (`where(eq('__name__', '1'))` / `DocRef` tuples at surfaces whose collection is statically known — feasible via the 2n vs n length parity) and typed cursor constraints (`Cursor` remains `unknown[]` pass-through).

## Verification

- `pnpm check` — pass
- `pnpm test` (emulator) — 541 passed
- Live pipeline spec against `ikenox-sunrise`/`enterprise-native-playground` (google-cloud adapter) — 196 passed, including the reference cases (`__name__` filter via `docRefValue`, raw `__name__` projection decoding to segments, composite-leaf reference decode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)