### PR TITLE
Expressions slice 4: timestamp function family

### DIFF
--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -257,9 +257,9 @@ both executors and the basic backend semantics in one round trip per family.
       `__name__` is a REFERENCE (probed via `type(__name__)`), so
       `FieldTypeOfPath` now resolves it to the context-free
       `DocRefType<'unknown'>` (ONE unified reference descriptor — the type
-      parameter is the known collection or the `'unknown'` sentinel; the
-      context-free flavor has `output: string` for the core query API's id
-      filters and `input: never`). Future refinement, same skeleton: while a
+      parameter is the known collection or the `'unknown'` sentinel; both
+      flavors read/write `RefPath` segment paths since the segment-path
+      unification). Future refinement, same skeleton: while a
       pipeline's read-identity is alive (`Id = DocRef<T>`), the source
       collection IS statically known — `fieldProvider` could resolve
       `'__name__'` to `DocRefType<T>` and fall back to `'unknown'` once the
@@ -277,8 +277,25 @@ both executors and the basic backend semantics in one round trip per family.
       `constant(new GeoPoint(...))` — this closed the hole where every value
       node inhabited every operand domain (`toUpper(geoPointValue(...))`
       type-checked), and needed no type-level membership trick.
-- [ ] **4. Timestamp family** (literal-union factory args pattern:
-      `TimeUnit`, truncation granularity).
+- [x] **4. Timestamp family** (`currentTimestamp`; unix conversions ×6;
+      `timestampAdd` / `timestampSubtract` / `timestampDiff` (ternary);
+      `timestampTruncate` / `timestampExtract` (dual arity over the optional
+      timezone) — the SDK-only extras `timestampDiff` / `timestampExtract`
+      were included beyond the original inventory). The isType literal-lift
+      pattern generalized cleanly: probed, the backend REQUIRES literal
+      constants for unit / granularity / part AND the timezone (a dynamic
+      operand is INVALID_ARGUMENT at validation, not an ERROR value), so the
+      factories take literal-union parameters (`TimeUnit` ⊂
+      `TimeGranularity` ⊂ `TimePart`, `timezone: string`) lifted via
+      `Constant.of`; the executors pass the translated constant expressions
+      straight through (no raw-string recovery needed — the SDK standalone
+      signatures accept expression forms). Probed semantics pinned in the
+      catalog: integer-only amounts/epochs (a fractional value cannot
+      coerce), diff truncates toward zero and is negative when end precedes
+      start, bare `'week'` truncates to Sunday vs `'week(monday)'` /
+      `'isoweek'`, `'dayofweek'` is 1-based from Sunday, out-of-range
+      results and invalid timezone VALUES are backend ERROR values. All
+      value functions propagate null (incl. absent → null).
 - [ ] **5. Existence/error + conditional + logicalMax/Min + equalAny/notEqualAny**
       (T2: operand-derived return types, fallback unions).
 - [ ] **6. Array + map families + `ArrayValue` / `MapValue` constructors**

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -36,7 +36,19 @@ import {
   notEqual as sdkNotEqual,
   or as sdkOr,
   pow as sdkPow,
+  currentTimestamp as sdkCurrentTimestamp,
   rand as sdkRand,
+  timestampAdd as sdkTimestampAdd,
+  timestampDiff as sdkTimestampDiff,
+  timestampExtract as sdkTimestampExtract,
+  timestampSubtract as sdkTimestampSubtract,
+  timestampToUnixMicros as sdkTimestampToUnixMicros,
+  timestampToUnixMillis as sdkTimestampToUnixMillis,
+  timestampToUnixSeconds as sdkTimestampToUnixSeconds,
+  timestampTruncate as sdkTimestampTruncate,
+  unixMicrosToTimestamp as sdkUnixMicrosToTimestamp,
+  unixMillisToTimestamp as sdkUnixMillisToTimestamp,
+  unixSecondsToTimestamp as sdkUnixSecondsToTimestamp,
   regexContains as sdkRegexContains,
   regexFind as sdkRegexFind,
   regexFindAll as sdkRegexFindAll,
@@ -307,7 +319,10 @@ const isConstantArrayValue = (value: Constant['value']): value is ConstantArray 
 // (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
 // type-tag only, no wire change.)
 
-const nullaryFns: Record<NullaryFunctionName, () => SdkExpression> = { rand: sdkRand };
+const nullaryFns: Record<NullaryFunctionName, () => SdkExpression> = {
+  rand: sdkRand,
+  currentTimestamp: sdkCurrentTimestamp,
+};
 
 const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> = {
   not: (o) => sdkNot(o.asBoolean()),
@@ -331,6 +346,12 @@ const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> =
   documentId: sdkDocumentId,
   collectionId: sdkCollectionId,
   type: sdkType,
+  timestampToUnixSeconds: sdkTimestampToUnixSeconds,
+  timestampToUnixMillis: sdkTimestampToUnixMillis,
+  timestampToUnixMicros: sdkTimestampToUnixMicros,
+  unixSecondsToTimestamp: sdkUnixSecondsToTimestamp,
+  unixMillisToTimestamp: sdkUnixMillisToTimestamp,
+  unixMicrosToTimestamp: sdkUnixMicrosToTimestamp,
   vectorLength: sdkVectorLength,
 };
 
@@ -370,6 +391,10 @@ const binaryFns: Record<
   regexFind: sdkRegexFind,
   regexFindAll: sdkRegexFindAll,
   isType: (l, _r, node) => sdkIsType(l, literalStringOperand(node.right)),
+  // The lifted literal constants (granularity / part) translate as constant
+  // expressions, which IS the literal form the backend validates — probed.
+  timestampTruncate: (l, r) => sdkTimestampTruncate(l, r),
+  timestampExtract: (l, r) => sdkTimestampExtract(l, r),
   cosineDistance: sdkCosineDistance,
   dotProduct: sdkDotProduct,
   euclideanDistance: sdkEuclideanDistance,
@@ -382,6 +407,11 @@ const ternaryFns: Record<
   stringReplaceAll: sdkStringReplaceAll,
   stringReplaceOne: sdkStringReplaceOne,
   substring: sdkSubstring,
+  timestampAdd: sdkTimestampAdd,
+  timestampSubtract: sdkTimestampSubtract,
+  timestampDiff: sdkTimestampDiff,
+  timestampTruncate: sdkTimestampTruncate,
+  timestampExtract: sdkTimestampExtract,
 };
 
 /**

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -5,40 +5,29 @@ import {
   abs,
   add,
   and,
-  collectionId,
-  cosineDistance,
-  documentId,
-  dotProduct,
-  euclideanDistance,
-  isType,
-  like,
-  regexContains,
-  regexFind,
-  regexFindAll,
-  regexMatch,
-  stringIndexOf,
-  stringRepeat,
-  stringReplaceAll,
-  stringReplaceOne,
-  substring,
-  type,
-  vectorLength,
-  docRefValue,
   byteLength,
   ceil,
   charLength,
+  collectionId,
   constant,
+  cosineDistance,
+  currentTimestamp,
   divide,
+  docRefValue,
+  documentId,
+  dotProduct,
   endsWith,
   equal,
+  euclideanDistance,
   exp,
   floor,
   geoPointValue,
-  vectorValue,
   greaterThan,
   greaterThanOrEqual,
+  isType,
   lessThan,
   lessThanOrEqual,
+  like,
   ln,
   log10,
   ltrim,
@@ -49,18 +38,41 @@ import {
   or,
   pow,
   rand,
+  regexContains,
+  regexFind,
+  regexFindAll,
+  regexMatch,
   round,
   rtrim,
   sqrt,
   startsWith,
   stringConcat,
   stringContains,
+  stringIndexOf,
+  stringRepeat,
+  stringReplaceAll,
+  stringReplaceOne,
   stringReverse,
+  substring,
   subtract,
+  timestampAdd,
+  timestampDiff,
+  timestampExtract,
+  timestampSubtract,
+  timestampToUnixMicros,
+  timestampToUnixMillis,
+  timestampToUnixSeconds,
+  timestampTruncate,
   toLower,
   toUpper,
   trim,
   trunc,
+  type,
+  unixMicrosToTimestamp,
+  unixMillisToTimestamp,
+  unixSecondsToTimestamp,
+  vectorLength,
+  vectorValue,
 } from '../pipelines/expression.js';
 import { asc, desc } from '../pipelines/ordering.js';
 import type {
@@ -593,6 +605,71 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
           ]),
           [{ data: { id: 'a1', cid: collectionName() } }],
         );
+      });
+
+      it('timestamp', async () => {
+        const base = new Date('2024-03-15T10:30:45.123Z');
+        const later = new Date('2024-03-18T01:00:00Z');
+        await expectPipeline(
+          one().select(() => [
+            timestampAdd(constant(base), 'day', constant(1)).as('add'),
+            timestampSubtract(constant(base), 'hour', constant(2)).as('subtract'),
+            timestampToUnixSeconds(constant(base)).as('toSecs'),
+            timestampToUnixMillis(constant(base)).as('toMillis'),
+            timestampToUnixMicros(constant(base)).as('toMicros'),
+            unixSecondsToTimestamp(constant(1710498645)).as('fromSecs'),
+            unixMillisToTimestamp(constant(1710498645123)).as('fromMillis'),
+            unixMicrosToTimestamp(constant(1710498645123000)).as('fromMicros'),
+            timestampTruncate(constant(base), 'month').as('truncMonth'),
+            // bare 'week' starts on Sunday; 'week(monday)' picks the start day
+            timestampTruncate(constant(base), 'week').as('truncWeek'),
+            timestampTruncate(constant(base), 'week(monday)').as('truncWeekMon'),
+            timestampTruncate(constant(base), 'day', 'Asia/Tokyo').as('truncDayTokyo'),
+            timestampExtract(constant(base), 'year').as('extractYear'),
+            // 1-based from Sunday: 2024-03-15 is a Friday
+            timestampExtract(constant(base), 'dayofweek').as('extractDow'),
+            timestampExtract(constant(base), 'hour', 'Asia/Tokyo').as('extractHourTokyo'),
+            // end - start in whole units, truncated toward zero (2.6 days -> 2)
+            timestampDiff(constant(later), constant(base), 'day').as('diffDays'),
+            timestampDiff(constant(base), constant(later), 'hour').as('diffHoursNeg'),
+          ]),
+          [
+            {
+              data: {
+                add: new Date('2024-03-16T10:30:45.123Z'),
+                subtract: new Date('2024-03-15T08:30:45.123Z'),
+                toSecs: 1710498645,
+                toMillis: 1710498645123,
+                toMicros: 1710498645123000,
+                fromSecs: new Date('2024-03-15T10:30:45.000Z'),
+                fromMillis: new Date('2024-03-15T10:30:45.123Z'),
+                fromMicros: new Date('2024-03-15T10:30:45.123Z'),
+                truncMonth: new Date('2024-03-01T00:00:00Z'),
+                truncWeek: new Date('2024-03-10T00:00:00Z'),
+                truncWeekMon: new Date('2024-03-11T00:00:00Z'),
+                truncDayTokyo: new Date('2024-03-14T15:00:00Z'),
+                extractYear: 2024,
+                extractDow: 6,
+                extractHourTokyo: 19,
+                diffDays: 2,
+                diffHoursNeg: -62,
+              },
+            },
+          ],
+        );
+      });
+
+      it('currentTimestamp is the server time at evaluation', async () => {
+        const before = Date.now();
+        const results = await executor.execute(one().select(() => [currentTimestamp().as('now')]));
+        const after = Date.now();
+        const times = results.map((row) => row.data.now.getTime());
+        expect(times).toHaveLength(1);
+        for (const now of times) {
+          // generous clock-skew allowance — this asserts "server time", not precision
+          expect(now).toBeGreaterThanOrEqual(before - 60_000);
+          expect(now).toBeLessThanOrEqual(after + 60_000);
+        }
       });
 
       // rand (the remaining nullary) is covered by its own range test below —

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -30,21 +30,30 @@ import {
   byteLength,
   ceil,
   charLength,
-  Constant,
+  collectionId,
   constant,
+  Constant,
+  cosineDistance,
+  currentTimestamp,
   divide,
+  DocRefValue,
+  docRefValue,
+  documentId,
+  dotProduct,
   endsWith,
   equal,
+  euclideanDistance,
   exp,
-  type ExpressionWithAlias,
   Field,
   field,
   floor,
   geoPointValue,
   greaterThan,
   greaterThanOrEqual,
+  isType,
   lessThan,
   lessThanOrEqual,
+  like,
   ln,
   log10,
   ltrim,
@@ -56,23 +65,14 @@ import {
   or,
   pow,
   rand,
-  round,
-  rtrim,
-  sqrt,
-  startsWith,
-  collectionId,
-  cosineDistance,
-  docRefValue,
-  DocRefValue,
-  documentId,
-  dotProduct,
-  euclideanDistance,
-  isType,
-  like,
   regexContains,
   regexFind,
   regexFindAll,
   regexMatch,
+  round,
+  rtrim,
+  sqrt,
+  startsWith,
   stringConcat,
   stringContains,
   stringIndexOf,
@@ -83,14 +83,26 @@ import {
   substring,
   subtract,
   TernaryFunction,
-  type,
-  vectorLength,
+  timestampAdd,
+  timestampDiff,
+  timestampExtract,
+  timestampSubtract,
+  timestampToUnixMicros,
+  timestampToUnixMillis,
+  timestampToUnixSeconds,
+  timestampTruncate,
   toLower,
   toUpper,
   trim,
   trunc,
+  type,
+  type ExpressionWithAlias,
   UnaryFunction,
+  unixMicrosToTimestamp,
+  unixMillisToTimestamp,
+  unixSecondsToTimestamp,
   VariadicFunction,
+  vectorLength,
   vectorValue,
 } from './expression.js';
 
@@ -756,6 +768,90 @@ describe('reference / type / vector operators', () => {
     dotProduct(vec, field(array(double()), 'nums'));
     // @ts-expect-error -- a string is not a vector
     vectorLength(field(string(), 'name'));
+  });
+});
+
+describe('timestamp operators', () => {
+  const ts = field(timestamp(), 'createdAt');
+  const num = field(int64(), 'secs');
+
+  it('currentTimestamp is a nullary timestamp', () => {
+    expect(currentTimestamp()).toStrictEqual(new NullaryFunction('currentTimestamp', timestamp()));
+  });
+
+  it('unix conversions map between the timestamp and numeric domains', () => {
+    expect(timestampToUnixSeconds(ts)).toStrictEqual(
+      new UnaryFunction('timestampToUnixSeconds', int64(), ts),
+    );
+    expect(timestampToUnixMillis(ts).name).toBe('timestampToUnixMillis');
+    expect(timestampToUnixMicros(ts).name).toBe('timestampToUnixMicros');
+    expect(unixSecondsToTimestamp(num)).toStrictEqual(
+      new UnaryFunction('unixSecondsToTimestamp', timestamp(), num),
+    );
+    expect(unixMillisToTimestamp(num).name).toBe('unixMillisToTimestamp');
+    expect(unixMicrosToTimestamp(num).name).toBe('unixMicrosToTimestamp');
+    // @ts-expect-error -- a number is not a timestamp
+    timestampToUnixSeconds(num);
+    // @ts-expect-error -- a timestamp is not a unix epoch number
+    unixSecondsToTimestamp(ts);
+    // A nullable/optional operand propagates.
+    const viaOptional = timestampToUnixSeconds(field(optional(timestamp()), 'ot'));
+    expect(viaOptional.type).toStrictEqual(nullable(int64()));
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullable(int64()));
+  });
+
+  it('add/subtract lift the literal unit into a constant operand', () => {
+    expect(timestampAdd(ts, 'day', constant(1))).toStrictEqual(
+      new TernaryFunction('timestampAdd', timestamp(), ts, constant('day'), constant(1)),
+    );
+    expect(timestampSubtract(ts, 'hour', constant(2)).name).toBe('timestampSubtract');
+    // @ts-expect-error -- an arbitrary string is not a time unit
+    timestampAdd(ts, 'fortnight', constant(1));
+    // @ts-expect-error -- calendar granularities are add units the backend rejects
+    timestampAdd(ts, 'month', constant(1));
+    // @ts-expect-error -- the amount is a numeric operand
+    timestampAdd(ts, 'day', constant('1'));
+    // The amount operand's nullability propagates.
+    const viaOptional = timestampAdd(ts, 'day', field(optional(int64()), 'n'));
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullable(timestamp()));
+  });
+
+  it('diff is end - start in whole units', () => {
+    expect(timestampDiff(ts, ts, 'hour')).toStrictEqual(
+      new TernaryFunction('timestampDiff', int64(), ts, ts, constant('hour')),
+    );
+    // @ts-expect-error -- units only: calendar granularities are rejected (probed)
+    timestampDiff(ts, ts, 'month');
+    // @ts-expect-error -- a number is not a timestamp
+    timestampDiff(ts, num, 'hour');
+  });
+
+  it('truncate/extract are dual-arity over the optional literal timezone', () => {
+    expect(timestampTruncate(ts, 'week(monday)')).toStrictEqual(
+      new BinaryFunction('timestampTruncate', timestamp(), ts, constant('week(monday)')),
+    );
+    expect(timestampTruncate(ts, 'day', 'Asia/Tokyo')).toStrictEqual(
+      new TernaryFunction(
+        'timestampTruncate',
+        timestamp(),
+        ts,
+        constant('day'),
+        constant('Asia/Tokyo'),
+      ),
+    );
+    expect(timestampExtract(ts, 'dayofweek')).toStrictEqual(
+      new BinaryFunction('timestampExtract', int64(), ts, constant('dayofweek')),
+    );
+    expect(timestampExtract(ts, 'hour', 'Asia/Tokyo').name).toBe('timestampExtract');
+    // @ts-expect-error -- not a granularity
+    timestampTruncate(ts, 'fortnight');
+    // @ts-expect-error -- 'week(noday)' is not a week start day
+    timestampTruncate(ts, 'week(noday)');
+    // @ts-expect-error -- 'dayofweek' is extract-only, not a truncation granularity
+    timestampTruncate(ts, 'dayofweek');
+    // A nullable operand propagates through both arities.
+    const viaOptional = timestampTruncate(field(optional(timestamp()), 'ot'), 'day');
+    expectTypeOf(viaOptional.type).toEqualTypeOf(nullable(timestamp()));
   });
 });
 

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -402,7 +402,7 @@ export class NullaryFunction<T extends FieldType = FieldType> extends Expression
     super();
   }
 }
-export type NullaryFunctionName = 'rand';
+export type NullaryFunctionName = 'rand' | 'currentTimestamp';
 
 /** A function call with a single operand. */
 export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -445,6 +445,13 @@ export type UnaryFunctionName =
   // reference
   | 'documentId'
   | 'collectionId'
+  // timestamp
+  | 'timestampToUnixSeconds'
+  | 'timestampToUnixMillis'
+  | 'timestampToUnixMicros'
+  | 'unixSecondsToTimestamp'
+  | 'unixMillisToTimestamp'
+  | 'unixMicrosToTimestamp'
   // type
   | 'type'
   // vector
@@ -497,6 +504,9 @@ export type BinaryFunctionName =
   | 'regexFindAll'
   // type
   | 'isType'
+  // timestamp (2-arg forms; the 3-arg forms carry an explicit timezone)
+  | 'timestampTruncate'
+  | 'timestampExtract'
   // vector
   | 'cosineDistance'
   | 'dotProduct'
@@ -515,7 +525,17 @@ export class TernaryFunction<T extends FieldType = FieldType> extends Expression
     super();
   }
 }
-export type TernaryFunctionName = 'stringReplaceAll' | 'stringReplaceOne' | 'substring';
+export type TernaryFunctionName =
+  // string
+  | 'stringReplaceAll'
+  | 'stringReplaceOne'
+  | 'substring'
+  // timestamp
+  | 'timestampAdd'
+  | 'timestampSubtract'
+  | 'timestampDiff'
+  | 'timestampTruncate'
+  | 'timestampExtract';
 
 /** A function call with two or more uniform operands. */
 export class VariadicFunction<T extends FieldType = FieldType> extends ExpressionBase {
@@ -1305,6 +1325,189 @@ const typeNameLiteral = (): LiteralType<FirestoreTypeName[]> =>
     'regex',
     'request_timestamp',
   );
+
+// ---- timestamp ----
+// The unit/granularity/part argument and the timezone argument must be
+// compile-time literals: the backend validates them as literal constants
+// (probed: a field operand is INVALID_ARGUMENT at query validation, not an
+// ERROR value), so the factories take literal parameters and lift them via
+// `Constant.of`, like `isType`. Out-of-range results and invalid timezone
+// VALUES, by contrast, are backend ERROR values (`isError`-catchable).
+// Integer-only positions (an add/subtract amount, a unix epoch input) are
+// typed as the numeric domain: `'integer'` alone cannot be demanded at the
+// type level (a number-valued descriptor honestly carries
+// `'integer' | 'double'` — see `Int64Type`), and a whole `number` wire-encodes
+// as an integer anyway; an actually-fractional value is a backend error.
+
+/** The time units accepted by `timestampAdd` / `timestampSubtract` / `timestampDiff`. */
+export type TimeUnit = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day';
+type Weekday = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
+/**
+ * The truncation granularities of `timestampTruncate`. Bare `'week'` starts
+ * weeks on Sunday; `'week(<day>)'` picks the start day; `'isoweek'` is
+ * `'week(monday)'` (probed).
+ */
+export type TimeGranularity =
+  | TimeUnit
+  | 'week'
+  | `week(${Weekday})`
+  | 'isoweek'
+  | 'month'
+  | 'quarter'
+  | 'year'
+  | 'isoyear';
+/** The extractable parts of `timestampExtract`. */
+export type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
+
+/** A timestamp-domain operand. */
+type TimestampOperand = Expression<Valued<'timestamp'>>;
+
+/** The server's timestamp at query evaluation time. */
+export const currentTimestamp = (): NullaryFunction<TimestampType> =>
+  new NullaryFunction('currentTimestamp', timestamp());
+
+/** The operand as a unix epoch in seconds (fractions truncated toward zero). */
+export const timestampToUnixSeconds = <Op extends TimestampOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('timestampToUnixSeconds', propagateNull([value], int64()), value);
+
+/** The operand as a unix epoch in milliseconds. */
+export const timestampToUnixMillis = <Op extends TimestampOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('timestampToUnixMillis', propagateNull([value], int64()), value);
+
+/** The operand as a unix epoch in microseconds. */
+export const timestampToUnixMicros = <Op extends TimestampOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
+  new UnaryFunction('timestampToUnixMicros', propagateNull([value], int64()), value);
+
+/** The timestamp at the given unix epoch in seconds (integers only — a fractional value is a backend error). */
+export const unixSecondsToTimestamp = <Op extends NumericOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
+  new UnaryFunction('unixSecondsToTimestamp', propagateNull([value], timestamp()), value);
+
+/** The timestamp at the given unix epoch in milliseconds (integers only). */
+export const unixMillisToTimestamp = <Op extends NumericOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
+  new UnaryFunction('unixMillisToTimestamp', propagateNull([value], timestamp()), value);
+
+/** The timestamp at the given unix epoch in microseconds (integers only). */
+export const unixMicrosToTimestamp = <Op extends NumericOperand>(
+  value: Op,
+): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
+  new UnaryFunction('unixMicrosToTimestamp', propagateNull([value], timestamp()), value);
+
+/** The timestamp moved forward by `amount` `unit`s (out-of-range results are backend ERROR values). */
+export const timestampAdd = <Ts extends TimestampOperand, Amount extends NumericOperand>(
+  value: Ts,
+  unit: TimeUnit,
+  amount: Amount,
+): TernaryFunction<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
+  new TernaryFunction(
+    'timestampAdd',
+    propagateNull([value, amount], timestamp()),
+    value,
+    Constant.of(unit),
+    amount,
+  );
+
+/** The timestamp moved backward by `amount` `unit`s. */
+export const timestampSubtract = <Ts extends TimestampOperand, Amount extends NumericOperand>(
+  value: Ts,
+  unit: TimeUnit,
+  amount: Amount,
+): TernaryFunction<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
+  new TernaryFunction(
+    'timestampSubtract',
+    propagateNull([value, amount], timestamp()),
+    value,
+    Constant.of(unit),
+    amount,
+  );
+
+/**
+ * `end - start` in whole `unit`s, truncated toward zero (probed: 2.6 days →
+ * `2`; negative when `end` precedes `start`). Units only — calendar
+ * granularities (`'week'`, `'month'`, ...) are rejected by the backend.
+ */
+export const timestampDiff = <End extends TimestampOperand, Start extends TimestampOperand>(
+  end: End,
+  start: Start,
+  unit: TimeUnit,
+): TernaryFunction<PropagateNull<End['type'] | Start['type'], Int64Type>> =>
+  new TernaryFunction(
+    'timestampDiff',
+    propagateNull([end, start], int64()),
+    end,
+    start,
+    Constant.of(unit),
+  );
+
+/**
+ * The timestamp truncated down to the given granularity, in the given IANA
+ * timezone (default UTC). An invalid timezone VALUE is a backend ERROR value.
+ */
+export function timestampTruncate<Ts extends TimestampOperand>(
+  value: Ts,
+  granularity: TimeGranularity,
+): BinaryFunction<PropagateNull<Ts['type'], TimestampType>>;
+export function timestampTruncate<Ts extends TimestampOperand>(
+  value: Ts,
+  granularity: TimeGranularity,
+  timezone: string,
+): TernaryFunction<PropagateNull<Ts['type'], TimestampType>>;
+export function timestampTruncate(
+  value: Expression,
+  granularity: TimeGranularity,
+  timezone?: string,
+): BinaryFunction | TernaryFunction {
+  const type = propagateNull([value], timestamp());
+  return timezone === undefined
+    ? new BinaryFunction('timestampTruncate', type, value, Constant.of(granularity))
+    : new TernaryFunction(
+        'timestampTruncate',
+        type,
+        value,
+        Constant.of(granularity),
+        Constant.of(timezone),
+      );
+}
+
+/**
+ * The given part of the timestamp as an integer, in the given IANA timezone
+ * (default UTC). `'dayofweek'` is 1-based from Sunday (probed: a Friday →
+ * `6`).
+ */
+export function timestampExtract<Ts extends TimestampOperand>(
+  value: Ts,
+  part: TimePart,
+): BinaryFunction<PropagateNull<Ts['type'], Int64Type>>;
+export function timestampExtract<Ts extends TimestampOperand>(
+  value: Ts,
+  part: TimePart,
+  timezone: string,
+): TernaryFunction<PropagateNull<Ts['type'], Int64Type>>;
+export function timestampExtract(
+  value: Expression,
+  part: TimePart,
+  timezone?: string,
+): BinaryFunction | TernaryFunction {
+  const type = propagateNull([value], int64());
+  return timezone === undefined
+    ? new BinaryFunction('timestampExtract', type, value, Constant.of(part))
+    : new TernaryFunction(
+        'timestampExtract',
+        type,
+        value,
+        Constant.of(part),
+        Constant.of(timezone),
+      );
+}
 
 // ---- vector ----
 // Distance functions over mismatched dimensions are backend ERROR values.

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -243,6 +243,7 @@ const toSdkConstant = (db: Firestore, value: Constant['value']): Pipelines.Expre
 
 const nullaryFns: Record<NullaryFunctionName, () => Pipelines.Expression> = {
   rand: Pipelines.rand,
+  currentTimestamp: Pipelines.currentTimestamp,
 };
 
 const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines.Expression> = {
@@ -269,6 +270,12 @@ const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines
   documentId: Pipelines.documentId,
   collectionId: Pipelines.collectionId,
   type: Pipelines.type,
+  timestampToUnixSeconds: Pipelines.timestampToUnixSeconds,
+  timestampToUnixMillis: Pipelines.timestampToUnixMillis,
+  timestampToUnixMicros: Pipelines.timestampToUnixMicros,
+  unixSecondsToTimestamp: Pipelines.unixSecondsToTimestamp,
+  unixMillisToTimestamp: Pipelines.unixMillisToTimestamp,
+  unixMicrosToTimestamp: Pipelines.unixMicrosToTimestamp,
   vectorLength: Pipelines.vectorLength,
 };
 
@@ -311,6 +318,10 @@ const binaryFns: Record<
   regexFind: Pipelines.regexFind,
   regexFindAll: Pipelines.regexFindAll,
   isType: (l, _r, node) => Pipelines.isType(l, literalStringOperand(node.right)),
+  // The lifted literal constants (granularity / part) translate as constant
+  // expressions, which IS the literal form the backend validates — probed.
+  timestampTruncate: (l, r) => Pipelines.timestampTruncate(l, r),
+  timestampExtract: (l, r) => Pipelines.timestampExtract(l, r),
   cosineDistance: Pipelines.cosineDistance,
   dotProduct: Pipelines.dotProduct,
   euclideanDistance: Pipelines.euclideanDistance,
@@ -327,6 +338,11 @@ const ternaryFns: Record<
   stringReplaceAll: (a, b, c) => a.stringReplaceAll(b, c),
   stringReplaceOne: (a, b, c) => a.stringReplaceOne(b, c),
   substring: Pipelines.substring,
+  timestampAdd: Pipelines.timestampAdd,
+  timestampSubtract: Pipelines.timestampSubtract,
+  timestampDiff: Pipelines.timestampDiff,
+  timestampTruncate: Pipelines.timestampTruncate,
+  timestampExtract: Pipelines.timestampExtract,
 };
 
 /**


### PR DESCRIPTION
## Summary

Implements the timestamp function family (rollout slice 4 of the expressions plan), extending the inventory with the SDK's `timestampDiff` / `timestampExtract`.

| Shape | Functions |
|---|---|
| nullary | `currentTimestamp` |
| unary | `timestampToUnix{Seconds,Millis,Micros}`, `unix{Seconds,Millis,Micros}ToTimestamp` |
| ternary | `timestampAdd`, `timestampSubtract`, `timestampDiff` |
| dual arity (binary/ternary) | `timestampTruncate`, `timestampExtract` — optional IANA timezone |

## Design

- **Literal-lift pattern generalized**: probed against the live DB, the backend requires the unit / granularity / part argument AND the timezone to be **literal constants** (a dynamic `field(...)` operand is `INVALID_ARGUMENT` at query validation — not an ERROR value). The factories therefore take literal-union parameters — `TimeUnit` ⊂ `TimeGranularity` ⊂ `TimePart`, exported — lifted via `Constant.of`, exactly like `isType`. Unlike `isType`, the executors need no raw-string recovery: the SDK standalone signatures accept expression forms, and a translated constant IS the literal the backend validates.
- **Numeric positions stay the honest numeric domain**: an add/subtract amount and a unix epoch are integer-only on the backend, but `'integer'` alone cannot be demanded at the type level (a number-valued descriptor honestly carries `'integer' | 'double'`); a fractional VALUE is a backend error. Noted in the section comment.
- All value functions ride `PropagateNull` (probed: null and absent operands both yield null).

## Probed semantics (pinned in the live function catalog)

- `timestampDiff` is `end - start` in whole units, truncated toward zero, negative when reversed; **units only** — calendar granularities are rejected.
- Bare `'week'` truncates to Sunday; `'week(monday)'` / `'isoweek'` to Monday. `'dayofweek'` extraction is 1-based from Sunday.
- Timezone-aware truncate/extract verified with `Asia/Tokyo`; an invalid timezone VALUE is a backend ERROR value (`isError`-catchable), as are out-of-range results.
- `currentTimestamp` returns server time (tolerance-tested live).

## Verification

- `pnpm check` — pass
- Emulator suite + live pipeline spec against `ikenox-sunrise`/`enterprise-native-playground`: 631 passed (catalog gains the timestamp family, one straightforward evaluation per function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)