### PR TITLE
Restructure the function-call AST into a payload union

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -407,8 +407,19 @@ second / third` is (ts, unit, amount) for `timestampAdd` but
      signature. Anything that would traverse operands generically must know
      payloads per name (today nothing does — executors translate per-function
      anyway).
-- [ ] Per-op numeric return type refinement (Int64-pair → Int64 vs
-      auto-widen to Double) — TODO comments already in `expression.ts`.
+     DONE (2026-07): all three distortions resolved — no factory overloads
+     remain (dual-arity families are single `(a, b, c?)` signatures with
+     optional payload fields), payloads carry named per-function fields, and
+     backend-literal arguments (`typeName`, timestamp `unit` / `granularity`
+     / `part` / `timezone`, map `key`) are plain payload fields with the
+     whole `literalStringOperand` recovery mechanism deleted. Both executors
+     dispatch through one `FunctionTranslators` mapped table via a generic
+     helper — the correlated-union dispatch needed NO type assertion — and
+     the gcloud `equalAny`-family options assertion fell away too (the d.ts
+     does declare the array-expression overload; the earlier gap report
+     missed it). Wire behavior verified unchanged by the full live catalog.
+- [x] Per-op numeric return type refinement (Int64-pair → Int64 vs
+      auto-widen to Double) — done in expressions slice 7 (`NumericResult`).
 - [x] Improve `constant(value)` type inference from runtime value — see the
       expressions plan, slice 1.
 - [ ] Tighten `arrayGet` return type via element typing.

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -103,7 +103,6 @@ import {
 } from '@firebase/firestore/pipelines';
 import { collectionPath } from 'firestore-repository/path';
 import {
-  type BinaryFunctionName,
   type Constant,
   type ConstantArray,
   type Expression,
@@ -111,11 +110,8 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
-  type BinaryFunction,
-  type NullaryFunctionName,
-  type TernaryFunctionName,
-  UnaryFunctionName,
-  VariadicFunctionName,
+  type FunctionName,
+  type FunctionPayload,
 } from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
@@ -254,38 +250,8 @@ const toSdkExpression = (db: Firestore, expression: Expression): SdkExpression =
       return field(expression.path);
     case 'constant':
       return toSdkConstant(db, expression.value);
-    case 'nullaryFunction':
-      return nullaryFns[expression.name]();
-    case 'unaryFunction':
-      return unaryFns[expression.name](toSdkExpression(db, expression.operand));
-    case 'binaryFunction':
-      return binaryFns[expression.name](
-        toSdkExpression(db, expression.left),
-        toSdkExpression(db, expression.right),
-        expression,
-      );
-    case 'ternaryFunction':
-      return ternaryFns[expression.name](
-        toSdkExpression(db, expression.first),
-        toSdkExpression(db, expression.second),
-        toSdkExpression(db, expression.third),
-      );
-    case 'variadicFunction': {
-      const [first, second, ...rest] = expression.operands;
-      return variadicFns[expression.name](
-        toSdkExpression(db, first),
-        toSdkExpression(db, second),
-        ...rest.map((operand) => toSdkExpression(db, operand)),
-      );
-    }
-    case 'arrayConstructor':
-      return sdkArray(expression.elements.map((element) => toSdkExpression(db, element)));
-    case 'mapConstructor':
-      return sdkMap(
-        Object.fromEntries(
-          Object.entries(expression.fields).map(([k, e]) => [k, toSdkExpression(db, e)]),
-        ),
-      );
+    case 'functionCall':
+      return dispatch(expression.call, (e) => toSdkExpression(db, e));
     default:
       return assertNever(expression);
   }
@@ -347,169 +313,195 @@ const toSdkConstant = (db: Firestore, value: Constant['value']): SdkExpression =
 const isConstantArrayValue = (value: Constant['value']): value is ConstantArray =>
   Array.isArray(value);
 
-// Per-shape translation tables: `Record` over the name union requires every
-// key, so a newly added function name fails to compile here until translated.
-// (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
-// type-tag only, no wire change.)
-
-const nullaryFns: Record<NullaryFunctionName, () => SdkExpression> = {
-  rand: sdkRand,
-  currentTimestamp: sdkCurrentTimestamp,
-};
-
-const unaryFns: Record<UnaryFunctionName, (o: SdkExpression) => SdkExpression> = {
-  not: (o) => sdkNot(o.asBoolean()),
-  abs: sdkAbs,
-  ceil: sdkCeil,
-  floor: sdkFloor,
-  round: sdkRound,
-  trunc: sdkTrunc,
-  sqrt: sdkSqrt,
-  exp: sdkExp,
-  ln: sdkLn,
-  log10: sdkLog10,
-  charLength: sdkCharLength,
-  byteLength: sdkByteLength,
-  toLower: sdkToLower,
-  toUpper: sdkToUpper,
-  stringReverse: sdkStringReverse,
-  trim: sdkTrim,
-  ltrim: sdkLtrim,
-  rtrim: sdkRtrim,
-  documentId: sdkDocumentId,
-  collectionId: sdkCollectionId,
-  type: sdkType,
-  exists: sdkExists,
-  isAbsent: sdkIsAbsent,
-  isError: sdkIsError,
-  arrayLength: sdkArrayLength,
-  // arrayReverse exists at runtime but the SDK's typings only declare the fluent form.
-  arrayReverse: (o) => o.arrayReverse(),
-  mapKeys: sdkMapKeys,
-  mapValues: sdkMapValues,
-  mapEntries: sdkMapEntries,
-  timestampToUnixSeconds: sdkTimestampToUnixSeconds,
-  timestampToUnixMillis: sdkTimestampToUnixMillis,
-  timestampToUnixMicros: sdkTimestampToUnixMicros,
-  unixSecondsToTimestamp: sdkUnixSecondsToTimestamp,
-  unixMillisToTimestamp: sdkUnixMillisToTimestamp,
-  unixMicrosToTimestamp: sdkUnixMicrosToTimestamp,
-  vectorLength: sdkVectorLength,
-};
-
-// Entries receive the raw AST node too: functions with backend-mandated
-// LITERAL arguments (isType's type name) must hand the SDK helper the plain
-// string, which is unrecoverable from the translated constant expression.
-const binaryFns: Record<
-  BinaryFunctionName,
-  (l: SdkExpression, r: SdkExpression, node: BinaryFunction) => SdkExpression
-> = {
-  equal: sdkEqual,
-  notEqual: sdkNotEqual,
-  lessThan: sdkLessThan,
-  lessThanOrEqual: sdkLessThanOrEqual,
-  greaterThan: sdkGreaterThan,
-  greaterThanOrEqual: sdkGreaterThanOrEqual,
-  equalAny: sdkEqualAny,
-  notEqualAny: sdkNotEqualAny,
-  ifError: sdkIfError,
-  ifAbsent: sdkIfAbsent,
-  ifNull: sdkIfNull,
-  arrayGet: sdkArrayGet,
-  arrayContains: sdkArrayContains,
-  arrayContainsAll: sdkArrayContainsAll,
-  arrayContainsAny: sdkArrayContainsAny,
-  // The SDK's mapGet key parameter is a plain string — recover the lifted literal.
-  mapGet: (l, _r, node) => sdkMapGet(l, literalStringOperand(node.right)),
-  mapRemove: sdkMapRemove,
-  add: sdkAdd,
-  subtract: sdkSubtract,
-  multiply: sdkMultiply,
-  divide: sdkDivide,
-  mod: sdkMod,
-  pow: sdkPow,
-  round: sdkRound,
-  trunc: sdkTrunc,
-  trim: sdkTrim,
-  ltrim: sdkLtrim,
-  rtrim: sdkRtrim,
-  startsWith: sdkStartsWith,
-  endsWith: sdkEndsWith,
-  stringContains: sdkStringContains,
-  stringIndexOf: sdkStringIndexOf,
-  stringRepeat: sdkStringRepeat,
-  substring: (l, r) => sdkSubstring(l, r),
-  like: sdkLike,
-  regexContains: sdkRegexContains,
-  regexMatch: sdkRegexMatch,
-  regexFind: sdkRegexFind,
-  regexFindAll: sdkRegexFindAll,
-  isType: (l, _r, node) => sdkIsType(l, literalStringOperand(node.right)),
-  // The lifted literal constants (granularity / part) translate as constant
-  // expressions, which IS the literal form the backend validates — probed.
-  timestampTruncate: (l, r) => sdkTimestampTruncate(l, r),
-  timestampExtract: (l, r) => sdkTimestampExtract(l, r),
-  cosineDistance: sdkCosineDistance,
-  dotProduct: sdkDotProduct,
-  euclideanDistance: sdkEuclideanDistance,
-};
-
-const ternaryFns: Record<
-  TernaryFunctionName,
-  (a: SdkExpression, b: SdkExpression, c: SdkExpression) => SdkExpression
-> = {
-  stringReplaceAll: sdkStringReplaceAll,
-  stringReplaceOne: sdkStringReplaceOne,
-  substring: sdkSubstring,
-  conditional: (a, b, c) => sdkConditional(a.asBoolean(), b, c),
-  mapSet: sdkMapSet,
-  timestampAdd: sdkTimestampAdd,
-  timestampSubtract: sdkTimestampSubtract,
-  timestampDiff: sdkTimestampDiff,
-  timestampTruncate: sdkTimestampTruncate,
-  timestampExtract: sdkTimestampExtract,
-};
+/**
+ * Dispatches a function-call payload to its translator. The generic `K` ties
+ * the payload's `name` to the matching translator entry: TS cannot correlate a
+ * whole-union table index (`functionTranslators[call.name](call, ...)`) against
+ * the whole-union payload on its own, but a single type variable lets the
+ * mapped-type access `functionTranslators[K]` line up with the narrowed
+ * `Extract<FunctionPayload, { name: K }>` argument — so no assertion is needed.
+ */
+const dispatch = <K extends FunctionName>(
+  call: Extract<FunctionPayload, { name: K }>,
+  t: (e: Expression) => SdkExpression,
+): SdkExpression => functionTranslators[call.name](call, t);
 
 /**
- * Recovers the literal string a factory lifted into a constant operand
- * (e.g. `isType`'s type name): the backend requires the wire argument to be
- * a constant, and the SDK helper takes it as a plain string.
+ * One translator per function name: a `Record`-like mapped type over the name
+ * union requires every key, so a newly added function fails to compile here
+ * until translated. Each entry receives its NARROWED payload (typed named
+ * operands, literal fields as plain values) and `t`, the recursive translator
+ * for operand expressions.
+ *
+ * (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
+ * type-tag only, no wire change.)
  */
-const literalStringOperand = (operand: Expression): string => {
-  switch (operand.kind) {
-    case 'constant': {
-      const { value } = operand;
-      if (typeof value === 'string') {
-        return value;
-      }
-      throw new Error('expected a literal string constant operand');
-    }
-    case 'field':
-    case 'nullaryFunction':
-    case 'unaryFunction':
-    case 'binaryFunction':
-    case 'ternaryFunction':
-    case 'variadicFunction':
-    case 'arrayConstructor':
-    case 'mapConstructor':
-      throw new Error(`expected a constant operand, got ${operand.kind}`);
-    default:
-      return assertNever(operand);
-  }
+type FunctionTranslators = {
+  [K in FunctionName]: (
+    call: Extract<FunctionPayload, { name: K }>,
+    t: (e: Expression) => SdkExpression,
+  ) => SdkExpression;
 };
 
-const variadicFns: Record<
-  VariadicFunctionName,
-  (first: SdkExpression, second: SdkExpression, ...rest: SdkExpression[]) => SdkExpression
-> = {
-  and: (f, s, ...r) => sdkAnd(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  or: (f, s, ...r) => sdkOr(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  stringConcat: sdkStringConcat,
-  xor: (f, s, ...r) => sdkXor(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  logicalMaximum: sdkLogicalMaximum,
-  logicalMinimum: sdkLogicalMinimum,
-  arrayConcat: sdkArrayConcat,
-  mapMerge: sdkMapMerge,
+const functionTranslators: FunctionTranslators = {
+  // logical
+  and: (c, t) => {
+    const [f, s, ...r] = c.conditions;
+    return sdkAnd(t(f).asBoolean(), t(s).asBoolean(), ...r.map((e) => t(e).asBoolean()));
+  },
+  or: (c, t) => {
+    const [f, s, ...r] = c.conditions;
+    return sdkOr(t(f).asBoolean(), t(s).asBoolean(), ...r.map((e) => t(e).asBoolean()));
+  },
+  xor: (c, t) => {
+    const [f, s, ...r] = c.conditions;
+    return sdkXor(t(f).asBoolean(), t(s).asBoolean(), ...r.map((e) => t(e).asBoolean()));
+  },
+  not: (c, t) => sdkNot(t(c.condition).asBoolean()),
+  // comparison
+  equal: (c, t) => sdkEqual(t(c.left), t(c.right)),
+  notEqual: (c, t) => sdkNotEqual(t(c.left), t(c.right)),
+  lessThan: (c, t) => sdkLessThan(t(c.left), t(c.right)),
+  lessThanOrEqual: (c, t) => sdkLessThanOrEqual(t(c.left), t(c.right)),
+  greaterThan: (c, t) => sdkGreaterThan(t(c.left), t(c.right)),
+  greaterThanOrEqual: (c, t) => sdkGreaterThanOrEqual(t(c.left), t(c.right)),
+  // The SDK declares an (Expression, arrayExpression: Expression) overload —
+  // pass the translated array-typed operand directly.
+  equalAny: (c, t) => sdkEqualAny(t(c.value), t(c.options)),
+  notEqualAny: (c, t) => sdkNotEqualAny(t(c.value), t(c.options)),
+  // conditional & extremes
+  conditional: (c, t) => sdkConditional(t(c.condition).asBoolean(), t(c.thenExpr), t(c.elseExpr)),
+  logicalMaximum: (c, t) => {
+    const [f, s, ...r] = c.operands;
+    return sdkLogicalMaximum(t(f), t(s), ...r.map(t));
+  },
+  logicalMinimum: (c, t) => {
+    const [f, s, ...r] = c.operands;
+    return sdkLogicalMinimum(t(f), t(s), ...r.map(t));
+  },
+  // arithmetic
+  rand: () => sdkRand(),
+  add: (c, t) => sdkAdd(t(c.left), t(c.right)),
+  subtract: (c, t) => sdkSubtract(t(c.left), t(c.right)),
+  multiply: (c, t) => sdkMultiply(t(c.left), t(c.right)),
+  divide: (c, t) => sdkDivide(t(c.left), t(c.right)),
+  mod: (c, t) => sdkMod(t(c.left), t(c.right)),
+  pow: (c, t) => sdkPow(t(c.base), t(c.exponent)),
+  abs: (c, t) => sdkAbs(t(c.value)),
+  ceil: (c, t) => sdkCeil(t(c.value)),
+  floor: (c, t) => sdkFloor(t(c.value)),
+  round: (c, t) =>
+    c.decimalPlaces === undefined ? sdkRound(t(c.value)) : sdkRound(t(c.value), t(c.decimalPlaces)),
+  trunc: (c, t) =>
+    c.decimalPlaces === undefined ? sdkTrunc(t(c.value)) : sdkTrunc(t(c.value), t(c.decimalPlaces)),
+  sqrt: (c, t) => sdkSqrt(t(c.value)),
+  exp: (c, t) => sdkExp(t(c.value)),
+  ln: (c, t) => sdkLn(t(c.value)),
+  log10: (c, t) => sdkLog10(t(c.value)),
+  // string
+  charLength: (c, t) => sdkCharLength(t(c.value)),
+  byteLength: (c, t) => sdkByteLength(t(c.value)),
+  toLower: (c, t) => sdkToLower(t(c.value)),
+  toUpper: (c, t) => sdkToUpper(t(c.value)),
+  stringReverse: (c, t) => sdkStringReverse(t(c.value)),
+  trim: (c, t) =>
+    c.characters === undefined ? sdkTrim(t(c.value)) : sdkTrim(t(c.value), t(c.characters)),
+  ltrim: (c, t) =>
+    c.characters === undefined ? sdkLtrim(t(c.value)) : sdkLtrim(t(c.value), t(c.characters)),
+  rtrim: (c, t) =>
+    c.characters === undefined ? sdkRtrim(t(c.value)) : sdkRtrim(t(c.value), t(c.characters)),
+  startsWith: (c, t) => sdkStartsWith(t(c.value), t(c.prefix)),
+  endsWith: (c, t) => sdkEndsWith(t(c.value), t(c.suffix)),
+  stringContains: (c, t) => sdkStringContains(t(c.value), t(c.substring)),
+  stringConcat: (c, t) => {
+    const [f, s, ...r] = c.operands;
+    return sdkStringConcat(t(f), t(s), ...r.map(t));
+  },
+  stringIndexOf: (c, t) => sdkStringIndexOf(t(c.value), t(c.substring)),
+  stringRepeat: (c, t) => sdkStringRepeat(t(c.value), t(c.count)),
+  stringReplaceAll: (c, t) => sdkStringReplaceAll(t(c.value), t(c.find), t(c.replacement)),
+  stringReplaceOne: (c, t) => sdkStringReplaceOne(t(c.value), t(c.find), t(c.replacement)),
+  substring: (c, t) =>
+    c.length === undefined
+      ? sdkSubstring(t(c.value), t(c.position))
+      : sdkSubstring(t(c.value), t(c.position), t(c.length)),
+  like: (c, t) => sdkLike(t(c.value), t(c.pattern)),
+  // regex
+  regexContains: (c, t) => sdkRegexContains(t(c.value), t(c.pattern)),
+  regexMatch: (c, t) => sdkRegexMatch(t(c.value), t(c.pattern)),
+  regexFind: (c, t) => sdkRegexFind(t(c.value), t(c.pattern)),
+  regexFindAll: (c, t) => sdkRegexFindAll(t(c.value), t(c.pattern)),
+  // reference
+  documentId: (c, t) => sdkDocumentId(t(c.reference)),
+  collectionId: (c, t) => sdkCollectionId(t(c.reference)),
+  // type
+  type: (c, t) => sdkType(t(c.value)),
+  // The SDK's isType type name is a plain string — pass the literal payload field.
+  isType: (c, t) => sdkIsType(t(c.value), c.typeName),
+  // existence & error
+  exists: (c, t) => sdkExists(t(c.target)),
+  isAbsent: (c, t) => sdkIsAbsent(t(c.target)),
+  isError: (c, t) => sdkIsError(t(c.value)),
+  ifError: (c, t) => sdkIfError(t(c.tryExpr), t(c.catchExpr)),
+  ifAbsent: (c, t) => sdkIfAbsent(t(c.value), t(c.fallback)),
+  ifNull: (c, t) => sdkIfNull(t(c.value), t(c.fallback)),
+  // array
+  arrayValue: (c, t) => sdkArray(c.elements.map(t)),
+  arrayLength: (c, t) => sdkArrayLength(t(c.value)),
+  // arrayReverse exists at runtime but the SDK's typings only declare the fluent form.
+  arrayReverse: (c, t) => t(c.value).arrayReverse(),
+  arrayGet: (c, t) => sdkArrayGet(t(c.value), t(c.index)),
+  arrayContains: (c, t) => sdkArrayContains(t(c.value), t(c.element)),
+  arrayContainsAll: (c, t) => sdkArrayContainsAll(t(c.value), t(c.options)),
+  arrayContainsAny: (c, t) => sdkArrayContainsAny(t(c.value), t(c.options)),
+  arrayConcat: (c, t) => {
+    const [f, s, ...r] = c.operands;
+    return sdkArrayConcat(t(f), t(s), ...r.map(t));
+  },
+  // map
+  mapValue: (c, t) =>
+    sdkMap(Object.fromEntries(Object.entries(c.fields).map(([k, e]) => [k, t(e)]))),
+  // The SDK's map key parameters are plain strings — pass the literal payload fields.
+  mapGet: (c, t) => sdkMapGet(t(c.value), c.key),
+  mapKeys: (c, t) => sdkMapKeys(t(c.value)),
+  mapValues: (c, t) => sdkMapValues(t(c.value)),
+  mapEntries: (c, t) => sdkMapEntries(t(c.value)),
+  mapSet: (c, t) => sdkMapSet(t(c.value), c.key, t(c.entry)),
+  mapRemove: (c, t) => sdkMapRemove(t(c.value), c.key),
+  mapMerge: (c, t) => {
+    const [f, s, ...r] = c.operands;
+    return sdkMapMerge(t(f), t(s), ...r.map(t));
+  },
+  // timestamp
+  currentTimestamp: () => sdkCurrentTimestamp(),
+  timestampToUnixSeconds: (c, t) => sdkTimestampToUnixSeconds(t(c.value)),
+  timestampToUnixMillis: (c, t) => sdkTimestampToUnixMillis(t(c.value)),
+  timestampToUnixMicros: (c, t) => sdkTimestampToUnixMicros(t(c.value)),
+  unixSecondsToTimestamp: (c, t) => sdkUnixSecondsToTimestamp(t(c.value)),
+  unixMillisToTimestamp: (c, t) => sdkUnixMillisToTimestamp(t(c.value)),
+  unixMicrosToTimestamp: (c, t) => sdkUnixMicrosToTimestamp(t(c.value)),
+  // The literal `unit` has no (Expression, literal-unit, Expression-amount)
+  // overload — take the all-Expression form, lifting the unit to a constant
+  // (the same wire form the backend validates — probed).
+  timestampAdd: (c, t) => sdkTimestampAdd(t(c.value), sdkConstant(c.unit), t(c.amount)),
+  timestampSubtract: (c, t) => sdkTimestampSubtract(t(c.value), sdkConstant(c.unit), t(c.amount)),
+  timestampDiff: (c, t) => sdkTimestampDiff(t(c.end), t(c.start), c.unit),
+  // granularity / part / timezone are plain literals — the SDK's TimeGranularity
+  // / TimePart overloads take them directly (probed to be the literal form the
+  // backend validates).
+  timestampTruncate: (c, t) =>
+    c.timezone === undefined
+      ? sdkTimestampTruncate(t(c.value), c.granularity)
+      : sdkTimestampTruncate(t(c.value), c.granularity, c.timezone),
+  timestampExtract: (c, t) =>
+    c.timezone === undefined
+      ? sdkTimestampExtract(t(c.value), c.part)
+      : sdkTimestampExtract(t(c.value), c.part, c.timezone),
+  // vector
+  cosineDistance: (c, t) => sdkCosineDistance(t(c.left), t(c.right)),
+  dotProduct: (c, t) => sdkDotProduct(t(c.left), t(c.right)),
+  euclideanDistance: (c, t) => sdkEuclideanDistance(t(c.left), t(c.right)),
+  vectorLength: (c, t) => sdkVectorLength(t(c.vector)),
 };
 
 const toSdkOrdering = (ordering: Ordering) => {
@@ -518,13 +510,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'nullaryFunction':
-    case 'unaryFunction':
-    case 'binaryFunction':
-    case 'ternaryFunction':
-    case 'variadicFunction':
-    case 'arrayConstructor':
-    case 'mapConstructor':
+    case 'functionCall':
       throw new Error('firebase pipeline executor: only field orderings are supported in sort yet');
     default:
       return assertNever(expression);

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -34,7 +34,6 @@ import {
   arrayLength,
   arrayReverse,
   arrayValue,
-  BinaryFunction,
   byteLength,
   ceil,
   charLength,
@@ -58,6 +57,7 @@ import {
   Field,
   field,
   floor,
+  FunctionCall,
   geoPointValue,
   greaterThan,
   greaterThanOrEqual,
@@ -88,7 +88,6 @@ import {
   not,
   notEqual,
   notEqualAny,
-  NullaryFunction,
   or,
   pow,
   rand,
@@ -109,7 +108,6 @@ import {
   stringReverse,
   substring,
   subtract,
-  TernaryFunction,
   timestampAdd,
   timestampDiff,
   timestampExtract,
@@ -124,11 +122,9 @@ import {
   trunc,
   type,
   type ExpressionWithAlias,
-  UnaryFunction,
   unixMicrosToTimestamp,
   unixMillisToTimestamp,
   unixSecondsToTimestamp,
-  VariadicFunction,
   vectorLength,
   vectorValue,
   xor,
@@ -145,7 +141,7 @@ describe('expression factories', () => {
     notEqual(rank, count); // Int64 and Double mix
     lessThan(count, rank);
     greaterThanOrEqual(rank, rank);
-    expectTypeOf(greaterThan(rank, count)).toEqualTypeOf<BinaryFunction<BoolType>>();
+    expectTypeOf(greaterThan(rank, count)).toEqualTypeOf<FunctionCall<BoolType>>();
   });
 
   it('comparisons reject cross-group operands', () => {
@@ -241,19 +237,23 @@ describe('expression factories', () => {
     equal(field(bool(), 'flag'), constant(false));
   });
 
-  it('builds shape-grouped nodes with typed payloads', () => {
+  it('builds function-call nodes with typed payloads', () => {
     // Whole-instance comparison: `toStrictEqual` checks the constructor and
     // every own field, so a payload field added later cannot silently escape.
     const cmp = lessThan(rank, count);
-    expect(cmp).toStrictEqual(new BinaryFunction('lessThan', bool(), rank, count));
+    expect(cmp).toStrictEqual(
+      new FunctionCall(bool(), { name: 'lessThan', left: rank, right: count }),
+    );
 
     const neg = not(flag);
-    expect(neg).toStrictEqual(new UnaryFunction('not', bool(), flag));
-    expectTypeOf(neg).toEqualTypeOf<UnaryFunction<BoolType>>();
+    expect(neg).toStrictEqual(new FunctionCall(bool(), { name: 'not', condition: flag }));
+    expectTypeOf(neg).toEqualTypeOf<FunctionCall<BoolType>>();
 
     const both = and(flag, cmp, neg);
-    expect(both).toStrictEqual(new VariadicFunction('and', bool(), [flag, cmp, neg]));
-    expectTypeOf(both).toEqualTypeOf<VariadicFunction<BoolType>>();
+    expect(both).toStrictEqual(
+      new FunctionCall(bool(), { name: 'and', conditions: [flag, cmp, neg] }),
+    );
+    expectTypeOf(both).toEqualTypeOf<FunctionCall<BoolType>>();
   });
 });
 
@@ -359,18 +359,20 @@ describe('comparison operators (table-driven over all six)', () => {
   it('every comparison shares the same operand domains', () => {
     for (const [fnName, cmp] of table) {
       // number domain (int64 / double / numeric literal / number constant)
-      expect(cmp(rank, count)).toStrictEqual(new BinaryFunction(fnName, bool(), rank, count));
-      expect(cmp(field(literal(1, 2), 'lv'), constant(2)).name).toBe(fnName);
+      expect(cmp(rank, count)).toStrictEqual(
+        new FunctionCall(bool(), { name: fnName, left: rank, right: count }),
+      );
+      expect(cmp(field(literal(1, 2), 'lv'), constant(2)).call.name).toBe(fnName);
       // string domain (plain / literal)
-      expect(cmp(field(literal('x', 'y'), 's'), constant('x')).name).toBe(fnName);
+      expect(cmp(field(literal('x', 'y'), 's'), constant('x')).call.name).toBe(fnName);
       // same-T pairs for the remaining groups
-      expect(cmp(field(timestamp(), 'at'), constant(new Date(0))).name).toBe(fnName);
-      expect(cmp(field(bytes(), 'raw'), constant(new Uint8Array([1]))).name).toBe(fnName);
-      expect(cmp(field(geoPoint(), 'geo'), constant(geoPointValue(1, 2))).name).toBe(fnName);
-      expect(cmp(field(vector(), 'vec'), constant(vectorValue([1]))).name).toBe(fnName);
-      expect(cmp(field(nullType(), 'z'), constant(null)).name).toBe(fnName);
+      expect(cmp(field(timestamp(), 'at'), constant(new Date(0))).call.name).toBe(fnName);
+      expect(cmp(field(bytes(), 'raw'), constant(new Uint8Array([1]))).call.name).toBe(fnName);
+      expect(cmp(field(geoPoint(), 'geo'), constant(geoPointValue(1, 2))).call.name).toBe(fnName);
+      expect(cmp(field(vector(), 'vec'), constant(vectorValue([1]))).call.name).toBe(fnName);
+      expect(cmp(field(nullType(), 'z'), constant(null)).call.name).toBe(fnName);
       // function operands nest (bool same-T)
-      expect(cmp(equal(rank, count), constant(true)).name).toBe(fnName);
+      expect(cmp(equal(rank, count), constant(true)).call.name).toBe(fnName);
     }
   });
 
@@ -472,8 +474,12 @@ describe('logical operator edges', () => {
   it('takes many operands and nests', () => {
     const cmp = equal(field(double(), 'rank'), constant(1));
     const five = and(flag, cmp, not(flag), or(flag, cmp), not(not(flag)));
-    expect(five.operands).toHaveLength(5);
-    expect(five.name).toBe('and');
+    expect(five).toStrictEqual(
+      new FunctionCall(bool(), {
+        name: 'and',
+        conditions: [flag, cmp, not(flag), or(flag, cmp), not(not(flag))],
+      }),
+    );
   });
 
   it("conditions are Valued<'boolean'>: boolean literals and nullable booleans qualify", () => {
@@ -538,10 +544,12 @@ describe('arithmetic operators', () => {
   const rank = field(double(), 'rank');
   const count = field(int64(), 'count');
 
-  it('builds shape-grouped nodes across all three arities', () => {
-    expect(rand()).toStrictEqual(new NullaryFunction('rand', double()));
-    expect(abs(rank)).toStrictEqual(new UnaryFunction('abs', double(), rank));
-    expect(add(rank, count)).toStrictEqual(new BinaryFunction('add', double(), rank, count));
+  it('builds function-call nodes across all three arities', () => {
+    expect(rand()).toStrictEqual(new FunctionCall(double(), { name: 'rand' }));
+    expect(abs(rank)).toStrictEqual(new FunctionCall(double(), { name: 'abs', value: rank }));
+    expect(add(rank, count)).toStrictEqual(
+      new FunctionCall(double(), { name: 'add', left: rank, right: count }),
+    );
   });
 
   it('unary functions share the numeric domain; the rounding family preserves int64', () => {
@@ -552,8 +560,8 @@ describe('arithmetic operators', () => {
       ['floor', floor],
     ] as const;
     for (const [fnName, fn] of preserving) {
-      expect(fn(count)).toStrictEqual(new UnaryFunction(fnName, int64(), count));
-      expect(fn(rank)).toStrictEqual(new UnaryFunction(fnName, double(), rank));
+      expect(fn(count)).toStrictEqual(new FunctionCall(int64(), { name: fnName, value: count }));
+      expect(fn(rank)).toStrictEqual(new FunctionCall(double(), { name: fnName, value: rank }));
     }
     // Always-double (probed): sqrt/exp/ln/log10 leave the integer domain.
     const alwaysDouble = [
@@ -563,24 +571,27 @@ describe('arithmetic operators', () => {
       ['log10', log10],
     ] as const;
     for (const [fnName, fn] of alwaysDouble) {
-      expect(fn(count)).toStrictEqual(new UnaryFunction(fnName, double(), count));
-      expect(fn(field(literal(1, 2), 'lv')).name).toBe(fnName);
+      expect(fn(count)).toStrictEqual(new FunctionCall(double(), { name: fnName, value: count }));
+      expect(fn(field(literal(1, 2), 'lv')).call.name).toBe(fnName);
     }
-    // round/trunc are overloaded (dual-arity), so a union-typed table entry
-    // is not callable — exercised individually. They preserve the FIRST
-    // operand's kind even with decimal places (probed).
-    expect(round(count)).toStrictEqual(new UnaryFunction('round', int64(), count));
+    // round/trunc carry an extra generic for the optional decimal-places
+    // operand, so a union-typed table entry is not callable — exercised
+    // individually. They preserve the FIRST operand's kind even with decimal
+    // places (probed).
+    expect(round(count)).toStrictEqual(new FunctionCall(int64(), { name: 'round', value: count }));
     expect(trunc(count, constant(1))).toStrictEqual(
-      new BinaryFunction('trunc', int64(), count, constant(1)),
+      new FunctionCall(int64(), { name: 'trunc', value: count, decimalPlaces: constant(1) }),
     );
-    expect(round(rank)).toStrictEqual(new UnaryFunction('round', double(), rank));
+    expect(round(rank)).toStrictEqual(new FunctionCall(double(), { name: 'round', value: rank }));
     expectTypeOf(round(count).type).toEqualTypeOf(int64());
     // @ts-expect-error -- a string operand is not numeric
     abs(field(string(), 'name'));
   });
 
   it('binary type-preserving functions keep an int64 pair; any double side widens', () => {
-    expect(add(count, count)).toStrictEqual(new BinaryFunction('add', int64(), count, count));
+    expect(add(count, count)).toStrictEqual(
+      new FunctionCall(int64(), { name: 'add', left: count, right: count }),
+    );
     expectTypeOf(add(count, count).type).toEqualTypeOf(int64());
     expect(divide(count, count).type).toStrictEqual(int64());
     expect(add(count, rank).type).toStrictEqual(double());
@@ -601,13 +612,17 @@ describe('arithmetic operators', () => {
       ['multiply', multiply],
       ['divide', divide],
       ['mod', mod],
-      ['pow', pow],
     ] as const;
     for (const [fnName, fn] of table) {
       expect(fn(rank, constant(2))).toStrictEqual(
-        new BinaryFunction(fnName, double(), rank, constant(2)),
+        new FunctionCall(double(), { name: fnName, left: rank, right: constant(2) }),
       );
     }
+    // pow's payload names its operands base/exponent, so it sits outside the
+    // left/right table.
+    expect(pow(rank, constant(2))).toStrictEqual(
+      new FunctionCall(double(), { name: 'pow', base: rank, exponent: constant(2) }),
+    );
     // @ts-expect-error -- a string operand is not numeric
     add(field(string(), 'name'), constant(1));
     // @ts-expect-error -- a boolean operand is not numeric
@@ -616,9 +631,11 @@ describe('arithmetic operators', () => {
 
   it('round/trunc are dual-arity: an optional decimal-places operand', () => {
     expect(round(rank, constant(2))).toStrictEqual(
-      new BinaryFunction('round', double(), rank, constant(2)),
+      new FunctionCall(double(), { name: 'round', value: rank, decimalPlaces: constant(2) }),
     );
-    expect(trunc(rank, count)).toStrictEqual(new BinaryFunction('trunc', double(), rank, count));
+    expect(trunc(rank, count)).toStrictEqual(
+      new FunctionCall(double(), { name: 'trunc', value: rank, decimalPlaces: count }),
+    );
     // @ts-expect-error -- decimal places must be numeric
     round(rank, constant('2'));
   });
@@ -651,40 +668,42 @@ describe('string operators', () => {
       ['byteLength', byteLength, int64()],
     ] as const;
     for (const [fnName, fn, resultType] of table) {
-      expect(fn(name)).toStrictEqual(new UnaryFunction(fnName, resultType, name));
+      expect(fn(name)).toStrictEqual(new FunctionCall(resultType, { name: fnName, value: name }));
       // Literal-typed string fields are inside the domain.
-      expect(fn(gender).name).toBe(fnName);
+      expect(fn(gender).call.name).toBe(fnName);
     }
-    // The trim family is overloaded (dual-arity), so a union-typed table
-    // entry is not callable — exercised individually.
-    expect(trim(name)).toStrictEqual(new UnaryFunction('trim', string(), name));
-    expect(ltrim(name)).toStrictEqual(new UnaryFunction('ltrim', string(), name));
-    expect(rtrim(name)).toStrictEqual(new UnaryFunction('rtrim', string(), name));
-    expect(trim(gender).name).toBe('trim');
+    // The trim family carries an extra generic for the optional character-set
+    // operand, so a union-typed table entry is not callable — exercised
+    // individually.
+    expect(trim(name)).toStrictEqual(new FunctionCall(string(), { name: 'trim', value: name }));
+    expect(ltrim(name)).toStrictEqual(new FunctionCall(string(), { name: 'ltrim', value: name }));
+    expect(rtrim(name)).toStrictEqual(new FunctionCall(string(), { name: 'rtrim', value: name }));
+    expect(trim(gender).call.name).toBe('trim');
     // @ts-expect-error -- a numeric operand is not a string
     toUpper(field(double(), 'rank'));
   });
 
   it('trim family is dual-arity: an optional character-set operand', () => {
     expect(trim(name, constant('"'))).toStrictEqual(
-      new BinaryFunction('trim', string(), name, constant('"')),
+      new FunctionCall(string(), { name: 'trim', value: name, characters: constant('"') }),
     );
-    expect(ltrim(name, constant('x')).name).toBe('ltrim');
-    expect(rtrim(name, constant('x')).name).toBe('rtrim');
+    expect(ltrim(name, constant('x')).call.name).toBe('ltrim');
+    expect(rtrim(name, constant('x')).call.name).toBe('rtrim');
     // @ts-expect-error -- the character set must be a string
     trim(name, constant(1));
   });
 
   it('predicates return BoolType but PROPAGATE null (unlike comparisons)', () => {
-    const table = [
-      ['startsWith', startsWith],
-      ['endsWith', endsWith],
-      ['stringContains', stringContains],
-    ] as const;
-    for (const [fnName, fn] of table) {
-      expect(fn(name, constant('a'))).toStrictEqual(
-        new BinaryFunction(fnName, bool(), name, constant('a')),
-      );
+    expect(startsWith(name, constant('a'))).toStrictEqual(
+      new FunctionCall(bool(), { name: 'startsWith', value: name, prefix: constant('a') }),
+    );
+    expect(endsWith(name, constant('a'))).toStrictEqual(
+      new FunctionCall(bool(), { name: 'endsWith', value: name, suffix: constant('a') }),
+    );
+    expect(stringContains(name, constant('a'))).toStrictEqual(
+      new FunctionCall(bool(), { name: 'stringContains', value: name, substring: constant('a') }),
+    );
+    for (const fn of [startsWith, endsWith, stringContains] as const) {
       const viaNullable = fn(field(nullable(string()), 'ns'), constant('a'));
       expect(viaNullable.type).toStrictEqual(nullable(bool()));
       expectTypeOf(viaNullable.type).toEqualTypeOf(nullable(bool()));
@@ -698,7 +717,7 @@ describe('string operators', () => {
   it('stringConcat takes two or more strings and propagates nullability', () => {
     const c = stringConcat(name, constant('-'), gender);
     expect(c).toStrictEqual(
-      new VariadicFunction('stringConcat', string(), [name, constant('-'), gender]),
+      new FunctionCall(string(), { name: 'stringConcat', operands: [name, constant('-'), gender] }),
     );
     expectTypeOf(c.type).toEqualTypeOf(string());
     const viaNullable = stringConcat(name, field(nullable(string()), 'ns'));
@@ -726,16 +745,26 @@ describe('string operators (slice 3)', () => {
 
   it('indexOf / repeat / replace / substring shapes and domains', () => {
     expect(stringIndexOf(name, constant('b'))).toStrictEqual(
-      new BinaryFunction('stringIndexOf', int64(), name, constant('b')),
+      new FunctionCall(int64(), { name: 'stringIndexOf', value: name, substring: constant('b') }),
     );
     expect(stringRepeat(name, constant(2))).toStrictEqual(
-      new BinaryFunction('stringRepeat', string(), name, constant(2)),
+      new FunctionCall(string(), { name: 'stringRepeat', value: name, count: constant(2) }),
     );
     expect(stringReplaceAll(name, constant('a'), constant('x'))).toStrictEqual(
-      new TernaryFunction('stringReplaceAll', string(), name, constant('a'), constant('x')),
+      new FunctionCall(string(), {
+        name: 'stringReplaceAll',
+        value: name,
+        find: constant('a'),
+        replacement: constant('x'),
+      }),
     );
     expect(stringReplaceOne(name, constant('a'), constant('x'))).toStrictEqual(
-      new TernaryFunction('stringReplaceOne', string(), name, constant('a'), constant('x')),
+      new FunctionCall(string(), {
+        name: 'stringReplaceOne',
+        value: name,
+        find: constant('a'),
+        replacement: constant('x'),
+      }),
     );
     // @ts-expect-error -- the repeat count is numeric
     stringRepeat(name, constant('2'));
@@ -745,10 +774,15 @@ describe('string operators (slice 3)', () => {
 
   it('substring is dual-arity: an optional length operand', () => {
     expect(substring(name, constant(1))).toStrictEqual(
-      new BinaryFunction('substring', string(), name, constant(1)),
+      new FunctionCall(string(), { name: 'substring', value: name, position: constant(1) }),
     );
     expect(substring(name, constant(1), constant(2))).toStrictEqual(
-      new TernaryFunction('substring', string(), name, constant(1), constant(2)),
+      new FunctionCall(string(), {
+        name: 'substring',
+        value: name,
+        position: constant(1),
+        length: constant(2),
+      }),
     );
     // @ts-expect-error -- position is numeric
     substring(name, constant('1'));
@@ -778,8 +812,10 @@ describe('reference / type / vector operators', () => {
   it('documentId/collectionId take reference operands only', () => {
     const key = field(docRef(), '__name__');
     const refField = field(docRef(authors), 'ref');
-    expect(documentId(key)).toStrictEqual(new UnaryFunction('documentId', string(), key));
-    expect(collectionId(key).name).toBe('collectionId');
+    expect(documentId(key)).toStrictEqual(
+      new FunctionCall(string(), { name: 'documentId', reference: key }),
+    );
+    expect(collectionId(key).call.name).toBe('collectionId');
     documentId(refField);
     collectionId(refField);
     // @ts-expect-error -- a string is not a reference (probed: the backend rejects it too)
@@ -802,10 +838,14 @@ describe('reference / type / vector operators', () => {
     expect(viaOptional.type.type).toBe('union');
   });
 
-  it('isType lifts its literal type name into a constant operand', () => {
+  it('isType stores its literal type name as a plain payload field', () => {
     const call = isType(field(string(), 'name'), 'string');
     expect(call).toStrictEqual(
-      new BinaryFunction('isType', bool(), field(string(), 'name'), constant('string')),
+      new FunctionCall(bool(), {
+        name: 'isType',
+        value: field(string(), 'name'),
+        typeName: 'string',
+      }),
     );
     isType(field(double(), 'rank'), 'float64');
     // @ts-expect-error -- an arbitrary string is not a backend type name
@@ -815,11 +855,17 @@ describe('reference / type / vector operators', () => {
   it('vector functions take vector operands only', () => {
     const vec = field(vector(), 'vec');
     expect(dotProduct(vec, constant(vectorValue([1, 2])))).toStrictEqual(
-      new BinaryFunction('dotProduct', double(), vec, constant(vectorValue([1, 2]))),
+      new FunctionCall(double(), {
+        name: 'dotProduct',
+        left: vec,
+        right: constant(vectorValue([1, 2])),
+      }),
     );
-    expect(cosineDistance(vec, vec).name).toBe('cosineDistance');
-    expect(euclideanDistance(vec, vec).name).toBe('euclideanDistance');
-    expect(vectorLength(vec)).toStrictEqual(new UnaryFunction('vectorLength', int64(), vec));
+    expect(cosineDistance(vec, vec).call.name).toBe('cosineDistance');
+    expect(euclideanDistance(vec, vec).call.name).toBe('euclideanDistance');
+    expect(vectorLength(vec)).toStrictEqual(
+      new FunctionCall(int64(), { name: 'vectorLength', vector: vec }),
+    );
     // @ts-expect-error -- a number array field is not a vector (the tag axis at work)
     dotProduct(vec, field(array(double()), 'nums'));
     // @ts-expect-error -- a string is not a vector
@@ -834,8 +880,10 @@ describe('existence / error / conditional operators (slice 5)', () => {
   const nullableName = field(nullable(string()), 'nullableName');
 
   it('exists/isAbsent take FIELD references only and are total booleans', () => {
-    expect(exists(name)).toStrictEqual(new UnaryFunction('exists', bool(), name));
-    expect(isAbsent(optName)).toStrictEqual(new UnaryFunction('isAbsent', bool(), optName));
+    expect(exists(name)).toStrictEqual(new FunctionCall(bool(), { name: 'exists', target: name }));
+    expect(isAbsent(optName)).toStrictEqual(
+      new FunctionCall(bool(), { name: 'isAbsent', target: optName }),
+    );
     // @ts-expect-error -- the backend requires a field reference, not a constant
     exists(constant(1));
     // @ts-expect-error -- nor any computed expression
@@ -846,7 +894,7 @@ describe('existence / error / conditional operators (slice 5)', () => {
 
   it('isError is total over any expression', () => {
     expect(isError(divide(rank, constant(0)))).toStrictEqual(
-      new UnaryFunction('isError', bool(), divide(rank, constant(0))),
+      new FunctionCall(bool(), { name: 'isError', value: divide(rank, constant(0)) }),
     );
     expectTypeOf(isError(field(optional(string()), 'o')).type).toEqualTypeOf(bool());
   });
@@ -885,13 +933,12 @@ describe('existence / error / conditional operators (slice 5)', () => {
     const flag = field(bool(), 'flag');
     const t = conditional(flag, constant('a'), constant(0));
     expect(t).toStrictEqual(
-      new TernaryFunction(
-        'conditional',
-        union(string(), double()),
-        flag,
-        constant('a'),
-        constant(0),
-      ),
+      new FunctionCall(union(string(), double()), {
+        name: 'conditional',
+        condition: flag,
+        thenExpr: constant('a'),
+        elseExpr: constant(0),
+      }),
     );
     const same = conditional(flag, name, field(string(), 'other'));
     expect(same.type).toStrictEqual(string());
@@ -918,7 +965,9 @@ describe('existence / error / conditional operators (slice 5)', () => {
 
   it('equalAny/notEqualAny take one array-typed options expression', () => {
     const t = equalAny(rank, constant([1, 5, 9]));
-    expect(t).toStrictEqual(new BinaryFunction('equalAny', bool(), rank, constant([1, 5, 9])));
+    expect(t).toStrictEqual(
+      new FunctionCall(bool(), { name: 'equalAny', value: rank, options: constant([1, 5, 9]) }),
+    );
     equalAny(rank, field(array(int64()), 'options'));
     notEqualAny(name, constant(['a', 'b']));
     // @ts-expect-error -- options must be an array, not a scalar
@@ -929,7 +978,9 @@ describe('existence / error / conditional operators (slice 5)', () => {
 
   it('xor is a variadic Kleene boolean', () => {
     const flag = field(bool(), 'flag');
-    expect(xor(flag, flag)).toStrictEqual(new VariadicFunction('xor', bool(), [flag, flag]));
+    expect(xor(flag, flag)).toStrictEqual(
+      new FunctionCall(bool(), { name: 'xor', conditions: [flag, flag] }),
+    );
     const viaNullable = xor(flag, field(nullable(bool()), 'nb'));
     expect(viaNullable.type).toStrictEqual(nullable(bool()));
     // @ts-expect-error -- operands are boolean
@@ -994,7 +1045,9 @@ describe('array / map operators (slice 6)', () => {
 
   it('mapGet is key-aware', () => {
     const got = mapGet(profile, 'age');
-    expect(got).toStrictEqual(new BinaryFunction('mapGet', int64(), profile, constant('age')));
+    expect(got).toStrictEqual(
+      new FunctionCall(int64(), { name: 'mapGet', value: profile, key: 'age' }),
+    );
     expectTypeOf(got.type).toEqualTypeOf(int64());
     // @ts-expect-error -- unknown keys are rejected on a precise map
     void (() => mapGet(profile, 'zz'));
@@ -1039,20 +1092,22 @@ describe('timestamp operators', () => {
   const num = field(int64(), 'secs');
 
   it('currentTimestamp is a nullary timestamp', () => {
-    expect(currentTimestamp()).toStrictEqual(new NullaryFunction('currentTimestamp', timestamp()));
+    expect(currentTimestamp()).toStrictEqual(
+      new FunctionCall(timestamp(), { name: 'currentTimestamp' }),
+    );
   });
 
   it('unix conversions map between the timestamp and numeric domains', () => {
     expect(timestampToUnixSeconds(ts)).toStrictEqual(
-      new UnaryFunction('timestampToUnixSeconds', int64(), ts),
+      new FunctionCall(int64(), { name: 'timestampToUnixSeconds', value: ts }),
     );
-    expect(timestampToUnixMillis(ts).name).toBe('timestampToUnixMillis');
-    expect(timestampToUnixMicros(ts).name).toBe('timestampToUnixMicros');
+    expect(timestampToUnixMillis(ts).call.name).toBe('timestampToUnixMillis');
+    expect(timestampToUnixMicros(ts).call.name).toBe('timestampToUnixMicros');
     expect(unixSecondsToTimestamp(num)).toStrictEqual(
-      new UnaryFunction('unixSecondsToTimestamp', timestamp(), num),
+      new FunctionCall(timestamp(), { name: 'unixSecondsToTimestamp', value: num }),
     );
-    expect(unixMillisToTimestamp(num).name).toBe('unixMillisToTimestamp');
-    expect(unixMicrosToTimestamp(num).name).toBe('unixMicrosToTimestamp');
+    expect(unixMillisToTimestamp(num).call.name).toBe('unixMillisToTimestamp');
+    expect(unixMicrosToTimestamp(num).call.name).toBe('unixMicrosToTimestamp');
     // @ts-expect-error -- a number is not a timestamp
     timestampToUnixSeconds(num);
     // @ts-expect-error -- a timestamp is not a unix epoch number
@@ -1063,11 +1118,16 @@ describe('timestamp operators', () => {
     expectTypeOf(viaOptional.type).toEqualTypeOf(nullable(int64()));
   });
 
-  it('add/subtract lift the literal unit into a constant operand', () => {
+  it('add/subtract store the literal unit as a plain payload field', () => {
     expect(timestampAdd(ts, 'day', constant(1))).toStrictEqual(
-      new TernaryFunction('timestampAdd', timestamp(), ts, constant('day'), constant(1)),
+      new FunctionCall(timestamp(), {
+        name: 'timestampAdd',
+        value: ts,
+        unit: 'day',
+        amount: constant(1),
+      }),
     );
-    expect(timestampSubtract(ts, 'hour', constant(2)).name).toBe('timestampSubtract');
+    expect(timestampSubtract(ts, 'hour', constant(2)).call.name).toBe('timestampSubtract');
     // @ts-expect-error -- an arbitrary string is not a time unit
     timestampAdd(ts, 'fortnight', constant(1));
     // @ts-expect-error -- calendar granularities are add units the backend rejects
@@ -1081,7 +1141,7 @@ describe('timestamp operators', () => {
 
   it('diff is end - start in whole units', () => {
     expect(timestampDiff(ts, ts, 'hour')).toStrictEqual(
-      new TernaryFunction('timestampDiff', int64(), ts, ts, constant('hour')),
+      new FunctionCall(int64(), { name: 'timestampDiff', end: ts, start: ts, unit: 'hour' }),
     );
     // @ts-expect-error -- units only: calendar granularities are rejected (probed)
     timestampDiff(ts, ts, 'month');
@@ -1091,21 +1151,24 @@ describe('timestamp operators', () => {
 
   it('truncate/extract are dual-arity over the optional literal timezone', () => {
     expect(timestampTruncate(ts, 'week(monday)')).toStrictEqual(
-      new BinaryFunction('timestampTruncate', timestamp(), ts, constant('week(monday)')),
+      new FunctionCall(timestamp(), {
+        name: 'timestampTruncate',
+        value: ts,
+        granularity: 'week(monday)',
+      }),
     );
     expect(timestampTruncate(ts, 'day', 'Asia/Tokyo')).toStrictEqual(
-      new TernaryFunction(
-        'timestampTruncate',
-        timestamp(),
-        ts,
-        constant('day'),
-        constant('Asia/Tokyo'),
-      ),
+      new FunctionCall(timestamp(), {
+        name: 'timestampTruncate',
+        value: ts,
+        granularity: 'day',
+        timezone: 'Asia/Tokyo',
+      }),
     );
     expect(timestampExtract(ts, 'dayofweek')).toStrictEqual(
-      new BinaryFunction('timestampExtract', int64(), ts, constant('dayofweek')),
+      new FunctionCall(int64(), { name: 'timestampExtract', value: ts, part: 'dayofweek' }),
     );
-    expect(timestampExtract(ts, 'hour', 'Asia/Tokyo').name).toBe('timestampExtract');
+    expect(timestampExtract(ts, 'hour', 'Asia/Tokyo').call.name).toBe('timestampExtract');
     // @ts-expect-error -- not a granularity
     timestampTruncate(ts, 'fortnight');
     // @ts-expect-error -- 'week(noday)' is not a week start day

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -53,16 +53,7 @@ import { assertNever } from '../util.js';
 // (and like the official SDK's `constant(new GeoPoint(...))`). Every member
 // therefore carries `type: T` natively, which is what scopes operand domains
 // and feeds operator type inference.
-export type Expression<T extends FieldType = FieldType> =
-  | Field<T>
-  | Constant<T>
-  | NullaryFunction<T>
-  | UnaryFunction<T>
-  | BinaryFunction<T>
-  | TernaryFunction<T>
-  | VariadicFunction<T>
-  | ArrayConstructor<T>
-  | MapConstructor<T>;
+export type Expression<T extends FieldType = FieldType> = Field<T> | Constant<T> | FunctionCall<T>;
 
 /**
  * An expression bound to an output name — the aliased form of a `select` /
@@ -380,7 +371,7 @@ export const constant = <const V extends ConstantValue>(value: V): Constant<Cons
  * structurally it is just an object, so it would be ambiguous with map
  * constants (and tolerant of excess fields). Named `geoPointValue` to avoid
  * colliding with the `geoPoint()` descriptor factory in `schema.ts`, matching
- * the planned `arrayValue` / `mapValue` constructor naming.
+ * the `arrayValue` / `mapValue` constructor naming.
  */
 export const geoPointValue = (latitude: number, longitude: number): GeoPointValue =>
   new GeoPointValue(latitude, longitude);
@@ -388,239 +379,160 @@ export const geoPointValue = (latitude: number, longitude: number): GeoPointValu
 /** Builds a vector value from explicit components — see {@link VectorValue}. */
 export const vectorValue = (values: readonly number[]): VectorValue => new VectorValue(values);
 
-// Function-call nodes are grouped by SHAPE (arity), not one class per
-// function: each shape carries typed payload fields (no untyped `args` array,
-// so executors need no runtime arity guards), and its `name` is a
-// string-literal union so an executor can translate a whole shape with an
-// exhaustive `Record<Name, ...>` lookup. Per-function individuality (operand
-// compatibility, return types) lives in the factory signatures. See
-// "Restructure FunctionCall" in docs/plan/pipeline-query.md.
-
-/** A function call with no operands. */
-export class NullaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'nullaryFunction';
+/**
+ * A function-call expression node. ONE class for every function: per-function
+ * structure lives in the {@link FunctionPayload} union (discriminated by
+ * `name`), not in per-shape classes — a class exists where a node needs an
+ * `instanceof` brand (the value nodes, `Constant`'s sealed constructor), and
+ * a payload needs no brand, so it stays plain data. The node carries the
+ * function-independent parts (the `kind` discriminant, the return descriptor
+ * `type`, the `.as()` base); everything per-function — which operands exist
+ * and what they are named — is the payload's business, so executors translate
+ * calls with one exhaustive `switch (call.name)` over typed payload fields
+ * (no untyped `args` array, no runtime arity guards). Per-function operand
+ * compatibility and return-type inference live in the factory signatures.
+ */
+export class FunctionCall<T extends FieldType = FieldType> extends ExpressionBase {
+  readonly kind = 'functionCall';
   constructor(
-    readonly name: NullaryFunctionName,
     readonly type: T,
+    readonly call: FunctionPayload,
   ) {
     super();
   }
 }
-export type NullaryFunctionName = 'rand' | 'currentTimestamp';
 
-/** A function call with a single operand. */
-export class UnaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'unaryFunction';
-  constructor(
-    readonly name: UnaryFunctionName,
-    readonly type: T,
-    readonly operand: Expression,
-  ) {
-    super();
-  }
-}
-// A name appearing in two shape unions (round/trunc/trim/ltrim/rtrim) is the
-// dual-arity pattern: the factory overloads to a unary and a binary form and
-// each executor table translates its own arity.
-// The name unions are ordered by function CATEGORY (matching the factory
-// sections below), not by anything historical.
-export type UnaryFunctionName =
-  // logical
-  | 'not'
-  // arithmetic
-  | 'abs'
-  | 'ceil'
-  | 'floor'
-  | 'round'
-  | 'trunc'
-  | 'sqrt'
-  | 'exp'
-  | 'ln'
-  | 'log10'
-  // string
-  | 'charLength'
-  | 'byteLength'
-  | 'toLower'
-  | 'toUpper'
-  | 'stringReverse'
-  | 'trim'
-  | 'ltrim'
-  | 'rtrim'
-  // reference
-  | 'documentId'
-  | 'collectionId'
-  // timestamp
-  | 'timestampToUnixSeconds'
-  | 'timestampToUnixMillis'
-  | 'timestampToUnixMicros'
-  | 'unixSecondsToTimestamp'
-  | 'unixMillisToTimestamp'
-  | 'unixMicrosToTimestamp'
-  // type
-  | 'type'
-  // existence & error
-  | 'exists'
-  | 'isAbsent'
-  | 'isError'
-  // array
-  | 'arrayLength'
-  | 'arrayReverse'
-  // map
-  | 'mapKeys'
-  | 'mapValues'
-  | 'mapEntries'
-  // vector
-  | 'vectorLength';
-
-/** A function call with exactly two operands. */
-export class BinaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'binaryFunction';
-  constructor(
-    readonly name: BinaryFunctionName,
-    readonly type: T,
-    readonly left: Expression,
-    readonly right: Expression,
-  ) {
-    super();
-  }
-}
-export type BinaryFunctionName =
-  // comparison
-  | 'equal'
-  | 'notEqual'
-  | 'lessThan'
-  | 'lessThanOrEqual'
-  | 'greaterThan'
-  | 'greaterThanOrEqual'
-  | 'equalAny'
-  | 'notEqualAny'
-  // existence & error fallbacks
-  | 'ifError'
-  | 'ifAbsent'
-  | 'ifNull'
-  // arithmetic
-  | 'add'
-  | 'subtract'
-  | 'multiply'
-  | 'divide'
-  | 'mod'
-  | 'pow'
-  | 'round'
-  | 'trunc'
-  // string
-  | 'trim'
-  | 'ltrim'
-  | 'rtrim'
-  | 'startsWith'
-  | 'endsWith'
-  | 'stringContains'
-  | 'stringIndexOf'
-  | 'stringRepeat'
-  | 'substring'
-  | 'like'
-  // regex
-  | 'regexContains'
-  | 'regexMatch'
-  | 'regexFind'
-  | 'regexFindAll'
-  // type
-  | 'isType'
-  // array
-  | 'arrayGet'
-  | 'arrayContains'
-  | 'arrayContainsAll'
-  | 'arrayContainsAny'
-  // map
-  | 'mapGet'
-  | 'mapRemove'
-  // timestamp (2-arg forms; the 3-arg forms carry an explicit timezone)
-  | 'timestampTruncate'
-  | 'timestampExtract'
-  // vector
-  | 'cosineDistance'
-  | 'dotProduct'
-  | 'euclideanDistance';
-
-/** A function call with exactly three operands. */
-export class TernaryFunction<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'ternaryFunction';
-  constructor(
-    readonly name: TernaryFunctionName,
-    readonly type: T,
-    readonly first: Expression,
-    readonly second: Expression,
-    readonly third: Expression,
-  ) {
-    super();
-  }
-}
-export type TernaryFunctionName =
-  // string
-  | 'stringReplaceAll'
-  | 'stringReplaceOne'
-  | 'substring'
-  // timestamp
-  | 'timestampAdd'
-  | 'timestampSubtract'
-  | 'timestampDiff'
-  | 'timestampTruncate'
-  | 'timestampExtract'
-  // conditional
-  | 'conditional'
-  // map
-  | 'mapSet';
-
-/** A function call with two or more uniform operands. */
-export class VariadicFunction<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'variadicFunction';
-  constructor(
-    readonly name: VariadicFunctionName,
-    readonly type: T,
-    readonly operands: readonly [Expression, Expression, ...Expression[]],
-  ) {
-    super();
-  }
-}
+/** The name vocabulary of every supported function — {@link FunctionPayload}'s discriminant. */
+export type FunctionName = FunctionPayload['name'];
 
 /**
- * An array EXPRESSION constructor — `arrayValue([field('a'), constant(1)])`.
- * Unlike the value nodes (which hold plain values and enter expressions via
- * `constant()`), the elements here are expressions, evaluated per row
- * (probed: fields nest arbitrarily). Non-empty, mirroring `constant([])`'s
- * rejection: an empty literal has no element to infer a descriptor from.
+ * The per-function payload union, discriminated by `name`: each member states
+ * the exact named operands its function takes, so an executor destructures a
+ * narrowed payload without arity checks. Operand fields are `Expression`s;
+ * backend-mandated LITERAL arguments (`isType`'s type name, the timestamp
+ * units/granularities/parts/timezones, the map keys) are PLAIN fields of
+ * their literal type instead — the backend requires literal constants there
+ * (probed), so nothing is lost by not modelling them as expressions, and the
+ * executors serialize them as wire constants. A dual-arity function is one
+ * payload with an optional trailing field (`round.decimalPlaces?`,
+ * `substring.length?`, ...), never two members.
  */
-export class ArrayConstructor<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'arrayConstructor';
-  constructor(
-    readonly type: T,
-    readonly elements: readonly [Expression, ...Expression[]],
-  ) {
-    super();
-  }
-}
-
-/** A map EXPRESSION constructor — `mapValue({ x: field('num') })`. See {@link ArrayConstructor}. */
-export class MapConstructor<T extends FieldType = FieldType> extends ExpressionBase {
-  readonly kind = 'mapConstructor';
-  constructor(
-    readonly type: T,
-    readonly fields: Readonly<Record<string, Expression>>,
-  ) {
-    super();
-  }
-}
-export type VariadicFunctionName =
+// Grouped by function CATEGORY (matching the factory sections below), not by
+// anything historical.
+export type FunctionPayload =
   // logical
-  | 'and'
-  | 'or'
+  | { name: 'and'; conditions: readonly [Expression, Expression, ...Expression[]] }
+  | { name: 'or'; conditions: readonly [Expression, Expression, ...Expression[]] }
+  | { name: 'xor'; conditions: readonly [Expression, Expression, ...Expression[]] }
+  | { name: 'not'; condition: Expression }
+  // comparison
+  | { name: 'equal'; left: Expression; right: Expression }
+  | { name: 'notEqual'; left: Expression; right: Expression }
+  | { name: 'lessThan'; left: Expression; right: Expression }
+  | { name: 'lessThanOrEqual'; left: Expression; right: Expression }
+  | { name: 'greaterThan'; left: Expression; right: Expression }
+  | { name: 'greaterThanOrEqual'; left: Expression; right: Expression }
+  | { name: 'equalAny'; value: Expression; options: Expression }
+  | { name: 'notEqualAny'; value: Expression; options: Expression }
+  // conditional & extremes
+  | { name: 'conditional'; condition: Expression; thenExpr: Expression; elseExpr: Expression }
+  | { name: 'logicalMaximum'; operands: readonly [Expression, Expression, ...Expression[]] }
+  | { name: 'logicalMinimum'; operands: readonly [Expression, Expression, ...Expression[]] }
+  // arithmetic
+  | { name: 'rand' }
+  | { name: 'add'; left: Expression; right: Expression }
+  | { name: 'subtract'; left: Expression; right: Expression }
+  | { name: 'multiply'; left: Expression; right: Expression }
+  | { name: 'divide'; left: Expression; right: Expression }
+  | { name: 'mod'; left: Expression; right: Expression }
+  | { name: 'pow'; base: Expression; exponent: Expression }
+  | { name: 'abs'; value: Expression }
+  | { name: 'ceil'; value: Expression }
+  | { name: 'floor'; value: Expression }
+  | { name: 'round'; value: Expression; decimalPlaces?: Expression }
+  | { name: 'trunc'; value: Expression; decimalPlaces?: Expression }
+  | { name: 'sqrt'; value: Expression }
+  | { name: 'exp'; value: Expression }
+  | { name: 'ln'; value: Expression }
+  | { name: 'log10'; value: Expression }
   // string
-  | 'stringConcat'
-  | 'xor'
-  | 'logicalMaximum'
-  | 'logicalMinimum'
-  // array / map
-  | 'arrayConcat'
-  | 'mapMerge';
+  | { name: 'charLength'; value: Expression }
+  | { name: 'byteLength'; value: Expression }
+  | { name: 'toLower'; value: Expression }
+  | { name: 'toUpper'; value: Expression }
+  | { name: 'stringReverse'; value: Expression }
+  | { name: 'trim'; value: Expression; characters?: Expression }
+  | { name: 'ltrim'; value: Expression; characters?: Expression }
+  | { name: 'rtrim'; value: Expression; characters?: Expression }
+  | { name: 'startsWith'; value: Expression; prefix: Expression }
+  | { name: 'endsWith'; value: Expression; suffix: Expression }
+  | { name: 'stringContains'; value: Expression; substring: Expression }
+  | { name: 'stringConcat'; operands: readonly [Expression, Expression, ...Expression[]] }
+  | { name: 'stringIndexOf'; value: Expression; substring: Expression }
+  | { name: 'stringRepeat'; value: Expression; count: Expression }
+  | { name: 'stringReplaceAll'; value: Expression; find: Expression; replacement: Expression }
+  | { name: 'stringReplaceOne'; value: Expression; find: Expression; replacement: Expression }
+  | { name: 'substring'; value: Expression; position: Expression; length?: Expression }
+  | { name: 'like'; value: Expression; pattern: Expression }
+  // regex
+  | { name: 'regexContains'; value: Expression; pattern: Expression }
+  | { name: 'regexMatch'; value: Expression; pattern: Expression }
+  | { name: 'regexFind'; value: Expression; pattern: Expression }
+  | { name: 'regexFindAll'; value: Expression; pattern: Expression }
+  // reference
+  | { name: 'documentId'; reference: Expression }
+  | { name: 'collectionId'; reference: Expression }
+  // type
+  | { name: 'type'; value: Expression }
+  | { name: 'isType'; value: Expression; typeName: FirestoreTypeName }
+  // existence & error
+  | { name: 'exists'; target: Expression }
+  | { name: 'isAbsent'; target: Expression }
+  | { name: 'isError'; value: Expression }
+  | { name: 'ifError'; tryExpr: Expression; catchExpr: Expression }
+  | { name: 'ifAbsent'; value: Expression; fallback: Expression }
+  | { name: 'ifNull'; value: Expression; fallback: Expression }
+  // array
+  | { name: 'arrayValue'; elements: readonly [Expression, ...Expression[]] }
+  | { name: 'arrayLength'; value: Expression }
+  | { name: 'arrayReverse'; value: Expression }
+  | { name: 'arrayGet'; value: Expression; index: Expression }
+  | { name: 'arrayContains'; value: Expression; element: Expression }
+  | { name: 'arrayContainsAll'; value: Expression; options: Expression }
+  | { name: 'arrayContainsAny'; value: Expression; options: Expression }
+  | { name: 'arrayConcat'; operands: readonly [Expression, Expression, ...Expression[]] }
+  // map
+  | { name: 'mapValue'; fields: Readonly<Record<string, Expression>> }
+  | { name: 'mapGet'; value: Expression; key: string }
+  | { name: 'mapKeys'; value: Expression }
+  | { name: 'mapValues'; value: Expression }
+  | { name: 'mapEntries'; value: Expression }
+  | { name: 'mapSet'; value: Expression; key: string; entry: Expression }
+  | { name: 'mapRemove'; value: Expression; key: string }
+  | { name: 'mapMerge'; operands: readonly [Expression, Expression, ...Expression[]] }
+  // timestamp
+  | { name: 'currentTimestamp' }
+  | { name: 'timestampToUnixSeconds'; value: Expression }
+  | { name: 'timestampToUnixMillis'; value: Expression }
+  | { name: 'timestampToUnixMicros'; value: Expression }
+  | { name: 'unixSecondsToTimestamp'; value: Expression }
+  | { name: 'unixMillisToTimestamp'; value: Expression }
+  | { name: 'unixMicrosToTimestamp'; value: Expression }
+  | { name: 'timestampAdd'; value: Expression; unit: TimeUnit; amount: Expression }
+  | { name: 'timestampSubtract'; value: Expression; unit: TimeUnit; amount: Expression }
+  | { name: 'timestampDiff'; end: Expression; start: Expression; unit: TimeUnit }
+  | {
+      name: 'timestampTruncate';
+      value: Expression;
+      granularity: TimeGranularity;
+      timezone?: string;
+    }
+  | { name: 'timestampExtract'; value: Expression; part: TimePart; timezone?: string }
+  // vector
+  | { name: 'cosineDistance'; left: Expression; right: Expression }
+  | { name: 'dotProduct'; left: Expression; right: Expression }
+  | { name: 'euclideanDistance'; left: Expression; right: Expression }
+  | { name: 'vectorLength'; vector: Expression };
 
 /**
  * The value-domain predicate: descriptors whose `firestoreType` tags fit the
@@ -742,32 +654,32 @@ type SharedKeysComparable<
 export const equal = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('equal', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'equal', left, right });
 
 export const notEqual = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('notEqual', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'notEqual', left, right });
 
 export const lessThan = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('lessThan', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'lessThan', left, right });
 
 export const lessThanOrEqual = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('lessThanOrEqual', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'lessThanOrEqual', left, right });
 
 export const greaterThan = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('greaterThan', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'greaterThan', left, right });
 
 export const greaterThanOrEqual = <L extends FieldType, R extends FieldType>(
   left: Expression<L>,
   right: Expression<R> & Comparable<L, R>,
-): BinaryFunction<BoolType> => new BinaryFunction('greaterThanOrEqual', bool(), left, right);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'greaterThanOrEqual', left, right });
 
 /** The element domain of an array descriptor (wide/lenient for imprecise inputs, like `TagSetsComparable`). */
 type ElementsOf<T extends FieldType> = T extends {
@@ -788,13 +700,13 @@ type ElementsOf<T extends FieldType> = T extends {
 export const equalAny = <L extends FieldType, R extends Valued<readonly FirestoreType[]>>(
   value: Expression<L>,
   options: Expression<R> & Comparable<L, ElementsOf<R>>,
-): BinaryFunction<BoolType> => new BinaryFunction('equalAny', bool(), value, options);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'equalAny', value, options });
 
 /** Whether `value` differs from EVERY element of the `options` array — see {@link equalAny}. */
 export const notEqualAny = <L extends FieldType, R extends Valued<readonly FirestoreType[]>>(
   value: Expression<L>,
   options: Expression<R> & Comparable<L, ElementsOf<R>>,
-): BinaryFunction<BoolType> => new BinaryFunction('notEqualAny', bool(), value, options);
+): FunctionCall<BoolType> => new FunctionCall(bool(), { name: 'notEqualAny', value, options });
 
 /**
  * Null propagation for a function's RETURN descriptor: `T` when no operand
@@ -1093,8 +1005,8 @@ export const and = <
   ],
 >(
   ...conditions: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], BoolType>> =>
-  new VariadicFunction('and', propagateNull(conditions, bool()), conditions);
+): FunctionCall<PropagateNull<Ops[number]['type'], BoolType>> =>
+  new FunctionCall(propagateNull(conditions, bool()), { name: 'and', conditions });
 
 /** Logical disjunction of two or more boolean expressions (Kleene: null operands propagate). */
 export const or = <
@@ -1105,14 +1017,14 @@ export const or = <
   ],
 >(
   ...conditions: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], BoolType>> =>
-  new VariadicFunction('or', propagateNull(conditions, bool()), conditions);
+): FunctionCall<PropagateNull<Ops[number]['type'], BoolType>> =>
+  new FunctionCall(propagateNull(conditions, bool()), { name: 'or', conditions });
 
 /** Logical negation of a boolean expression (Kleene: a null operand propagates). */
 export const not = <C extends Expression<Valued<'boolean'>>>(
   condition: C,
-): UnaryFunction<PropagateNull<C['type'], BoolType>> =>
-  new UnaryFunction('not', propagateNull([condition], bool()), condition);
+): FunctionCall<PropagateNull<C['type'], BoolType>> =>
+  new FunctionCall(propagateNull([condition], bool()), { name: 'not', condition });
 
 /** Logical parity — true iff an odd number of operands is true (Kleene: null operands propagate). */
 export const xor = <
@@ -1123,8 +1035,8 @@ export const xor = <
   ],
 >(
   ...conditions: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], BoolType>> =>
-  new VariadicFunction('xor', propagateNull(conditions, bool()), conditions);
+): FunctionCall<PropagateNull<Ops[number]['type'], BoolType>> =>
+  new FunctionCall(propagateNull(conditions, bool()), { name: 'xor', conditions });
 
 /**
  * Branches on a boolean condition: the `then` value when it is `true`, the
@@ -1140,8 +1052,13 @@ export const conditional = <
   condition: C,
   thenExpr: T,
   elseExpr: E,
-): TernaryFunction<EitherType<T['type'], E['type']>> =>
-  new TernaryFunction('conditional', eitherType(thenExpr, elseExpr), condition, thenExpr, elseExpr);
+): FunctionCall<EitherType<T['type'], E['type']>> =>
+  new FunctionCall(eitherType(thenExpr, elseExpr), {
+    name: 'conditional',
+    condition,
+    thenExpr,
+    elseExpr,
+  });
 
 /**
  * The largest operand under the backend's cross-type value ordering. Null
@@ -1152,16 +1069,16 @@ export const logicalMaximum = <
   const Ops extends readonly [Expression, Expression, ...Expression[]],
 >(
   ...operands: Ops
-): VariadicFunction<LogicalExtreme<Ops>> =>
-  new VariadicFunction('logicalMaximum', logicalExtremeType(operands), operands);
+): FunctionCall<LogicalExtreme<Ops>> =>
+  new FunctionCall(logicalExtremeType(operands), { name: 'logicalMaximum', operands });
 
 /** The smallest operand — see {@link logicalMaximum}. */
 export const logicalMinimum = <
   const Ops extends readonly [Expression, Expression, ...Expression[]],
 >(
   ...operands: Ops
-): VariadicFunction<LogicalExtreme<Ops>> =>
-  new VariadicFunction('logicalMinimum', logicalExtremeType(operands), operands);
+): FunctionCall<LogicalExtreme<Ops>> =>
+  new FunctionCall(logicalExtremeType(operands), { name: 'logicalMinimum', operands });
 
 // Operand shorthands for the factories below. These name EXPRESSION domains
 // (the null special-casing itself lives once, in `Valued`).
@@ -1200,277 +1117,226 @@ function numericResultType(operands: readonly Expression[]): FieldType {
 }
 
 /** A uniformly distributed random double in [0, 1), regenerated per row. */
-export const rand = (): NullaryFunction<DoubleType> => new NullaryFunction('rand', double());
+export const rand = (): FunctionCall<DoubleType> => new FunctionCall(double(), { name: 'rand' });
 
 /** Numeric addition. */
 export const add = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
-  new BinaryFunction(
-    'add',
-    propagateNull([left, right], numericResultType([left, right])),
+): FunctionCall<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new FunctionCall(propagateNull([left, right], numericResultType([left, right])), {
+    name: 'add',
     left,
     right,
-  );
+  });
 
 /** Numeric subtraction (`left - right`). */
 export const subtract = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
-  new BinaryFunction(
-    'subtract',
-    propagateNull([left, right], numericResultType([left, right])),
+): FunctionCall<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new FunctionCall(propagateNull([left, right], numericResultType([left, right])), {
+    name: 'subtract',
     left,
     right,
-  );
+  });
 
 /** Numeric multiplication. */
 export const multiply = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
-  new BinaryFunction(
-    'multiply',
-    propagateNull([left, right], numericResultType([left, right])),
+): FunctionCall<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new FunctionCall(propagateNull([left, right], numericResultType([left, right])), {
+    name: 'multiply',
     left,
     right,
-  );
+  });
 
 /** Numeric division (`left / right`) — TRUNCATING on an int64 pair (probed); a zero divisor is a backend ERROR value. */
 export const divide = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
-  new BinaryFunction(
-    'divide',
-    propagateNull([left, right], numericResultType([left, right])),
+): FunctionCall<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new FunctionCall(propagateNull([left, right], numericResultType([left, right])), {
+    name: 'divide',
     left,
     right,
-  );
+  });
 
 /** Modulo (`left % right`). */
 export const mod = <L extends NumericOperand, R extends NumericOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
-  new BinaryFunction(
-    'mod',
-    propagateNull([left, right], numericResultType([left, right])),
+): FunctionCall<PropagateNull<L['type'] | R['type'], NumericResult<L['type'] | R['type']>>> =>
+  new FunctionCall(propagateNull([left, right], numericResultType([left, right])), {
+    name: 'mod',
     left,
     right,
-  );
+  });
 
 /** Exponentiation (`base ** exponent`). */
 export const pow = <L extends NumericOperand, R extends NumericOperand>(
   base: L,
   exponent: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('pow', propagateNull([base, exponent], double()), base, exponent);
+): FunctionCall<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([base, exponent], double()), { name: 'pow', base, exponent });
 
 /** Absolute value. */
 export const abs = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
-  new UnaryFunction(
-    'abs',
-    propagateNull([expression], numericResultType([expression])),
-    expression,
-  );
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new FunctionCall(propagateNull([value], numericResultType([value])), { name: 'abs', value });
 
 /** Rounds up to the nearest whole number. */
 export const ceil = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
-  new UnaryFunction(
-    'ceil',
-    propagateNull([expression], numericResultType([expression])),
-    expression,
-  );
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new FunctionCall(propagateNull([value], numericResultType([value])), { name: 'ceil', value });
 
 /** Rounds down to the nearest whole number. */
 export const floor = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
-  new UnaryFunction(
-    'floor',
-    propagateNull([expression], numericResultType([expression])),
-    expression,
-  );
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], NumericResult<Op['type']>>> =>
+  new FunctionCall(propagateNull([value], numericResultType([value])), { name: 'floor', value });
 
 /** Square root; a negative operand is a backend ERROR value. */
 export const sqrt = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('sqrt', propagateNull([expression], double()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([value], double()), { name: 'sqrt', value });
 
 /** The exponential function (e ** operand). */
 export const exp = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('exp', propagateNull([expression], double()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([value], double()), { name: 'exp', value });
 
 /** Natural logarithm; a non-positive operand is a backend ERROR value. */
 export const ln = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('ln', propagateNull([expression], double()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([value], double()), { name: 'ln', value });
 
 /** Base-10 logarithm; a non-positive operand is a backend ERROR value. */
 export const log10 = <Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], DoubleType>> =>
-  new UnaryFunction('log10', propagateNull([expression], double()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([value], double()), { name: 'log10', value });
+
+// The dual-arity factories (round/trunc, the trim family, substring,
+// timestampTruncate/timestampExtract) have ONE signature with an optional
+// trailing parameter, mirroring their single payload member. Where the extra
+// operand feeds null propagation, its type parameter defaults to `never` so
+// the omitted-argument call keeps the unwidened return descriptor
+// (`P['type']` is `never`, a no-op union member). The signature carries the
+// type-level result; the loose implementation signature is the usual
+// runtime-to-type bridge (same shape as `propagateNull`).
 
 /** Rounds to the nearest whole number, or to `decimalPlaces` decimal places. */
-export function round<Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>>;
-export function round<Op extends NumericOperand, P extends NumericOperand>(
-  expression: Op,
-  decimalPlaces: P,
-): BinaryFunction<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
-export function round(
-  expression: Expression,
-  decimalPlaces?: Expression,
-): UnaryFunction | BinaryFunction {
+export function round<Op extends NumericOperand, P extends NumericOperand = never>(
+  value: Op,
+  decimalPlaces?: P,
+): FunctionCall<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
+export function round(value: Expression, decimalPlaces?: Expression): FunctionCall {
   return decimalPlaces === undefined
-    ? new UnaryFunction(
-        'round',
-        propagateNull([expression], numericResultType([expression])),
-        expression,
-      )
-    : new BinaryFunction(
-        'round',
-        propagateNull([expression, decimalPlaces], numericResultType([expression])),
-        expression,
+    ? new FunctionCall(propagateNull([value], numericResultType([value])), { name: 'round', value })
+    : new FunctionCall(propagateNull([value, decimalPlaces], numericResultType([value])), {
+        name: 'round',
+        value,
         decimalPlaces,
-      );
+      });
 }
 
 /** Truncates toward zero, to a whole number or to `decimalPlaces` decimal places. */
-export function trunc<Op extends NumericOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], NumericResult<Op['type']>>>;
-export function trunc<Op extends NumericOperand, P extends NumericOperand>(
-  expression: Op,
-  decimalPlaces: P,
-): BinaryFunction<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
-export function trunc(
-  expression: Expression,
-  decimalPlaces?: Expression,
-): UnaryFunction | BinaryFunction {
+export function trunc<Op extends NumericOperand, P extends NumericOperand = never>(
+  value: Op,
+  decimalPlaces?: P,
+): FunctionCall<PropagateNull<Op['type'] | P['type'], NumericResult<Op['type']>>>;
+export function trunc(value: Expression, decimalPlaces?: Expression): FunctionCall {
   return decimalPlaces === undefined
-    ? new UnaryFunction(
-        'trunc',
-        propagateNull([expression], numericResultType([expression])),
-        expression,
-      )
-    : new BinaryFunction(
-        'trunc',
-        propagateNull([expression, decimalPlaces], numericResultType([expression])),
-        expression,
+    ? new FunctionCall(propagateNull([value], numericResultType([value])), { name: 'trunc', value })
+    : new FunctionCall(propagateNull([value, decimalPlaces], numericResultType([value])), {
+        name: 'trunc',
+        value,
         decimalPlaces,
-      );
+      });
 }
 
 // ---- string ----
 
 /** The number of characters (Unicode code points) in a string. */
 export const charLength = <Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('charLength', propagateNull([expression], int64()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'charLength', value });
 
 /** The number of bytes in a string's UTF-8 encoding. */
 export const byteLength = <Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('byteLength', propagateNull([expression], int64()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'byteLength', value });
 
 /** Lowercases a string. */
 export const toLower = <Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
-  new UnaryFunction('toLower', propagateNull([expression], string()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], StringType>> =>
+  new FunctionCall(propagateNull([value], string()), { name: 'toLower', value });
 
 /** Uppercases a string. */
 export const toUpper = <Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
-  new UnaryFunction('toUpper', propagateNull([expression], string()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], StringType>> =>
+  new FunctionCall(propagateNull([value], string()), { name: 'toUpper', value });
 
 /** Reverses a string. */
 export const stringReverse = <Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
-  new UnaryFunction('stringReverse', propagateNull([expression], string()), expression);
+  value: Op,
+): FunctionCall<PropagateNull<Op['type'], StringType>> =>
+  new FunctionCall(propagateNull([value], string()), { name: 'stringReverse', value });
 
-/** Trims whitespace from both ends, or every character of `charactersToTrim`. */
-export function trim<Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>>;
-export function trim<Op extends StringOperand, C extends StringOperand>(
-  expression: Op,
-  charactersToTrim: C,
-): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
-export function trim(
-  expression: Expression,
-  charactersToTrim?: Expression,
-): UnaryFunction | BinaryFunction {
-  return charactersToTrim === undefined
-    ? new UnaryFunction('trim', propagateNull([expression], string()), expression)
-    : new BinaryFunction(
-        'trim',
-        propagateNull([expression, charactersToTrim], string()),
-        expression,
-        charactersToTrim,
-      );
+/** Trims whitespace from both ends, or every character of `characters`. */
+export function trim<Op extends StringOperand, C extends StringOperand = never>(
+  value: Op,
+  characters?: C,
+): FunctionCall<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function trim(value: Expression, characters?: Expression): FunctionCall {
+  return characters === undefined
+    ? new FunctionCall(propagateNull([value], string()), { name: 'trim', value })
+    : new FunctionCall(propagateNull([value, characters], string()), {
+        name: 'trim',
+        value,
+        characters,
+      });
 }
 
 /** Trims the leading end — see {@link trim}. */
-export function ltrim<Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>>;
-export function ltrim<Op extends StringOperand, C extends StringOperand>(
-  expression: Op,
-  charactersToTrim: C,
-): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
-export function ltrim(
-  expression: Expression,
-  charactersToTrim?: Expression,
-): UnaryFunction | BinaryFunction {
-  return charactersToTrim === undefined
-    ? new UnaryFunction('ltrim', propagateNull([expression], string()), expression)
-    : new BinaryFunction(
-        'ltrim',
-        propagateNull([expression, charactersToTrim], string()),
-        expression,
-        charactersToTrim,
-      );
+export function ltrim<Op extends StringOperand, C extends StringOperand = never>(
+  value: Op,
+  characters?: C,
+): FunctionCall<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function ltrim(value: Expression, characters?: Expression): FunctionCall {
+  return characters === undefined
+    ? new FunctionCall(propagateNull([value], string()), { name: 'ltrim', value })
+    : new FunctionCall(propagateNull([value, characters], string()), {
+        name: 'ltrim',
+        value,
+        characters,
+      });
 }
 
 /** Trims the trailing end — see {@link trim}. */
-export function rtrim<Op extends StringOperand>(
-  expression: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>>;
-export function rtrim<Op extends StringOperand, C extends StringOperand>(
-  expression: Op,
-  charactersToTrim: C,
-): BinaryFunction<PropagateNull<Op['type'] | C['type'], StringType>>;
-export function rtrim(
-  expression: Expression,
-  charactersToTrim?: Expression,
-): UnaryFunction | BinaryFunction {
-  return charactersToTrim === undefined
-    ? new UnaryFunction('rtrim', propagateNull([expression], string()), expression)
-    : new BinaryFunction(
-        'rtrim',
-        propagateNull([expression, charactersToTrim], string()),
-        expression,
-        charactersToTrim,
-      );
+export function rtrim<Op extends StringOperand, C extends StringOperand = never>(
+  value: Op,
+  characters?: C,
+): FunctionCall<PropagateNull<Op['type'] | C['type'], StringType>>;
+export function rtrim(value: Expression, characters?: Expression): FunctionCall {
+  return characters === undefined
+    ? new FunctionCall(propagateNull([value], string()), { name: 'rtrim', value })
+    : new FunctionCall(propagateNull([value, characters], string()), {
+        name: 'rtrim',
+        value,
+        characters,
+      });
 }
 
 // The string predicates PROPAGATE null (probed: startsWith(null, 'x') is
@@ -1481,44 +1347,52 @@ export function rtrim(
 export const startsWith = <L extends StringOperand, R extends StringOperand>(
   value: L,
   prefix: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('startsWith', propagateNull([value, prefix], bool()), value, prefix);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, prefix], bool()), { name: 'startsWith', value, prefix });
 
 /** Whether `value` ends with `suffix`. */
 export const endsWith = <L extends StringOperand, R extends StringOperand>(
   value: L,
   suffix: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('endsWith', propagateNull([value, suffix], bool()), value, suffix);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, suffix], bool()), { name: 'endsWith', value, suffix });
 
 /** Whether `value` contains `substring`. */
 export const stringContains = <L extends StringOperand, R extends StringOperand>(
   value: L,
   substring: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('stringContains', propagateNull([value, substring], bool()), value, substring);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, substring], bool()), {
+    name: 'stringContains',
+    value,
+    substring,
+  });
 
 /** Concatenates two or more strings. */
 export const stringConcat = <
   const Ops extends readonly [StringOperand, StringOperand, ...StringOperand[]],
 >(
-  ...strings: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], StringType>> =>
-  new VariadicFunction('stringConcat', propagateNull(strings, string()), strings);
+  ...operands: Ops
+): FunctionCall<PropagateNull<Ops[number]['type'], StringType>> =>
+  new FunctionCall(propagateNull(operands, string()), { name: 'stringConcat', operands });
 
 /** The 0-based index of the first occurrence of `substring`, or -1 if absent. */
 export const stringIndexOf = <L extends StringOperand, R extends StringOperand>(
   value: L,
   substring: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], Int64Type>> =>
-  new BinaryFunction('stringIndexOf', propagateNull([value, substring], int64()), value, substring);
+): FunctionCall<PropagateNull<L['type'] | R['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value, substring], int64()), {
+    name: 'stringIndexOf',
+    value,
+    substring,
+  });
 
 /** Repeats a string `count` times. */
 export const stringRepeat = <L extends StringOperand, R extends NumericOperand>(
   value: L,
   count: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], StringType>> =>
-  new BinaryFunction('stringRepeat', propagateNull([value, count], string()), value, count);
+): FunctionCall<PropagateNull<L['type'] | R['type'], StringType>> =>
+  new FunctionCall(propagateNull([value, count], string()), { name: 'stringRepeat', value, count });
 
 /** Replaces every occurrence of `find` with `replacement`. */
 export const stringReplaceAll = <
@@ -1529,14 +1403,13 @@ export const stringReplaceAll = <
   value: L,
   find: M,
   replacement: R,
-): TernaryFunction<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
-  new TernaryFunction(
-    'stringReplaceAll',
-    propagateNull([value, find, replacement], string()),
+): FunctionCall<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
+  new FunctionCall(propagateNull([value, find, replacement], string()), {
+    name: 'stringReplaceAll',
     value,
     find,
     replacement,
-  );
+  });
 
 /** Replaces the first occurrence of `find` with `replacement`. */
 export const stringReplaceOne = <
@@ -1547,54 +1420,52 @@ export const stringReplaceOne = <
   value: L,
   find: M,
   replacement: R,
-): TernaryFunction<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
-  new TernaryFunction(
-    'stringReplaceOne',
-    propagateNull([value, find, replacement], string()),
+): FunctionCall<PropagateNull<L['type'] | M['type'] | R['type'], StringType>> =>
+  new FunctionCall(propagateNull([value, find, replacement], string()), {
+    name: 'stringReplaceOne',
     value,
     find,
     replacement,
-  );
+  });
 
 /**
  * The substring from the 0-based `position`, spanning `length` characters or
  * (omitted) to the end of the string.
  */
-export function substring<Op extends StringOperand, P extends NumericOperand>(
-  value: Op,
-  position: P,
-): BinaryFunction<PropagateNull<Op['type'] | P['type'], StringType>>;
 export function substring<
   Op extends StringOperand,
   P extends NumericOperand,
-  Len extends NumericOperand,
+  Len extends NumericOperand = never,
 >(
   value: Op,
   position: P,
-  length: Len,
-): TernaryFunction<PropagateNull<Op['type'] | P['type'] | Len['type'], StringType>>;
+  length?: Len,
+): FunctionCall<PropagateNull<Op['type'] | P['type'] | Len['type'], StringType>>;
 export function substring(
   value: Expression,
   position: Expression,
   length?: Expression,
-): BinaryFunction | TernaryFunction {
+): FunctionCall {
   return length === undefined
-    ? new BinaryFunction('substring', propagateNull([value, position], string()), value, position)
-    : new TernaryFunction(
-        'substring',
-        propagateNull([value, position, length], string()),
+    ? new FunctionCall(propagateNull([value, position], string()), {
+        name: 'substring',
+        value,
+        position,
+      })
+    : new FunctionCall(propagateNull([value, position, length], string()), {
+        name: 'substring',
         value,
         position,
         length,
-      );
+      });
 }
 
 /** SQL LIKE match (`%` any sequence, `_` any single character). */
 export const like = <L extends StringOperand, R extends StringOperand>(
   value: L,
   pattern: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('like', propagateNull([value, pattern], bool()), value, pattern);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, pattern], bool()), { name: 'like', value, pattern });
 
 // ---- regex ----
 // An invalid pattern is a backend ERROR value (see the error-channel note
@@ -1604,15 +1475,19 @@ export const like = <L extends StringOperand, R extends StringOperand>(
 export const regexContains = <L extends StringOperand, R extends StringOperand>(
   value: L,
   pattern: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('regexContains', propagateNull([value, pattern], bool()), value, pattern);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, pattern], bool()), {
+    name: 'regexContains',
+    value,
+    pattern,
+  });
 
 /** Whether `value` ENTIRELY matches the RE2 `pattern`. */
 export const regexMatch = <L extends StringOperand, R extends StringOperand>(
   value: L,
   pattern: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], BoolType>> =>
-  new BinaryFunction('regexMatch', propagateNull([value, pattern], bool()), value, pattern);
+): FunctionCall<PropagateNull<L['type'] | R['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, pattern], bool()), { name: 'regexMatch', value, pattern });
 
 /**
  * The first match of the RE2 `pattern`, or `null` when there is none — the
@@ -1621,20 +1496,19 @@ export const regexMatch = <L extends StringOperand, R extends StringOperand>(
 export const regexFind = <L extends StringOperand, R extends StringOperand>(
   value: L,
   pattern: R,
-): BinaryFunction<UnionType<[StringType, NullType]>> =>
-  new BinaryFunction('regexFind', nullable(string()), value, pattern);
+): FunctionCall<UnionType<[StringType, NullType]>> =>
+  new FunctionCall(nullable(string()), { name: 'regexFind', value, pattern });
 
 /** Every match of the RE2 `pattern` (empty array when there is none). */
 export const regexFindAll = <L extends StringOperand, R extends StringOperand>(
   value: L,
   pattern: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], ArrayType<StringType>>> =>
-  new BinaryFunction(
-    'regexFindAll',
-    propagateNull([value, pattern], array(string())),
+): FunctionCall<PropagateNull<L['type'] | R['type'], ArrayType<StringType>>> =>
+  new FunctionCall(propagateNull([value, pattern], array(string())), {
+    name: 'regexFindAll',
     value,
     pattern,
-  );
+  });
 
 // ---- reference ----
 
@@ -1644,14 +1518,14 @@ type ReferenceOperand = Expression<Valued<'reference'>>;
 /** The document id (the path's last segment) of a reference. */
 export const documentId = <Op extends ReferenceOperand>(
   reference: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
-  new UnaryFunction('documentId', propagateNull([reference], string()), reference);
+): FunctionCall<PropagateNull<Op['type'], StringType>> =>
+  new FunctionCall(propagateNull([reference], string()), { name: 'documentId', reference });
 
 /** The id of the collection containing the referenced document. */
 export const collectionId = <Op extends ReferenceOperand>(
   reference: Op,
-): UnaryFunction<PropagateNull<Op['type'], StringType>> =>
-  new UnaryFunction('collectionId', propagateNull([reference], string()), reference);
+): FunctionCall<PropagateNull<Op['type'], StringType>> =>
+  new FunctionCall(propagateNull([reference], string()), { name: 'collectionId', reference });
 
 // ---- type ----
 
@@ -1690,20 +1564,20 @@ export type FirestoreTypeName =
  */
 export const type = <Op extends Expression>(
   value: Op,
-): UnaryFunction<PropagateAbsence<Op['type'], LiteralType<FirestoreTypeName[]>>> =>
-  new UnaryFunction('type', propagateAbsence([value], typeNameLiteral()), value);
+): FunctionCall<PropagateAbsence<Op['type'], LiteralType<FirestoreTypeName[]>>> =>
+  new FunctionCall(propagateAbsence([value], typeNameLiteral()), { name: 'type', value });
 
 /**
  * Whether the operand's value is of the named backend type. The name must be
- * a compile-time literal (the backend requires a constant — probed), lifted
- * into a constant operand wire-faithfully. Type-observing like {@link type}:
- * only absence propagates.
+ * a compile-time literal (the backend requires a constant — probed), stored
+ * as a plain payload field; the executors serialize it as the wire constant.
+ * Type-observing like {@link type}: only absence propagates.
  */
 export const isType = <Op extends Expression>(
   value: Op,
   typeName: FirestoreTypeName,
-): BinaryFunction<PropagateAbsence<Op['type'], BoolType>> =>
-  new BinaryFunction('isType', propagateAbsence([value], bool()), value, Constant.of(typeName));
+): FunctionCall<PropagateAbsence<Op['type'], BoolType>> =>
+  new FunctionCall(propagateAbsence([value], bool()), { name: 'isType', value, typeName });
 
 /** The `type()` return descriptor: the closed backend type-name vocabulary. */
 const typeNameLiteral = (): LiteralType<FirestoreTypeName[]> =>
@@ -1763,23 +1637,29 @@ function elementUnionType(elements: readonly Expression[]): FieldType {
   return rest.length === 0 ? first : union(first, ...rest);
 }
 
-/** Builds an array expression from element expressions — see {@link ArrayConstructor}. */
+/**
+ * Builds an array EXPRESSION — `arrayValue([field('a'), constant(1)])`.
+ * Unlike the value nodes (which hold plain values and enter expressions via
+ * `constant()`), the elements here are expressions, evaluated per row
+ * (probed: fields nest arbitrarily). Non-empty, mirroring `constant([])`'s
+ * rejection: an empty literal has no element to infer a descriptor from.
+ */
 export const arrayValue = <const Els extends readonly [Expression, ...Expression[]]>(
   elements: Els,
-): ArrayConstructor<ArrayType<ElementUnion<Els>>> =>
-  new ArrayConstructor(array(elementUnionType(elements)), elements);
+): FunctionCall<ArrayType<ElementUnion<Els>>> =>
+  new FunctionCall(array(elementUnionType(elements)), { name: 'arrayValue', elements });
 
 /** The number of elements. */
 export const arrayLength = <Op extends ArrayOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('arrayLength', propagateNull([value], int64()), value);
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'arrayLength', value });
 
 /** The array reversed. */
 export const arrayReverse = <Op extends ArrayOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], StripNull<Op['type']>>> =>
-  new UnaryFunction('arrayReverse', propagateNull([value], stripNullOf(value)), value);
+): FunctionCall<PropagateNull<Op['type'], StripNull<Op['type']>>> =>
+  new FunctionCall(propagateNull([value], stripNullOf(value)), { name: 'arrayReverse', value });
 
 /** Runtime counterpart of `StripNull<Op['type']>` over an expression (same bridge shape as `propagateNull`). */
 function stripNullOf<Op extends Expression>(value: Op): StripNull<Op['type']>;
@@ -1796,8 +1676,8 @@ function stripNullOf(value: Expression): FieldType {
 export const arrayGet = <Arr extends ArrayOperand, Idx extends NumericOperand>(
   value: Arr,
   index: Idx,
-): BinaryFunction<UnionType<[ElementsOf<StripNull<Arr['type']>>, NullType]>> =>
-  new BinaryFunction('arrayGet', nullable(elementTypeOf(value)), value, index);
+): FunctionCall<UnionType<[ElementsOf<StripNull<Arr['type']>>, NullType]>> =>
+  new FunctionCall(nullable(elementTypeOf(value)), { name: 'arrayGet', value, index });
 
 /** Runtime counterpart of `ElementsOf<StripNull<...>>` (same bridge shape as `propagateNull`). */
 function elementTypeOf<Arr extends Expression>(value: Arr): ElementsOf<StripNull<Arr['type']>>;
@@ -1813,36 +1693,43 @@ function elementTypeOf(value: Expression): FieldType {
 export const arrayContains = <Arr extends ArrayOperand, El extends FieldType>(
   value: Arr,
   element: Expression<El> & Comparable<ElementsOf<StripNull<Arr['type']>>, El>,
-): BinaryFunction<PropagateNull<Arr['type'], BoolType>> =>
-  new BinaryFunction('arrayContains', propagateNull([value], bool()), value, element);
+): FunctionCall<PropagateNull<Arr['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value], bool()), { name: 'arrayContains', value, element });
 
 /** Whether the array contains EVERY element of the options array. */
 export const arrayContainsAll = <Arr extends ArrayOperand, Opts extends ArrayOperand>(
   value: Arr,
   options: Opts &
     Comparable<ElementsOf<StripNull<Arr['type']>>, ElementsOf<StripNull<Opts['type']>>>,
-): BinaryFunction<PropagateNull<Arr['type'] | Opts['type'], BoolType>> =>
-  new BinaryFunction('arrayContainsAll', propagateNull([value, options], bool()), value, options);
+): FunctionCall<PropagateNull<Arr['type'] | Opts['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, options], bool()), {
+    name: 'arrayContainsAll',
+    value,
+    options,
+  });
 
 /** Whether the array contains ANY element of the options array. */
 export const arrayContainsAny = <Arr extends ArrayOperand, Opts extends ArrayOperand>(
   value: Arr,
   options: Opts &
     Comparable<ElementsOf<StripNull<Arr['type']>>, ElementsOf<StripNull<Opts['type']>>>,
-): BinaryFunction<PropagateNull<Arr['type'] | Opts['type'], BoolType>> =>
-  new BinaryFunction('arrayContainsAny', propagateNull([value, options], bool()), value, options);
+): FunctionCall<PropagateNull<Arr['type'] | Opts['type'], BoolType>> =>
+  new FunctionCall(propagateNull([value, options], bool()), {
+    name: 'arrayContainsAny',
+    value,
+    options,
+  });
 
 /** The concatenation of two or more arrays. */
 export const arrayConcat = <
   const Ops extends readonly [ArrayOperand, ArrayOperand, ...ArrayOperand[]],
 >(
   ...operands: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], ArrayType<ConcatElementUnion<Ops>>>> =>
-  new VariadicFunction(
-    'arrayConcat',
-    propagateNull(operands, array(concatElementUnionType(operands))),
+): FunctionCall<PropagateNull<Ops[number]['type'], ArrayType<ConcatElementUnion<Ops>>>> =>
+  new FunctionCall(propagateNull(operands, array(concatElementUnionType(operands))), {
+    name: 'arrayConcat',
     operands,
-  );
+  });
 
 type ConcatElementUnion<Ops extends readonly Expression[]> = RebuildUnion<
   DedupDescriptors<ConcatElementTypes<Ops>>
@@ -1870,10 +1757,11 @@ function concatElementUnionType(operands: readonly Expression[]): FieldType {
 
 // ---- map ----
 // `mapSet` / `mapRemove` keys must be literal constants (probed:
-// "map_set keys must be constants/literals"), lifted like `isType`'s type
-// name. `mapGet`'s key MAY be dynamic on the backend, but the factory takes
-// a literal so the result subschema is key-aware; a dynamic-key overload is
-// deferred.
+// "map_set keys must be constants/literals"), so they are plain payload
+// fields like `isType`'s type name, serialized as wire constants by the
+// executors. `mapGet`'s key MAY be dynamic on the backend, but the factory
+// takes a literal so the result subschema is key-aware; a dynamic-key
+// overload is deferred.
 
 /** A map-domain operand. */
 type MapOperand = Expression<Valued<{ readonly [field: string]: FirestoreType }>>;
@@ -1896,13 +1784,12 @@ type MapKeysOf<T extends FieldType> =
 export const mapGet = <M extends MapOperand, K extends MapKeysOf<M['type']>>(
   value: M,
   key: K,
-): BinaryFunction<PropagateNull<M['type'], MapValueType<FieldsOf<StripNull<M['type']>>[K]>>> =>
-  new BinaryFunction(
-    'mapGet',
-    propagateNull([value], mapValueTypeOf(value, key)),
+): FunctionCall<PropagateNull<M['type'], MapValueType<FieldsOf<StripNull<M['type']>>[K]>>> =>
+  new FunctionCall(propagateNull([value], mapValueTypeOf(value, key)), {
+    name: 'mapGet',
     value,
-    Constant.of(key),
-  );
+    key,
+  });
 
 type MapValueType<V extends FieldType> = [Extract<V, Optional>] extends [never]
   ? V
@@ -1944,46 +1831,49 @@ type WithoutDottedKeys<F> = {
 /** A key literal that must not contain the path separator. */
 type UndottedKey<K extends string> = K extends `${string}.${string}` ? never : K;
 
-/** Builds a map expression from field-value expressions — see {@link MapConstructor}. */
+/** Builds a map EXPRESSION from field-value expressions — `mapValue({ x: field('num') })`. See {@link arrayValue}. */
 export const mapValue = <const F extends Readonly<Record<string, Expression>>>(
   fields: F & WithoutDottedKeys<F>,
-): MapConstructor<MapType<{ [K in keyof F & string]: WithoutOptional<F[K]['type']> }>> =>
-  new MapConstructor(mapDescriptor(mapConstructorFields(fields)), fields);
+): FunctionCall<MapType<{ [K in keyof F & string]: WithoutOptional<F[K]['type']> }>> =>
+  new FunctionCall(mapDescriptor(mapValueFields(fields)), { name: 'mapValue', fields });
 
 /** Runtime counterpart of `mapValue`'s fields record (same bridge shape as `propagateNull`). */
-function mapConstructorFields<F extends Readonly<Record<string, Expression>>>(
+function mapValueFields<F extends Readonly<Record<string, Expression>>>(
   fields: F,
 ): { [K in keyof F & string]: WithoutOptional<F[K]['type']> };
-function mapConstructorFields(fields: Readonly<Record<string, Expression>>): FieldsRecord {
+function mapValueFields(fields: Readonly<Record<string, Expression>>): FieldsRecord {
   return Object.fromEntries(Object.entries(fields).map(([k, e]) => [k, withoutOptional(e.type)]));
 }
 
 /** The map's keys, as a string array. */
 export const mapKeys = <M extends MapOperand>(
   value: M,
-): UnaryFunction<PropagateNull<M['type'], ArrayType<StringType>>> =>
-  new UnaryFunction('mapKeys', propagateNull([value], array(string())), value);
+): FunctionCall<PropagateNull<M['type'], ArrayType<StringType>>> =>
+  new FunctionCall(propagateNull([value], array(string())), { name: 'mapKeys', value });
 
 /** The map's values, as an array of the deduped field-type union. */
 export const mapValues = <M extends MapOperand>(
   value: M,
-): UnaryFunction<
+): FunctionCall<
   PropagateNull<M['type'], ArrayType<MapFieldUnion<FieldsOf<StripNull<M['type']>>>>>
-> => new UnaryFunction('mapValues', propagateNull([value], array(mapFieldUnionType(value))), value);
+> =>
+  new FunctionCall(propagateNull([value], array(mapFieldUnionType(value))), {
+    name: 'mapValues',
+    value,
+  });
 
 /** The map's entries, as an array of `{ k, v }` maps (probed shape). */
 export const mapEntries = <M extends MapOperand>(
   value: M,
-): UnaryFunction<
+): FunctionCall<
   PropagateNull<
     M['type'],
     ArrayType<MapType<{ k: StringType; v: MapFieldUnion<FieldsOf<StripNull<M['type']>>> }>>
   >
 > =>
-  new UnaryFunction(
-    'mapEntries',
+  new FunctionCall(
     propagateNull([value], array(map({ k: string(), v: mapFieldUnionType(value) }))),
-    value,
+    { name: 'mapEntries', value },
   );
 
 /**
@@ -2026,14 +1916,15 @@ function mapFieldUnionType(value: Expression): FieldType {
 
 /**
  * The map with `key` set to the value (shallow; probed: a later value wins).
- * The key must be a literal constant (backend-validated), lifted like
- * `isType`'s type name.
+ * The key must be a literal constant (backend-validated) — a plain payload
+ * field like `isType`'s type name, serialized as a wire constant by the
+ * executors.
  */
 export const mapSet = <M extends MapOperand, K extends string, V extends Expression>(
   value: M,
   key: K & UndottedKey<K>,
   entry: V,
-): TernaryFunction<
+): FunctionCall<
   PropagateNull<
     M['type'],
     MapType<
@@ -2041,13 +1932,12 @@ export const mapSet = <M extends MapOperand, K extends string, V extends Express
     >
   >
 > =>
-  new TernaryFunction(
-    'mapSet',
-    propagateNull([value], mapDescriptor(setField(value, key, entry))),
+  new FunctionCall(propagateNull([value], mapDescriptor(setField(value, key, entry))), {
+    name: 'mapSet',
     value,
-    Constant.of(key),
+    key,
     entry,
-  );
+  });
 
 type SetField<F extends FieldsRecord, K extends string, V extends FieldType> = {
   [P in keyof F as P extends K ? never : P]: F[P];
@@ -2071,15 +1961,14 @@ function setField(value: Expression, key: string, entry: Expression): FieldsReco
 export const mapRemove = <M extends MapOperand, K extends string>(
   value: M,
   key: K & UndottedKey<K>,
-): BinaryFunction<
+): FunctionCall<
   PropagateNull<M['type'], MapType<Omit<FieldsOf<StripNull<M['type']>>, K & UndottedKey<K>>>>
 > =>
-  new BinaryFunction(
-    'mapRemove',
-    propagateNull([value], mapDescriptor(removeField(value, key))),
+  new FunctionCall(propagateNull([value], mapDescriptor(removeField(value, key))), {
+    name: 'mapRemove',
     value,
-    Constant.of(key),
-  );
+    key,
+  });
 
 /** Runtime counterpart of `mapRemove`'s fields record (same bridge shape as `propagateNull`). */
 function removeField<M extends Expression, K extends string>(
@@ -2098,12 +1987,11 @@ function removeField(value: Expression, key: string): FieldsRecord {
 /** The shallow merge of two or more maps — a later operand's key wins (probed). */
 export const mapMerge = <const Ops extends readonly [MapOperand, MapOperand, ...MapOperand[]]>(
   ...operands: Ops
-): VariadicFunction<PropagateNull<Ops[number]['type'], MapType<MergeFields<Ops>>>> =>
-  new VariadicFunction(
-    'mapMerge',
-    propagateNull(operands, mapDescriptor(mergeFields(operands))),
+): FunctionCall<PropagateNull<Ops[number]['type'], MapType<MergeFields<Ops>>>> =>
+  new FunctionCall(propagateNull(operands, mapDescriptor(mergeFields(operands))), {
+    name: 'mapMerge',
     operands,
-  );
+  });
 
 type MergeFields<Ops extends readonly Expression[]> = Ops extends readonly [
   infer H extends Expression,
@@ -2140,16 +2028,16 @@ function mergeFields(operands: readonly Expression[]): FieldsRecord {
  * (probed: any other expression, constants included, is INVALID_ARGUMENT),
  * so the factory takes a `Field`, not a general expression.
  */
-export const exists = <F extends Field>(target: F): UnaryFunction<BoolType> =>
-  new UnaryFunction('exists', bool(), target);
+export const exists = <F extends Field>(target: F): FunctionCall<BoolType> =>
+  new FunctionCall(bool(), { name: 'exists', target });
 
 /** Whether the field is absent from the document — the negation of {@link exists}, with the same field-reference-only constraint. */
-export const isAbsent = <F extends Field>(target: F): UnaryFunction<BoolType> =>
-  new UnaryFunction('isAbsent', bool(), target);
+export const isAbsent = <F extends Field>(target: F): FunctionCall<BoolType> =>
+  new FunctionCall(bool(), { name: 'isAbsent', target });
 
 /** Whether the operand evaluates to a backend ERROR value (total: null/absent are `false`). */
-export const isError = <Op extends Expression>(value: Op): UnaryFunction<BoolType> =>
-  new UnaryFunction('isError', bool(), value);
+export const isError = <Op extends Expression>(value: Op): FunctionCall<BoolType> =>
+  new FunctionCall(bool(), { name: 'isError', value });
 
 /**
  * The `try` value, or the `catch` value if `try` evaluates to a backend
@@ -2159,13 +2047,12 @@ export const isError = <Op extends Expression>(value: Op): UnaryFunction<BoolTyp
 export const ifError = <T extends Expression, C extends Expression>(
   tryExpr: T,
   catchExpr: C,
-): BinaryFunction<PropagateAbsence<T['type'], EitherType<T['type'], C['type']>>> =>
-  new BinaryFunction(
-    'ifError',
-    propagateAbsence([tryExpr], eitherType(tryExpr, catchExpr)),
+): FunctionCall<PropagateAbsence<T['type'], EitherType<T['type'], C['type']>>> =>
+  new FunctionCall(propagateAbsence([tryExpr], eitherType(tryExpr, catchExpr)), {
+    name: 'ifError',
     tryExpr,
     catchExpr,
-  );
+  });
 
 /**
  * The value, or the fallback when the value is ABSENT. A present null passes
@@ -2174,8 +2061,8 @@ export const ifError = <T extends Expression, C extends Expression>(
 export const ifAbsent = <T extends Expression, C extends Expression>(
   value: T,
   fallback: C,
-): BinaryFunction<EitherType<T['type'], C['type']>> =>
-  new BinaryFunction('ifAbsent', eitherType(value, fallback), value, fallback);
+): FunctionCall<EitherType<T['type'], C['type']>> =>
+  new FunctionCall(eitherType(value, fallback), { name: 'ifAbsent', value, fallback });
 
 /**
  * The value, or the fallback when the value is null OR absent (probed:
@@ -2186,8 +2073,8 @@ export const ifAbsent = <T extends Expression, C extends Expression>(
 export const ifNull = <T extends Expression, C extends Expression>(
   value: T,
   fallback: C,
-): BinaryFunction<EitherType<StripNull<T['type']>, C['type']>> =>
-  new BinaryFunction('ifNull', ifNullType(value, fallback), value, fallback);
+): FunctionCall<EitherType<StripNull<T['type']>, C['type']>> =>
+  new FunctionCall(ifNullType(value, fallback), { name: 'ifNull', value, fallback });
 
 /** Runtime counterpart of `ifNull`'s return descriptor (same bridge shape as `propagateNull`). */
 function ifNullType<T extends Expression, C extends Expression>(
@@ -2202,8 +2089,9 @@ function ifNullType(value: Expression, fallback: Expression): FieldType {
 // The unit/granularity/part argument and the timezone argument must be
 // compile-time literals: the backend validates them as literal constants
 // (probed: a field operand is INVALID_ARGUMENT at query validation, not an
-// ERROR value), so the factories take literal parameters and lift them via
-// `Constant.of`, like `isType`. Out-of-range results and invalid timezone
+// ERROR value), so the factories take literal parameters stored as plain
+// payload fields, like `isType`'s type name — the executors serialize them
+// as wire constants. Out-of-range results and invalid timezone
 // VALUES, by contrast, are backend ERROR values (`isError`-catchable).
 // Integer-only positions (an add/subtract amount, a unix epoch input) are
 // typed as the numeric domain: `'integer'` alone cannot be demanded at the
@@ -2235,72 +2123,70 @@ export type TimePart = TimeGranularity | 'dayofweek' | 'dayofyear';
 type TimestampOperand = Expression<Valued<'timestamp'>>;
 
 /** The server's timestamp at query evaluation time. */
-export const currentTimestamp = (): NullaryFunction<TimestampType> =>
-  new NullaryFunction('currentTimestamp', timestamp());
+export const currentTimestamp = (): FunctionCall<TimestampType> =>
+  new FunctionCall(timestamp(), { name: 'currentTimestamp' });
 
 /** The operand as a unix epoch in seconds (fractions truncated toward zero). */
 export const timestampToUnixSeconds = <Op extends TimestampOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('timestampToUnixSeconds', propagateNull([value], int64()), value);
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'timestampToUnixSeconds', value });
 
 /** The operand as a unix epoch in milliseconds. */
 export const timestampToUnixMillis = <Op extends TimestampOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('timestampToUnixMillis', propagateNull([value], int64()), value);
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'timestampToUnixMillis', value });
 
 /** The operand as a unix epoch in microseconds. */
 export const timestampToUnixMicros = <Op extends TimestampOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('timestampToUnixMicros', propagateNull([value], int64()), value);
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([value], int64()), { name: 'timestampToUnixMicros', value });
 
 /** The timestamp at the given unix epoch in seconds (integers only — a fractional value is a backend error). */
 export const unixSecondsToTimestamp = <Op extends NumericOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
-  new UnaryFunction('unixSecondsToTimestamp', propagateNull([value], timestamp()), value);
+): FunctionCall<PropagateNull<Op['type'], TimestampType>> =>
+  new FunctionCall(propagateNull([value], timestamp()), { name: 'unixSecondsToTimestamp', value });
 
 /** The timestamp at the given unix epoch in milliseconds (integers only). */
 export const unixMillisToTimestamp = <Op extends NumericOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
-  new UnaryFunction('unixMillisToTimestamp', propagateNull([value], timestamp()), value);
+): FunctionCall<PropagateNull<Op['type'], TimestampType>> =>
+  new FunctionCall(propagateNull([value], timestamp()), { name: 'unixMillisToTimestamp', value });
 
 /** The timestamp at the given unix epoch in microseconds (integers only). */
 export const unixMicrosToTimestamp = <Op extends NumericOperand>(
   value: Op,
-): UnaryFunction<PropagateNull<Op['type'], TimestampType>> =>
-  new UnaryFunction('unixMicrosToTimestamp', propagateNull([value], timestamp()), value);
+): FunctionCall<PropagateNull<Op['type'], TimestampType>> =>
+  new FunctionCall(propagateNull([value], timestamp()), { name: 'unixMicrosToTimestamp', value });
 
 /** The timestamp moved forward by `amount` `unit`s (out-of-range results are backend ERROR values). */
 export const timestampAdd = <Ts extends TimestampOperand, Amount extends NumericOperand>(
   value: Ts,
   unit: TimeUnit,
   amount: Amount,
-): TernaryFunction<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
-  new TernaryFunction(
-    'timestampAdd',
-    propagateNull([value, amount], timestamp()),
+): FunctionCall<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
+  new FunctionCall(propagateNull([value, amount], timestamp()), {
+    name: 'timestampAdd',
     value,
-    Constant.of(unit),
+    unit,
     amount,
-  );
+  });
 
 /** The timestamp moved backward by `amount` `unit`s. */
 export const timestampSubtract = <Ts extends TimestampOperand, Amount extends NumericOperand>(
   value: Ts,
   unit: TimeUnit,
   amount: Amount,
-): TernaryFunction<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
-  new TernaryFunction(
-    'timestampSubtract',
-    propagateNull([value, amount], timestamp()),
+): FunctionCall<PropagateNull<Ts['type'] | Amount['type'], TimestampType>> =>
+  new FunctionCall(propagateNull([value, amount], timestamp()), {
+    name: 'timestampSubtract',
     value,
-    Constant.of(unit),
+    unit,
     amount,
-  );
+  });
 
 /**
  * `end - start` in whole `unit`s, truncated toward zero (probed: 2.6 days →
@@ -2311,75 +2197,46 @@ export const timestampDiff = <End extends TimestampOperand, Start extends Timest
   end: End,
   start: Start,
   unit: TimeUnit,
-): TernaryFunction<PropagateNull<End['type'] | Start['type'], Int64Type>> =>
-  new TernaryFunction(
-    'timestampDiff',
-    propagateNull([end, start], int64()),
+): FunctionCall<PropagateNull<End['type'] | Start['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([end, start], int64()), {
+    name: 'timestampDiff',
     end,
     start,
-    Constant.of(unit),
-  );
+    unit,
+  });
 
 /**
  * The timestamp truncated down to the given granularity, in the given IANA
  * timezone (default UTC). An invalid timezone VALUE is a backend ERROR value.
  */
-export function timestampTruncate<Ts extends TimestampOperand>(
+export const timestampTruncate = <Ts extends TimestampOperand>(
   value: Ts,
-  granularity: TimeGranularity,
-): BinaryFunction<PropagateNull<Ts['type'], TimestampType>>;
-export function timestampTruncate<Ts extends TimestampOperand>(
-  value: Ts,
-  granularity: TimeGranularity,
-  timezone: string,
-): TernaryFunction<PropagateNull<Ts['type'], TimestampType>>;
-export function timestampTruncate(
-  value: Expression,
   granularity: TimeGranularity,
   timezone?: string,
-): BinaryFunction | TernaryFunction {
-  const type = propagateNull([value], timestamp());
-  return timezone === undefined
-    ? new BinaryFunction('timestampTruncate', type, value, Constant.of(granularity))
-    : new TernaryFunction(
-        'timestampTruncate',
-        type,
-        value,
-        Constant.of(granularity),
-        Constant.of(timezone),
-      );
-}
+): FunctionCall<PropagateNull<Ts['type'], TimestampType>> =>
+  new FunctionCall(
+    propagateNull([value], timestamp()),
+    timezone === undefined
+      ? { name: 'timestampTruncate', value, granularity }
+      : { name: 'timestampTruncate', value, granularity, timezone },
+  );
 
 /**
  * The given part of the timestamp as an integer, in the given IANA timezone
  * (default UTC). `'dayofweek'` is 1-based from Sunday (probed: a Friday →
  * `6`).
  */
-export function timestampExtract<Ts extends TimestampOperand>(
+export const timestampExtract = <Ts extends TimestampOperand>(
   value: Ts,
-  part: TimePart,
-): BinaryFunction<PropagateNull<Ts['type'], Int64Type>>;
-export function timestampExtract<Ts extends TimestampOperand>(
-  value: Ts,
-  part: TimePart,
-  timezone: string,
-): TernaryFunction<PropagateNull<Ts['type'], Int64Type>>;
-export function timestampExtract(
-  value: Expression,
   part: TimePart,
   timezone?: string,
-): BinaryFunction | TernaryFunction {
-  const type = propagateNull([value], int64());
-  return timezone === undefined
-    ? new BinaryFunction('timestampExtract', type, value, Constant.of(part))
-    : new TernaryFunction(
-        'timestampExtract',
-        type,
-        value,
-        Constant.of(part),
-        Constant.of(timezone),
-      );
-}
+): FunctionCall<PropagateNull<Ts['type'], Int64Type>> =>
+  new FunctionCall(
+    propagateNull([value], int64()),
+    timezone === undefined
+      ? { name: 'timestampExtract', value, part }
+      : { name: 'timestampExtract', value, part, timezone },
+  );
 
 // ---- vector ----
 // Distance functions over mismatched dimensions are backend ERROR values.
@@ -2391,25 +2248,29 @@ type VectorOperand = Expression<Valued<'vector'>>;
 export const cosineDistance = <L extends VectorOperand, R extends VectorOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('cosineDistance', propagateNull([left, right], double()), left, right);
+): FunctionCall<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([left, right], double()), { name: 'cosineDistance', left, right });
 
 /** The dot product of two vectors. */
 export const dotProduct = <L extends VectorOperand, R extends VectorOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('dotProduct', propagateNull([left, right], double()), left, right);
+): FunctionCall<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([left, right], double()), { name: 'dotProduct', left, right });
 
 /** The euclidean distance between two vectors. */
 export const euclideanDistance = <L extends VectorOperand, R extends VectorOperand>(
   left: L,
   right: R,
-): BinaryFunction<PropagateNull<L['type'] | R['type'], DoubleType>> =>
-  new BinaryFunction('euclideanDistance', propagateNull([left, right], double()), left, right);
+): FunctionCall<PropagateNull<L['type'] | R['type'], DoubleType>> =>
+  new FunctionCall(propagateNull([left, right], double()), {
+    name: 'euclideanDistance',
+    left,
+    right,
+  });
 
 /** The number of dimensions of a vector. */
 export const vectorLength = <Op extends VectorOperand>(
   vector: Op,
-): UnaryFunction<PropagateNull<Op['type'], Int64Type>> =>
-  new UnaryFunction('vectorLength', propagateNull([vector], int64()), vector);
+): FunctionCall<PropagateNull<Op['type'], Int64Type>> =>
+  new FunctionCall(propagateNull([vector], int64()), { name: 'vectorLength', vector });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -286,13 +286,7 @@ const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fie
     case 'field':
       return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
     case 'constant':
-    case 'nullaryFunction':
-    case 'unaryFunction':
-    case 'binaryFunction':
-    case 'ternaryFunction':
-    case 'variadicFunction':
-    case 'arrayConstructor':
-    case 'mapConstructor':
+    case 'functionCall':
       return pathToSchema(alias, expression.type);
     default:
       return assertNever(expression);

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -1,7 +1,6 @@
 import { FieldValue, type Firestore, GeoPoint, Pipelines } from '@google-cloud/firestore';
 import { collectionPath } from 'firestore-repository/path';
 import {
-  type BinaryFunctionName,
   type Constant,
   type ConstantArray,
   type Expression,
@@ -9,11 +8,8 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
-  type BinaryFunction,
-  type NullaryFunctionName,
-  type TernaryFunctionName,
-  UnaryFunctionName,
-  VariadicFunctionName,
+  type FunctionName,
+  type FunctionPayload,
 } from 'firestore-repository/pipelines/expression';
 import type { Ordering } from 'firestore-repository/pipelines/ordering';
 import type {
@@ -156,38 +152,8 @@ const toSdkExpression = (db: Firestore, expression: Expression): Pipelines.Expre
       return Pipelines.field(expression.path);
     case 'constant':
       return toSdkConstant(db, expression.value);
-    case 'nullaryFunction':
-      return nullaryFns[expression.name]();
-    case 'unaryFunction':
-      return unaryFns[expression.name](toSdkExpression(db, expression.operand));
-    case 'binaryFunction':
-      return binaryFns[expression.name](
-        toSdkExpression(db, expression.left),
-        toSdkExpression(db, expression.right),
-        expression,
-      );
-    case 'ternaryFunction':
-      return ternaryFns[expression.name](
-        toSdkExpression(db, expression.first),
-        toSdkExpression(db, expression.second),
-        toSdkExpression(db, expression.third),
-      );
-    case 'variadicFunction': {
-      const [first, second, ...rest] = expression.operands;
-      return variadicFns[expression.name](
-        toSdkExpression(db, first),
-        toSdkExpression(db, second),
-        ...rest.map((operand) => toSdkExpression(db, operand)),
-      );
-    }
-    case 'arrayConstructor':
-      return Pipelines.array(expression.elements.map((element) => toSdkExpression(db, element)));
-    case 'mapConstructor':
-      return Pipelines.map(
-        Object.fromEntries(
-          Object.entries(expression.fields).map(([k, e]) => [k, toSdkExpression(db, e)]),
-        ),
-      );
+    case 'functionCall':
+      return dispatchFunctionCall(expression.call, (e) => toSdkExpression(db, e));
     default:
       return assertNever(expression);
   }
@@ -244,189 +210,236 @@ const toSdkConstant = (db: Firestore, value: Constant['value']): Pipelines.Expre
   }
 };
 
-// Per-shape translation tables: `Record` over the name union requires every
-// key, so a newly added function name fails to compile here until translated.
-// (`asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters — a
-// type-tag only, no wire change.)
+/**
+ * Dispatches a function-call payload to its {@link functionTranslators} entry.
+ * Generic over the concrete function name `K` so the indexed table lookup and
+ * the narrowed payload stay correlated: TS resolves `functionTranslators[name]`
+ * and the `call` argument against the SAME `Extract<FunctionPayload,
+ * { name: K }>`, which is what lets a single table dispatch the whole union
+ * without a type assertion.
+ */
+const dispatchFunctionCall = <K extends FunctionName>(
+  call: Extract<FunctionPayload, { name: K }>,
+  translate: Translate,
+): Pipelines.Expression => functionTranslators[call.name](call, translate);
 
-const nullaryFns: Record<NullaryFunctionName, () => Pipelines.Expression> = {
-  rand: Pipelines.rand,
-  currentTimestamp: Pipelines.currentTimestamp,
-};
-
-const unaryFns: Record<UnaryFunctionName, (o: Pipelines.Expression) => Pipelines.Expression> = {
-  not: (o) => Pipelines.not(o.asBoolean()),
-  abs: Pipelines.abs,
-  ceil: Pipelines.ceil,
-  // floor/ltrim/rtrim exist at runtime but the SDK's namespace typings only
-  // declare their fluent forms — translate through those.
-  floor: (o) => o.floor(),
-  round: Pipelines.round,
-  trunc: Pipelines.trunc,
-  sqrt: Pipelines.sqrt,
-  exp: Pipelines.exp,
-  ln: Pipelines.ln,
-  log10: Pipelines.log10,
-  charLength: Pipelines.charLength,
-  byteLength: Pipelines.byteLength,
-  toLower: Pipelines.toLower,
-  toUpper: Pipelines.toUpper,
-  stringReverse: Pipelines.stringReverse,
-  trim: Pipelines.trim,
-  ltrim: (o) => o.ltrim(),
-  rtrim: (o) => o.rtrim(),
-  documentId: Pipelines.documentId,
-  collectionId: Pipelines.collectionId,
-  type: Pipelines.type,
-  exists: Pipelines.exists,
-  isAbsent: Pipelines.isAbsent,
-  isError: Pipelines.isError,
-  arrayLength: Pipelines.arrayLength,
-  arrayReverse: Pipelines.arrayReverse,
-  mapKeys: Pipelines.mapKeys,
-  mapValues: Pipelines.mapValues,
-  mapEntries: Pipelines.mapEntries,
-  timestampToUnixSeconds: Pipelines.timestampToUnixSeconds,
-  timestampToUnixMillis: Pipelines.timestampToUnixMillis,
-  timestampToUnixMicros: Pipelines.timestampToUnixMicros,
-  unixSecondsToTimestamp: Pipelines.unixSecondsToTimestamp,
-  unixMillisToTimestamp: Pipelines.unixMillisToTimestamp,
-  unixMicrosToTimestamp: Pipelines.unixMicrosToTimestamp,
-  vectorLength: Pipelines.vectorLength,
-};
-
-// Entries receive the raw AST node too: functions with backend-mandated
-// LITERAL arguments (isType's type name) must hand the SDK helper the plain
-// string, which is unrecoverable from the translated constant expression.
-const binaryFns: Record<
-  BinaryFunctionName,
-  (l: Pipelines.Expression, r: Pipelines.Expression, node: BinaryFunction) => Pipelines.Expression
-> = {
-  equal: Pipelines.equal,
-  notEqual: Pipelines.notEqual,
-  lessThan: Pipelines.lessThan,
-  lessThanOrEqual: Pipelines.lessThanOrEqual,
-  greaterThan: Pipelines.greaterThan,
-  greaterThanOrEqual: Pipelines.greaterThanOrEqual,
-  // The options operand is an array-typed EXPRESSION. The runtime accepts it
-  // (probed; the firebase d.ts even declares this form) but this SDK's
-  // typings only declare the values-list convenience.
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SDK typings gap (see above)
-  equalAny: (l, r) => Pipelines.equalAny(l, r as unknown as unknown[]),
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SDK typings gap (see above)
-  notEqualAny: (l, r) => Pipelines.notEqualAny(l, r as unknown as unknown[]),
-  ifError: Pipelines.ifError,
-  ifAbsent: Pipelines.ifAbsent,
-  ifNull: Pipelines.ifNull,
-  arrayGet: Pipelines.arrayGet,
-  arrayContains: Pipelines.arrayContains,
-  // Array-typed options expressions — the same typings gap as equalAny above.
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SDK typings gap (see equalAny)
-  arrayContainsAll: (l, r) => Pipelines.arrayContainsAll(l, r as unknown as unknown[]),
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SDK typings gap (see equalAny)
-  arrayContainsAny: (l, r) => Pipelines.arrayContainsAny(l, r as unknown as unknown[]),
-  // The SDK's mapGet key parameter is a plain string — recover the lifted literal.
-  mapGet: (l, _r, node) => Pipelines.mapGet(l, literalStringOperand(node.right)),
-  mapRemove: Pipelines.mapRemove,
-  add: Pipelines.add,
-  subtract: Pipelines.subtract,
-  multiply: Pipelines.multiply,
-  divide: Pipelines.divide,
-  mod: Pipelines.mod,
-  pow: Pipelines.pow,
-  round: Pipelines.round,
-  trunc: Pipelines.trunc,
-  trim: Pipelines.trim,
-  ltrim: (l, r) => l.ltrim(r),
-  rtrim: (l, r) => l.rtrim(r),
-  startsWith: Pipelines.startsWith,
-  endsWith: Pipelines.endsWith,
-  stringContains: Pipelines.stringContains,
-  // stringIndexOf/stringRepeat (and the ternary stringReplace* below) exist
-  // at runtime but the SDK's namespace typings only declare their fluent
-  // forms — translate through those.
-  stringIndexOf: (l, r) => l.stringIndexOf(r),
-  stringRepeat: (l, r) => l.stringRepeat(r),
-  substring: (l, r) => Pipelines.substring(l, r),
-  like: Pipelines.like,
-  regexContains: Pipelines.regexContains,
-  regexMatch: Pipelines.regexMatch,
-  regexFind: Pipelines.regexFind,
-  regexFindAll: Pipelines.regexFindAll,
-  isType: (l, _r, node) => Pipelines.isType(l, literalStringOperand(node.right)),
-  // The lifted literal constants (granularity / part) translate as constant
-  // expressions, which IS the literal form the backend validates — probed.
-  timestampTruncate: (l, r) => Pipelines.timestampTruncate(l, r),
-  timestampExtract: (l, r) => Pipelines.timestampExtract(l, r),
-  cosineDistance: Pipelines.cosineDistance,
-  dotProduct: Pipelines.dotProduct,
-  euclideanDistance: Pipelines.euclideanDistance,
-};
-
-const ternaryFns: Record<
-  TernaryFunctionName,
-  (
-    a: Pipelines.Expression,
-    b: Pipelines.Expression,
-    c: Pipelines.Expression,
-  ) => Pipelines.Expression
-> = {
-  stringReplaceAll: (a, b, c) => a.stringReplaceAll(b, c),
-  stringReplaceOne: (a, b, c) => a.stringReplaceOne(b, c),
-  substring: Pipelines.substring,
-  conditional: (a, b, c) => Pipelines.conditional(a.asBoolean(), b, c),
-  mapSet: Pipelines.mapSet,
-  timestampAdd: Pipelines.timestampAdd,
-  timestampSubtract: Pipelines.timestampSubtract,
-  timestampDiff: Pipelines.timestampDiff,
-  timestampTruncate: Pipelines.timestampTruncate,
-  timestampExtract: Pipelines.timestampExtract,
-};
+/** Translates one operand expression into its SDK form (threads `db` internally). */
+type Translate = (expression: Expression) => Pipelines.Expression;
 
 /**
- * Recovers the literal string a factory lifted into a constant operand
- * (e.g. `isType`'s type name): the backend requires the wire argument to be
- * a constant, and the SDK helper takes it as a plain string.
+ * Per-function translation into the SDK, keyed by function name — the single
+ * source that a newly added {@link FunctionName} must extend (a missing key
+ * fails to compile). Each entry receives its NARROWED payload, so it reads
+ * named operand fields directly.
+ *
+ * `asBoolean()` wraps satisfy the SDK's `BooleanExpression` parameters (a
+ * type-tag only, no wire change). Backend-mandated LITERAL arguments arrive as
+ * plain payload fields: the map keys and `isType`'s type name pass straight to
+ * the SDK's string parameters, while the timestamp units / granularities /
+ * parts / timezones are lifted back to constant expressions
+ * (`Pipelines.constant(...)`) — the literal wire form the backend validates
+ * (probed). A dual-arity payload (its trailing operand optional) branches on
+ * that field's presence.
  */
-const literalStringOperand = (operand: Expression): string => {
-  switch (operand.kind) {
-    case 'constant': {
-      const { value } = operand;
-      if (typeof value === 'string') {
-        return value;
-      }
-      throw new Error('expected a literal string constant operand');
-    }
-    case 'field':
-    case 'nullaryFunction':
-    case 'unaryFunction':
-    case 'binaryFunction':
-    case 'ternaryFunction':
-    case 'variadicFunction':
-    case 'arrayConstructor':
-    case 'mapConstructor':
-      throw new Error(`expected a constant operand, got ${operand.kind}`);
-    default:
-      return assertNever(operand);
-  }
+type FunctionTranslators = {
+  [K in FunctionName]: (
+    call: Extract<FunctionPayload, { name: K }>,
+    t: Translate,
+  ) => Pipelines.Expression;
 };
 
-const variadicFns: Record<
-  VariadicFunctionName,
-  (
-    first: Pipelines.Expression,
-    second: Pipelines.Expression,
-    ...rest: Pipelines.Expression[]
-  ) => Pipelines.Expression
-> = {
-  and: (f, s, ...r) => Pipelines.and(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  or: (f, s, ...r) => Pipelines.or(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  stringConcat: Pipelines.stringConcat,
-  xor: (f, s, ...r) => Pipelines.xor(f.asBoolean(), s.asBoolean(), ...r.map((e) => e.asBoolean())),
-  logicalMaximum: Pipelines.logicalMaximum,
-  logicalMinimum: Pipelines.logicalMinimum,
-  arrayConcat: Pipelines.arrayConcat,
-  mapMerge: Pipelines.mapMerge,
+const functionTranslators: FunctionTranslators = {
+  // ---- logical ----
+  and: (c, t) => {
+    const [first, second, ...rest] = c.conditions;
+    return Pipelines.and(
+      t(first).asBoolean(),
+      t(second).asBoolean(),
+      ...rest.map((e) => t(e).asBoolean()),
+    );
+  },
+  or: (c, t) => {
+    const [first, second, ...rest] = c.conditions;
+    return Pipelines.or(
+      t(first).asBoolean(),
+      t(second).asBoolean(),
+      ...rest.map((e) => t(e).asBoolean()),
+    );
+  },
+  xor: (c, t) => {
+    const [first, second, ...rest] = c.conditions;
+    return Pipelines.xor(
+      t(first).asBoolean(),
+      t(second).asBoolean(),
+      ...rest.map((e) => t(e).asBoolean()),
+    );
+  },
+  not: (c, t) => Pipelines.not(t(c.condition).asBoolean()),
+  // ---- comparison ----
+  equal: (c, t) => Pipelines.equal(t(c.left), t(c.right)),
+  notEqual: (c, t) => Pipelines.notEqual(t(c.left), t(c.right)),
+  lessThan: (c, t) => Pipelines.lessThan(t(c.left), t(c.right)),
+  lessThanOrEqual: (c, t) => Pipelines.lessThanOrEqual(t(c.left), t(c.right)),
+  greaterThan: (c, t) => Pipelines.greaterThan(t(c.left), t(c.right)),
+  greaterThanOrEqual: (c, t) => Pipelines.greaterThanOrEqual(t(c.left), t(c.right)),
+  // The options operand is one array-typed EXPRESSION; the SDK's Expression
+  // overload accepts it directly (probed at runtime, and the d.ts declares it).
+  equalAny: (c, t) => Pipelines.equalAny(t(c.value), t(c.options)),
+  notEqualAny: (c, t) => Pipelines.notEqualAny(t(c.value), t(c.options)),
+  // ---- conditional & extremes ----
+  conditional: (c, t) =>
+    Pipelines.conditional(t(c.condition).asBoolean(), t(c.thenExpr), t(c.elseExpr)),
+  logicalMaximum: (c, t) => {
+    const [first, second, ...rest] = c.operands;
+    return Pipelines.logicalMaximum(t(first), t(second), ...rest.map(t));
+  },
+  logicalMinimum: (c, t) => {
+    const [first, second, ...rest] = c.operands;
+    return Pipelines.logicalMinimum(t(first), t(second), ...rest.map(t));
+  },
+  // ---- arithmetic ----
+  rand: () => Pipelines.rand(),
+  add: (c, t) => Pipelines.add(t(c.left), t(c.right)),
+  subtract: (c, t) => Pipelines.subtract(t(c.left), t(c.right)),
+  multiply: (c, t) => Pipelines.multiply(t(c.left), t(c.right)),
+  divide: (c, t) => Pipelines.divide(t(c.left), t(c.right)),
+  mod: (c, t) => Pipelines.mod(t(c.left), t(c.right)),
+  pow: (c, t) => Pipelines.pow(t(c.base), t(c.exponent)),
+  abs: (c, t) => Pipelines.abs(t(c.value)),
+  ceil: (c, t) => Pipelines.ceil(t(c.value)),
+  // floor exists at runtime but the SDK's namespace typings only declare its
+  // fluent form — translate through that.
+  floor: (c, t) => t(c.value).floor(),
+  round: (c, t) =>
+    c.decimalPlaces === undefined
+      ? Pipelines.round(t(c.value))
+      : Pipelines.round(t(c.value), t(c.decimalPlaces)),
+  trunc: (c, t) =>
+    c.decimalPlaces === undefined
+      ? Pipelines.trunc(t(c.value))
+      : Pipelines.trunc(t(c.value), t(c.decimalPlaces)),
+  sqrt: (c, t) => Pipelines.sqrt(t(c.value)),
+  exp: (c, t) => Pipelines.exp(t(c.value)),
+  ln: (c, t) => Pipelines.ln(t(c.value)),
+  log10: (c, t) => Pipelines.log10(t(c.value)),
+  // ---- string ----
+  charLength: (c, t) => Pipelines.charLength(t(c.value)),
+  byteLength: (c, t) => Pipelines.byteLength(t(c.value)),
+  toLower: (c, t) => Pipelines.toLower(t(c.value)),
+  toUpper: (c, t) => Pipelines.toUpper(t(c.value)),
+  stringReverse: (c, t) => Pipelines.stringReverse(t(c.value)),
+  trim: (c, t) =>
+    c.characters === undefined
+      ? Pipelines.trim(t(c.value))
+      : Pipelines.trim(t(c.value), t(c.characters)),
+  // ltrim/rtrim exist at runtime but the SDK's namespace typings only declare
+  // their fluent forms — translate through those.
+  ltrim: (c, t) =>
+    c.characters === undefined ? t(c.value).ltrim() : t(c.value).ltrim(t(c.characters)),
+  rtrim: (c, t) =>
+    c.characters === undefined ? t(c.value).rtrim() : t(c.value).rtrim(t(c.characters)),
+  startsWith: (c, t) => Pipelines.startsWith(t(c.value), t(c.prefix)),
+  endsWith: (c, t) => Pipelines.endsWith(t(c.value), t(c.suffix)),
+  stringContains: (c, t) => Pipelines.stringContains(t(c.value), t(c.substring)),
+  stringConcat: (c, t) => {
+    const [first, second, ...rest] = c.operands;
+    return Pipelines.stringConcat(t(first), t(second), ...rest.map(t));
+  },
+  // stringIndexOf/stringRepeat and the stringReplace* pair exist at runtime but
+  // the SDK's namespace typings only declare their fluent forms.
+  stringIndexOf: (c, t) => t(c.value).stringIndexOf(t(c.substring)),
+  stringRepeat: (c, t) => t(c.value).stringRepeat(t(c.count)),
+  stringReplaceAll: (c, t) => t(c.value).stringReplaceAll(t(c.find), t(c.replacement)),
+  stringReplaceOne: (c, t) => t(c.value).stringReplaceOne(t(c.find), t(c.replacement)),
+  substring: (c, t) =>
+    c.length === undefined
+      ? Pipelines.substring(t(c.value), t(c.position))
+      : Pipelines.substring(t(c.value), t(c.position), t(c.length)),
+  like: (c, t) => Pipelines.like(t(c.value), t(c.pattern)),
+  // ---- regex ----
+  regexContains: (c, t) => Pipelines.regexContains(t(c.value), t(c.pattern)),
+  regexMatch: (c, t) => Pipelines.regexMatch(t(c.value), t(c.pattern)),
+  regexFind: (c, t) => Pipelines.regexFind(t(c.value), t(c.pattern)),
+  regexFindAll: (c, t) => Pipelines.regexFindAll(t(c.value), t(c.pattern)),
+  // ---- reference ----
+  documentId: (c, t) => Pipelines.documentId(t(c.reference)),
+  collectionId: (c, t) => Pipelines.collectionId(t(c.reference)),
+  // ---- type ----
+  type: (c, t) => Pipelines.type(t(c.value)),
+  // The SDK's isType takes the type name as a plain string.
+  isType: (c, t) => Pipelines.isType(t(c.value), c.typeName),
+  // ---- existence & error ----
+  exists: (c, t) => Pipelines.exists(t(c.target)),
+  isAbsent: (c, t) => Pipelines.isAbsent(t(c.target)),
+  isError: (c, t) => Pipelines.isError(t(c.value)),
+  ifError: (c, t) => Pipelines.ifError(t(c.tryExpr), t(c.catchExpr)),
+  ifAbsent: (c, t) => Pipelines.ifAbsent(t(c.value), t(c.fallback)),
+  ifNull: (c, t) => Pipelines.ifNull(t(c.value), t(c.fallback)),
+  // ---- array ----
+  arrayValue: (c, t) => Pipelines.array(c.elements.map(t)),
+  arrayLength: (c, t) => Pipelines.arrayLength(t(c.value)),
+  arrayReverse: (c, t) => Pipelines.arrayReverse(t(c.value)),
+  arrayGet: (c, t) => Pipelines.arrayGet(t(c.value), t(c.index)),
+  arrayContains: (c, t) => Pipelines.arrayContains(t(c.value), t(c.element)),
+  // Array-typed options expressions — the SDK's Expression overload accepts
+  // them directly (see equalAny).
+  arrayContainsAll: (c, t) => Pipelines.arrayContainsAll(t(c.value), t(c.options)),
+  arrayContainsAny: (c, t) => Pipelines.arrayContainsAny(t(c.value), t(c.options)),
+  arrayConcat: (c, t) => {
+    const [first, second, ...rest] = c.operands;
+    return Pipelines.arrayConcat(t(first), t(second), ...rest.map(t));
+  },
+  // ---- map ----
+  mapValue: (c, t) =>
+    Pipelines.map(Object.fromEntries(Object.entries(c.fields).map(([k, e]) => [k, t(e)]))),
+  // The SDK's mapGet/mapSet/mapRemove key parameter is a plain string.
+  mapGet: (c, t) => Pipelines.mapGet(t(c.value), c.key),
+  mapKeys: (c, t) => Pipelines.mapKeys(t(c.value)),
+  mapValues: (c, t) => Pipelines.mapValues(t(c.value)),
+  mapEntries: (c, t) => Pipelines.mapEntries(t(c.value)),
+  mapSet: (c, t) => Pipelines.mapSet(t(c.value), c.key, t(c.entry)),
+  mapRemove: (c, t) => Pipelines.mapRemove(t(c.value), c.key),
+  mapMerge: (c, t) => {
+    const [first, second, ...rest] = c.operands;
+    return Pipelines.mapMerge(t(first), t(second), ...rest.map(t));
+  },
+  // ---- timestamp ----
+  currentTimestamp: () => Pipelines.currentTimestamp(),
+  timestampToUnixSeconds: (c, t) => Pipelines.timestampToUnixSeconds(t(c.value)),
+  timestampToUnixMillis: (c, t) => Pipelines.timestampToUnixMillis(t(c.value)),
+  timestampToUnixMicros: (c, t) => Pipelines.timestampToUnixMicros(t(c.value)),
+  unixSecondsToTimestamp: (c, t) => Pipelines.unixSecondsToTimestamp(t(c.value)),
+  unixMillisToTimestamp: (c, t) => Pipelines.unixMillisToTimestamp(t(c.value)),
+  unixMicrosToTimestamp: (c, t) => Pipelines.unixMicrosToTimestamp(t(c.value)),
+  // The unit/granularity/part/timezone literals lift back to constant
+  // expressions — the literal wire form the backend validates (probed).
+  timestampAdd: (c, t) =>
+    Pipelines.timestampAdd(t(c.value), Pipelines.constant(c.unit), t(c.amount)),
+  timestampSubtract: (c, t) =>
+    Pipelines.timestampSubtract(t(c.value), Pipelines.constant(c.unit), t(c.amount)),
+  timestampDiff: (c, t) =>
+    Pipelines.timestampDiff(t(c.end), t(c.start), Pipelines.constant(c.unit)),
+  timestampTruncate: (c, t) =>
+    c.timezone === undefined
+      ? Pipelines.timestampTruncate(t(c.value), Pipelines.constant(c.granularity))
+      : Pipelines.timestampTruncate(
+          t(c.value),
+          Pipelines.constant(c.granularity),
+          Pipelines.constant(c.timezone),
+        ),
+  timestampExtract: (c, t) =>
+    c.timezone === undefined
+      ? Pipelines.timestampExtract(t(c.value), Pipelines.constant(c.part))
+      : Pipelines.timestampExtract(
+          t(c.value),
+          Pipelines.constant(c.part),
+          Pipelines.constant(c.timezone),
+        ),
+  // ---- vector ----
+  cosineDistance: (c, t) => Pipelines.cosineDistance(t(c.left), t(c.right)),
+  dotProduct: (c, t) => Pipelines.dotProduct(t(c.left), t(c.right)),
+  euclideanDistance: (c, t) => Pipelines.euclideanDistance(t(c.left), t(c.right)),
+  vectorLength: (c, t) => Pipelines.vectorLength(t(c.vector)),
 };
 
 /** `Array.isArray` narrows poorly over readonly-array unions — a dedicated guard does. */
@@ -439,13 +452,7 @@ const toSdkOrdering = (ordering: Ordering) => {
     case 'field':
       break;
     case 'constant':
-    case 'nullaryFunction':
-    case 'unaryFunction':
-    case 'binaryFunction':
-    case 'ternaryFunction':
-    case 'variadicFunction':
-    case 'arrayConstructor':
-    case 'mapConstructor':
+    case 'functionCall':
       throw new Error(
         'google-cloud pipeline executor: only field orderings are supported in sort yet',
       );


### PR DESCRIPTION
## Summary

Implements the agreed AST restructure (plan: "Expressions — remaining gaps"): the seven arity-grouped classes (`NullaryFunction`…`VariadicFunction`, `ArrayConstructor`, `MapConstructor`) and their five per-shape name unions are replaced by **one `FunctionCall<T>` class carrying a `name`-discriminated `FunctionPayload` union**. `Expression<T>` is now `Field | Constant | FunctionCall`.

The three distortions the arity buckets had accumulated are resolved:

1. **No factory overloads remain** — the dual-arity families (`round`/`trunc`/`trim`/`ltrim`/`rtrim`/`substring`/`timestampTruncate`/`timestampExtract`) are single `(a, b, c?)` signatures with optional payload fields (return-descriptor semantics preserved via a `P extends … = never` default; verified by the existing type tests).
2. **Named payload fields** — `{ end, start, unit }` instead of `first/second/third`.
3. **Backend-literal arguments are plain payload fields** (`isType.typeName`, timestamp `unit`/`granularity`/`part`/`timezone`, map `key`) — the `Constant.of` lifting and the executors' `literalStringOperand` recovery mechanism are deleted.

## Executors

Both adapters translate through **one `FunctionTranslators` mapped table** (`{ [K in FunctionName]: (call: Extract<FunctionPayload, { name: K }>, t) => SdkExpr }` — exhaustive: a new function name without a translator is a compile error), dispatched by a generic helper. The correlated-union dispatch needed **no type assertion**, and the gcloud `equalAny`-family options assertion fell away as well — the 8.6.0 d.ts does declare the array-expression overload (the earlier typings-gap report missed it). All fluent-form fallbacks and `.asBoolean()` coercions carried over with their comments.

## Process

Implemented by three subagents (core AST+tests, then the two executors in parallel) against a fixed design spec; reviewed here.

## Verification

- `pnpm check` — pass; the only remaining type assertions in the executors are the pre-existing decode-boundary casts
- Emulator + live pipeline spec (`ikenox-sunrise`/`enterprise-native-playground`): **652 passed** — the per-function live catalog doubles as the wire-equivalence regression net for this refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)