### PR TITLE
Expressions slice 7: numeric result kinds

### DIFF
--- a/docs/plan/pipeline-query-expressions.md
+++ b/docs/plan/pipeline-query-expressions.md
@@ -347,7 +347,17 @@ both executors and the basic backend semantics in one round trip per family.
       expression concept) and arrayAgg(Distinct) (aggregate-flavored).
       Include the mechanical ones in a follow-up pass; the lambda and
       aggregate ones need their own design.
-- [ ] **7. Numeric return refinement + any leftovers** (T4).
+- [x] **7. Numeric return refinement** (T4). Probed via `type(...)`: the
+      type-preserving operators (add / subtract / multiply / mod — and
+      divide, which truncates on integers — plus abs / ceil / floor /
+      round / trunc, decimal places notwithstanding) keep int64 when every
+      numeric operand is int64; `pow` / `sqrt` / `exp` / `ln` / `log10` are
+      ALWAYS doubles. `NumericResult<Ops>` (+ runtime twin) refines on the
+      DECLARED descriptor (`int64()` vs `double()` — both carry the same
+      honest tag; a stored `2.0` reads back as wire int64, confirming the
+      honest-tag design). Number constants are `DoubleType`, so a constant
+      operand widens to double. No other leftovers — the deferred lists
+      (6b array extras, lambda/aggregate functions) stand on their own.
 - [ ] **8. Fluent methods on `ExpressionBase`** (decision pending — see open
       questions).
 

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -793,6 +793,35 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
+      it('numeric result kinds: int64 pairs stay int64; pow and roots are doubles (slice 7)', async () => {
+        // constant(2) wire-encodes as an integer (a whole JS number), so the
+        // pairs below are int64 x int64 on the wire.
+        await expectPipeline(
+          one().select(() => [
+            type(add(constant(2), constant(3))).as('addKind'),
+            type(divide(constant(7), constant(2))).as('divideKind'),
+            type(abs(constant(-2))).as('absKind'),
+            type(round(constant(2.4))).as('roundDoubleKind'),
+            type(add(constant(2), constant(0.5))).as('mixedKind'),
+            type(pow(constant(2), constant(3))).as('powKind'),
+            type(sqrt(constant(9))).as('sqrtKind'),
+          ]),
+          [
+            {
+              data: {
+                addKind: 'int64',
+                divideKind: 'int64',
+                absKind: 'int64',
+                roundDoubleKind: 'float64',
+                mixedKind: 'float64',
+                powKind: 'float64',
+                sqrtKind: 'float64',
+              },
+            },
+          ],
+        );
+      });
+
       it('currentTimestamp is the server time at evaluation', async () => {
         const before = Date.now();
         const results = await executor.execute(one().select(() => [currentTimestamp().as('now')]));

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -31,6 +31,8 @@ import {
   euclideanDistance,
   exists,
   exp,
+  type Expression,
+  field,
   floor,
   geoPointValue,
   greaterThan,
@@ -115,13 +117,14 @@ import {
 } from '../pipelines/source.js';
 import type { Doc, DocRef, FirestoreEnvironment, PlainRepository } from '../repository.js';
 import {
-  type Collection,
-  type DocumentSchema,
   double,
+  int64,
   map,
   optional,
   rootCollection,
   string,
+  type Collection,
+  type DocumentSchema,
 } from '../schema.js';
 import {
   type AuthorsCollection,
@@ -793,32 +796,19 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
-      it('numeric result kinds: int64 pairs stay int64; pow and roots are doubles (slice 7)', async () => {
-        // constant(2) wire-encodes as an integer (a whole JS number), so the
-        // pairs below are int64 x int64 on the wire.
+      it('numeric constants wire-encode whole values as integers (the honest widening)', async () => {
+        // A number constant is DECLARED DoubleType, but a whole JS number
+        // wire-encodes as an integer — so the backend kind here is int64
+        // while the descriptor claim is double. This is the one deliberate
+        // claim/kind divergence (the honest 'integer' | 'double' tag makes
+        // it sound); field operands are oracle-tested exhaustively in the
+        // dedicated numeric-kinds suite below.
         await expectPipeline(
           one().select(() => [
-            type(add(constant(2), constant(3))).as('addKind'),
-            type(divide(constant(7), constant(2))).as('divideKind'),
-            type(abs(constant(-2))).as('absKind'),
-            type(round(constant(2.4))).as('roundDoubleKind'),
-            type(add(constant(2), constant(0.5))).as('mixedKind'),
-            type(pow(constant(2), constant(3))).as('powKind'),
-            type(sqrt(constant(9))).as('sqrtKind'),
+            type(add(constant(2), constant(3))).as('wholeConstants'),
+            type(add(constant(2), constant(0.5))).as('fractionalConstant'),
           ]),
-          [
-            {
-              data: {
-                addKind: 'int64',
-                divideKind: 'int64',
-                absKind: 'int64',
-                roundDoubleKind: 'float64',
-                mixedKind: 'float64',
-                powKind: 'float64',
-                sqrtKind: 'float64',
-              },
-            },
-          ],
+          [{ data: { wholeConstants: 'int64', fractionalConstant: 'float64' } }],
         );
       });
 
@@ -837,6 +827,80 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
 
       // rand (the remaining nullary) is covered by its own range test below —
       // its value is not deterministic.
+    });
+
+    describe('numeric result kinds (slice 7): the descriptor claim IS the oracle', () => {
+      const numericKindsCollection = rootCollection({
+        name: 'NumericKinds',
+        schema: { i: int64(), d: double() },
+      });
+      let numbers: typeof numericKindsCollection;
+      beforeEach(async () => {
+        numbers = uniqueCollection(numericKindsCollection);
+        // d holds a FRACTIONAL value: a whole value in a double() field would
+        // wire-encode as an integer and the field's kind would not exercise
+        // the double side (the honest tag).
+        await createRepository(numbers).batchSet([{ id: ['n1'], data: { i: 7, d: 2.5 } }]);
+      });
+
+      it('matches the backend kind for every arithmetic function and operand mix', async () => {
+        const i = field(int64(), 'i');
+        const d = field(double(), 'd');
+        const cases: [string, Expression][] = [];
+        const binary = [
+          ['add', add],
+          ['subtract', subtract],
+          ['multiply', multiply],
+          ['divide', divide],
+          ['mod', mod],
+          ['pow', pow],
+        ] as const;
+        for (const [name, fn] of binary) {
+          cases.push([`${name}_ii`, fn(i, i)], [`${name}_id`, fn(i, d)], [`${name}_dd`, fn(d, d)]);
+        }
+        const unary = [
+          ['abs', abs],
+          ['ceil', ceil],
+          ['floor', floor],
+          ['sqrt', sqrt],
+          ['exp', exp],
+          ['ln', ln],
+          ['log10', log10],
+        ] as const;
+        for (const [name, fn] of unary) {
+          cases.push([`${name}_i`, fn(i)], [`${name}_d`, fn(d)]);
+        }
+        // round/trunc are overloaded (dual-arity) — exercised individually,
+        // including the decimal-places forms.
+        cases.push(
+          ['round_i', round(i)],
+          ['round_d', round(d)],
+          ['round_i_places', round(i, i)],
+          ['round_d_places', round(d, i)],
+          ['trunc_i', trunc(i)],
+          ['trunc_d', trunc(d)],
+          ['trunc_i_places', trunc(i, i)],
+          ['trunc_d_places', trunc(d, i)],
+        );
+
+        // The ORACLE: each expression's own descriptor claim, mapped to the
+        // backend's kind vocabulary. Any divergence between the library's
+        // typing and the backend fails this test.
+        const expected = Object.fromEntries(
+          cases.map(([alias, e]) => [alias, e.type.type === 'int64' ? 'int64' : 'float64']),
+        );
+        const [head, ...rest] = cases;
+        if (head === undefined) {
+          throw new Error('no cases');
+        }
+        const results = await executor.execute(
+          collectionInput(numbers).select(() => [
+            type(head[1]).as(head[0]),
+            ...rest.map(([alias, e]) => type(e).as(alias)),
+          ]),
+        );
+        expect(results.map((row) => row.data)).toStrictEqual([expected]);
+      });
     });
 
     describe('arithmetic and string functions', () => {

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -544,26 +544,54 @@ describe('arithmetic operators', () => {
     expect(add(rank, count)).toStrictEqual(new BinaryFunction('add', double(), rank, count));
   });
 
-  it('every unary function shares the numeric domain and DoubleType result', () => {
-    const table = [
+  it('unary functions share the numeric domain; the rounding family preserves int64', () => {
+    // Type-preserving (probed): int64 in, int64 out.
+    const preserving = [
       ['abs', abs],
       ['ceil', ceil],
       ['floor', floor],
+    ] as const;
+    for (const [fnName, fn] of preserving) {
+      expect(fn(count)).toStrictEqual(new UnaryFunction(fnName, int64(), count));
+      expect(fn(rank)).toStrictEqual(new UnaryFunction(fnName, double(), rank));
+    }
+    // Always-double (probed): sqrt/exp/ln/log10 leave the integer domain.
+    const alwaysDouble = [
       ['sqrt', sqrt],
       ['exp', exp],
       ['ln', ln],
       ['log10', log10],
     ] as const;
-    for (const [fnName, fn] of table) {
+    for (const [fnName, fn] of alwaysDouble) {
       expect(fn(count)).toStrictEqual(new UnaryFunction(fnName, double(), count));
       expect(fn(field(literal(1, 2), 'lv')).name).toBe(fnName);
     }
     // round/trunc are overloaded (dual-arity), so a union-typed table entry
-    // is not callable — exercised individually.
-    expect(round(count)).toStrictEqual(new UnaryFunction('round', double(), count));
-    expect(trunc(count)).toStrictEqual(new UnaryFunction('trunc', double(), count));
+    // is not callable — exercised individually. They preserve the FIRST
+    // operand's kind even with decimal places (probed).
+    expect(round(count)).toStrictEqual(new UnaryFunction('round', int64(), count));
+    expect(trunc(count, constant(1))).toStrictEqual(
+      new BinaryFunction('trunc', int64(), count, constant(1)),
+    );
+    expect(round(rank)).toStrictEqual(new UnaryFunction('round', double(), rank));
+    expectTypeOf(round(count).type).toEqualTypeOf(int64());
     // @ts-expect-error -- a string operand is not numeric
     abs(field(string(), 'name'));
+  });
+
+  it('binary type-preserving functions keep an int64 pair; any double side widens', () => {
+    expect(add(count, count)).toStrictEqual(new BinaryFunction('add', int64(), count, count));
+    expectTypeOf(add(count, count).type).toEqualTypeOf(int64());
+    expect(divide(count, count).type).toStrictEqual(int64());
+    expect(add(count, rank).type).toStrictEqual(double());
+    // A number constant is a DoubleType — it widens.
+    expect(add(count, constant(2)).type).toStrictEqual(double());
+    // pow is always a double, even over an int64 pair (probed).
+    expect(pow(count, count).type).toStrictEqual(double());
+    // Null propagation wraps around the refined kind.
+    const viaNullable = add(count, field(nullable(int64()), 'n'));
+    expect(viaNullable.type).toStrictEqual(nullable(int64()));
+    expectTypeOf(viaNullable.type).toEqualTypeOf(nullable(int64()));
   });
 
   it('every binary function shares the numeric domain and DoubleType result', () => {

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -1169,12 +1169,35 @@ type NumericOperand = Expression<Valued<'integer' | 'double'>>;
 type StringOperand = Expression<Valued<'string'>>;
 
 // ---- arithmetic ----
-// All arithmetic returns a plain DoubleType (its 'integer' | 'double' tag is
-// the honest numeric domain; per-operator integer/double refinement is a
-// deferred cross-cutting item — see the expressions plan). Error edges
-// (divide by zero, ln(0), sqrt of a negative) produce backend ERROR values,
-// not null — observable/recoverable only through the error-channel
-// functions (isError / ifError; not implemented yet).
+// Numeric result kinds mirror the backend (probed): the type-preserving
+// operators (add / subtract / multiply / mod — and divide, which TRUNCATES
+// on integers — plus the rounding family abs / ceil / floor / round / trunc)
+// keep int64 when every numeric operand is declared int64 and are doubles
+// otherwise; pow / sqrt / exp / ln / log10 are ALWAYS doubles. The
+// declaration is what refines (`int64()` vs `double()` fields carry the same
+// honest 'integer' | 'double' tag — a whole JS number wire-encodes as an
+// integer either way). Error edges (divide by zero, ln(0), sqrt of a
+// negative) produce backend ERROR values, not null — observable and
+// recoverable only through the error channel (isError / ifError).
+
+/**
+ * The result kind of the type-preserving arithmetic: `Int64Type` when every
+ * numeric operand is a declared int64 (null-stripped), `DoubleType`
+ * otherwise.
+ */
+type NumericResult<Operands extends FieldType> = [StripNull<Operands>] extends [Int64Type]
+  ? Int64Type
+  : DoubleType;
+
+/** Runtime counterpart of {@link NumericResult} (same bridge shape as `propagateNull`). */
+function numericResultType<Ops extends readonly Expression[]>(
+  operands: Ops,
+): NumericResult<Ops[number]['type']>;
+function numericResultType(operands: readonly Expression[]): FieldType {
+  return operands.every((operand) => stripNull(operand.type)?.type === 'int64')
+    ? int64()
+    : double();
+}
 
 /** A uniformly distributed random double in [0, 1), regenerated per row. */
 export const rand = (): NullaryFunction<DoubleType> => new NullaryFunction('rand', double());
@@ -1183,36 +1206,61 @@ export const rand = (): NullaryFunction<DoubleType> => new NullaryFunction('rand
 export const add = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('add', propagateNull([left, right], double()), left, right);
+): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new BinaryFunction(
+    'add',
+    propagateNull([left, right], numericResultType([left, right])),
+    left,
+    right,
+  );
 
 /** Numeric subtraction (`left - right`). */
 export const subtract = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('subtract', propagateNull([left, right], double()), left, right);
+): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new BinaryFunction(
+    'subtract',
+    propagateNull([left, right], numericResultType([left, right])),
+    left,
+    right,
+  );
 
 /** Numeric multiplication. */
 export const multiply = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('multiply', propagateNull([left, right], double()), left, right);
+): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new BinaryFunction(
+    'multiply',
+    propagateNull([left, right], numericResultType([left, right])),
+    left,
+    right,
+  );
 
-/** Numeric division (`left / right`); a zero divisor is a backend ERROR value. */
+/** Numeric division (`left / right`) — TRUNCATING on an int64 pair (probed); a zero divisor is a backend ERROR value. */
 export const divide = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('divide', propagateNull([left, right], double()), left, right);
+): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new BinaryFunction(
+    'divide',
+    propagateNull([left, right], numericResultType([left, right])),
+    left,
+    right,
+  );
 
 /** Modulo (`left % right`). */
 export const mod = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('mod', propagateNull([left, right], double()), left, right);
+): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new BinaryFunction(
+    'mod',
+    propagateNull([left, right], numericResultType([left, right])),
+    left,
+    right,
+  );
 
 /** Exponentiation (`base ** exponent`). */
 export const pow = <L extends NumericOperand, R extends NumericOperand>(
@@ -1224,20 +1272,32 @@ export const pow = <L extends NumericOperand, R extends NumericOperand>(
 /** Absolute value. */
 export const abs = <Op extends NumericOperand>(
   expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('abs', propagateNull([expression], double()), expression);
+): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new UnaryFunction(
+    'abs',
+    propagateNull([expression], numericResultType([expression])),
+    expression,
+  );
 
 /** Rounds up to the nearest whole number. */
 export const ceil = <Op extends NumericOperand>(
   expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('ceil', propagateNull([expression], double()), expression);
+): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new UnaryFunction(
+    'ceil',
+    propagateNull([expression], numericResultType([expression])),
+    expression,
+  );
 
 /** Rounds down to the nearest whole number. */
 export const floor = <Op extends NumericOperand>(
   expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('floor', propagateNull([expression], double()), expression);
+): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new UnaryFunction(
+    'floor',
+    propagateNull([expression], numericResultType([expression])),
+    expression,
+  );
 
 /** Square root; a negative operand is a backend ERROR value. */
 export const sqrt = <Op extends NumericOperand>(
@@ -1266,20 +1326,24 @@ export const log10 = <Op extends NumericOperand>(
 /** Rounds to the nearest whole number, or to `decimalPlaces` decimal places. */
 export function round<Op extends NumericOperand>(
   expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>>;
+): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>>;
 export function round<Op extends NumericOperand, P extends NumericOperand>(
   expression: Op,
   decimalPlaces: P,
-): BinaryFunction<PropagateNull<Op['type'] | P['type'], DoubleType>>;
+): BinaryFunction<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
 export function round(
   expression: Expression,
   decimalPlaces?: Expression,
 ): UnaryFunction | BinaryFunction {
   return decimalPlaces === undefined
-    ? new UnaryFunction('round', propagateNull([expression], double()), expression)
+    ? new UnaryFunction(
+        'round',
+        propagateNull([expression], numericResultType([expression])),
+        expression,
+      )
     : new BinaryFunction(
         'round',
-        propagateNull([expression, decimalPlaces], double()),
+        propagateNull([expression, decimalPlaces], numericResultType([expression])),
         expression,
         decimalPlaces,
       );
@@ -1288,20 +1352,24 @@ export function round(
 /** Truncates toward zero, to a whole number or to `decimalPlaces` decimal places. */
 export function trunc<Op extends NumericOperand>(
   expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>>;
+): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>>;
 export function trunc<Op extends NumericOperand, P extends NumericOperand>(
   expression: Op,
   decimalPlaces: P,
-): BinaryFunction<PropagateNull<Op['type'] | P['type'], DoubleType>>;
+): BinaryFunction<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
 export function trunc(
   expression: Expression,
   decimalPlaces?: Expression,
 ): UnaryFunction | BinaryFunction {
   return decimalPlaces === undefined
-    ? new UnaryFunction('trunc', propagateNull([expression], double()), expression)
+    ? new UnaryFunction(
+        'trunc',
+        propagateNull([expression], numericResultType([expression])),
+        expression,
+      )
     : new BinaryFunction(
         'trunc',
-        propagateNull([expression, decimalPlaces], double()),
+        propagateNull([expression, decimalPlaces], numericResultType([expression])),
         expression,
         decimalPlaces,
       );


### PR DESCRIPTION
## Summary

Implements rollout slice 7 (T4): per-operator numeric result refinement, replacing the uniform `DoubleType` returns.

## Probed (via `type(...)` against the live backend, pinned in the catalog)

| Operators | int64 × int64 | any double side |
|---|---|---|
| `add` / `subtract` / `multiply` / `mod` / `divide` (truncating) | **int64** | float64 |
| `abs` / `ceil` / `floor` / `round` / `trunc` (decimal places notwithstanding) | **int64** | float64 |
| `pow` / `sqrt` / `exp` / `ln` / `log10` | float64 | float64 |

Also confirmed the honest-tag design: a stored `2.0` (whole JS number) reads back as wire `int64`.

## Design

`NumericResult<Ops>` (+ runtime twin `numericResultType`, the usual overload-bridge shape) refines on the **declared** descriptor — `int64()` vs `double()` fields carry the same honest `'integer' | 'double'` tag, so the declaration is the only statically available signal. Null-stripped before the check, so `nullable(int64())` operands refine and the null wraps back around (`nullable(int64())` results). Number constants are `DoubleType`, so a constant operand widens to double.

## Verification

- `pnpm check` — pass
- Emulator + live pipeline spec (`ikenox-sunrise`/`enterprise-native-playground`): 651 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)