### PR TITLE
docRefValue: the typed collection+address form

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -530,14 +530,19 @@ Query API (admin has `query.stream()`, web only `getDocs()`):
 Items agreed in discussion but previously recorded only inline in DONE notes
 (or not at all). Elevated to checklist items:
 
-- [ ] **Shorthand layer — "an address where a static context exists"**
-      (feasibility confirmed; details inline in the segment-path DONE notes
-      above): (a) core query `__name__` operands as bare ids / `DocRef`
-      tuples where the source collection is statically known (the 2n-vs-n
-      length parity disambiguates ids from segments once names are literal);
-      (b) `docRefValue(authors, ['a1'])` — the collection+address form,
-      typed `DocRefType<Authors>` (decided: receiving the collection
-      definition is what makes known-collection typing possible).
+- [~] **Shorthand layer — "an address where a static context exists".**
+  SCOPED DOWN (2026-07): only the collection+address value constructor
+  ships — `docRefValue(authors, ['a1'])`, typed `DocRefType<Authors>`
+  (receiving the collection definition is what makes known-collection
+  typing possible; segments are normalized internally, wire unchanged).
+  REJECTED: core query `__name__` operands as bare ids or `DocRef`
+  tuples. Bare ids are context-dependent (incomplete without the query
+  parent; unexpandable for groups) — the guideline's "don't widen for
+  possibly-invalid input". Address TUPLES would be sound (2n-vs-n length
+  parity disambiguates), but the runtime dual interpretation gives one
+  parameter two meanings a reader cannot tell apart without knowing the
+  collection depth, for the price of one `refPath(...)` call — not worth
+  the conceptual cost.
 - [ ] **Typed cursor constraints.** `Cursor` is an untyped `unknown[]`
       pass-through; typing it per orderBy field would also require encoding
       reference cursor values like the filter operands

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -1266,8 +1266,21 @@ describe('document-reference values', () => {
     const ref = docRefValue(refPath(authors, ['a1']));
     // Cross-source: the segment array is produced by refPath, checked against
     // the independently-written path — not a construction restatement.
-    expect(ref).toStrictEqual(new DocRefValue(['authors', 'a1']));
+    expect(ref).toStrictEqual(DocRefValue.of(['authors', 'a1']));
     expectTypedStrictEqual(ref.type, docRef());
+  });
+
+  it('the collection+address form is typed with the known collection', () => {
+    const typed = docRefValue(authors, ['a1']);
+    // The address normalizes to the SAME segment payload as the value form —
+    // only the descriptor claim gains the collection.
+    expect(typed.path).toStrictEqual(docRefValue(refPath(authors, ['a1'])).path);
+    expectTypedStrictEqual(typed.type, docRef(authors));
+    // @ts-expect-error -- the id tuple must match the collection's depth
+    void (() => docRefValue(authors, ['a1', 'extra']));
+    // Comparisons: typed and context-free flavors share the 'reference' tag.
+    equal(field(docRef(authors), 'ref'), docRefValue(authors, ['a1']));
+    equal(field(docRef(), '__name__'), docRefValue(authors, ['a1']));
   });
 
   it('compares against reference operands only (probed: strings never match)', () => {

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -188,7 +188,7 @@ export class DocRefValue<T extends Collection | 'unknown' = 'unknown'> {
   }
 
   /** Context-free form: an untyped segment path — `DocRefType<'unknown'>`. */
-  static of(path: readonly string[]): DocRefValue;
+  static of(this: void, path: readonly string[]): DocRefValue;
   /**
    * Collection + address form: `DocRefValue.of(authors, ['a1'])`, typed
    * `DocRefType<Authors>`. Receiving the collection DEFINITION is what makes
@@ -197,8 +197,9 @@ export class DocRefValue<T extends Collection | 'unknown' = 'unknown'> {
    * segment-path payload, so the wire form is identical to the
    * context-free flavor.
    */
-  static of<T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T>;
+  static of<T extends Collection>(this: void, collection: T, id: DocRef<T>): DocRefValue<T>;
   static of(
+    this: void,
     first: readonly string[] | Collection,
     id?: [...string[], string],
   ): DocRefValue<Collection | 'unknown'> {
@@ -212,28 +213,13 @@ export class DocRefValue<T extends Collection | 'unknown' = 'unknown'> {
   }
 }
 
-/** Builds a document-reference value — see {@link DocRefValue} (and its typed collection+address form). */
-export function docRefValue(path: readonly string[]): DocRefValue;
-export function docRefValue<T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T>;
-export function docRefValue(
-  first: readonly string[] | Collection,
-  id?: [...string[], string],
-): DocRefValue<Collection | 'unknown'> {
-  return isSegments(first) ? DocRefValue.of(first) : DocRefValue.of(first, requireId(id));
-}
+/** Builds a document-reference value — sugar for {@link DocRefValue}.of, like `constant` for `Constant.of`. */
+export const docRefValue = DocRefValue.of;
 
 // `Array.isArray`'s built-in `arg is any[]` does not narrow READONLY array
 // unions (the `isConstantArray` precedent) — the annotation deliberately
 // overrides it.
 const isSegments = (v: readonly string[] | Collection): v is readonly string[] => Array.isArray(v);
-
-/** The overload-impl bridge cannot see that the collection form always carries an id. */
-const requireId = (id: [...string[], string] | undefined): [...string[], string] => {
-  if (id === undefined) {
-    throw new Error('the collection form requires an id tuple');
-  }
-  return id;
-};
 
 /**
  * The value domain `constant()` accepts — everything with an unambiguous

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -1,6 +1,9 @@
+import { refPath } from '../path.js';
+import type { DocRef } from '../repository.js';
 import {
   type AnyUnionType,
   array,
+  type Collection,
   type ArrayType,
   assertNoDottedFieldNames,
   bool,
@@ -174,16 +177,63 @@ export class VectorValue {
  * segment path from a repository-side id with `refPath(collection, id)`
  * (`path.js`).
  */
-export class DocRefValue {
-  readonly type: DocRefType<'unknown'> = docRef();
+export class DocRefValue<T extends Collection | 'unknown' = 'unknown'> {
+  /** Always coherent with `path` — the sealed constructor is the only construction point (the `Constant` precedent). */
+  readonly type: DocRefType<T>;
   readonly path: readonly string[];
-  constructor(path: readonly string[]) {
+
+  private constructor(type: DocRefType<T>, path: readonly string[]) {
+    this.type = type;
     this.path = [...path];
+  }
+
+  /** Context-free form: an untyped segment path — `DocRefType<'unknown'>`. */
+  static of(path: readonly string[]): DocRefValue;
+  /**
+   * Collection + address form: `DocRefValue.of(authors, ['a1'])`, typed
+   * `DocRefType<Authors>`. Receiving the collection DEFINITION is what makes
+   * the known-collection typing possible (a segment tuple alone cannot
+   * recover the collection type); the address is normalized to the same
+   * segment-path payload, so the wire form is identical to the
+   * context-free flavor.
+   */
+  static of<T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T>;
+  static of(
+    first: readonly string[] | Collection,
+    id?: [...string[], string],
+  ): DocRefValue<Collection | 'unknown'> {
+    if (isSegments(first)) {
+      return new DocRefValue(docRef(), first);
+    }
+    if (id === undefined) {
+      throw new Error('the collection form requires an id tuple');
+    }
+    return new DocRefValue(docRef(first), refPath(first, id));
   }
 }
 
-/** Builds a document-reference value — see {@link DocRefValue}. */
-export const docRefValue = (path: readonly string[]): DocRefValue => new DocRefValue(path);
+/** Builds a document-reference value — see {@link DocRefValue} (and its typed collection+address form). */
+export function docRefValue(path: readonly string[]): DocRefValue;
+export function docRefValue<T extends Collection>(collection: T, id: DocRef<T>): DocRefValue<T>;
+export function docRefValue(
+  first: readonly string[] | Collection,
+  id?: [...string[], string],
+): DocRefValue<Collection | 'unknown'> {
+  return isSegments(first) ? DocRefValue.of(first) : DocRefValue.of(first, requireId(id));
+}
+
+// `Array.isArray`'s built-in `arg is any[]` does not narrow READONLY array
+// unions (the `isConstantArray` precedent) — the annotation deliberately
+// overrides it.
+const isSegments = (v: readonly string[] | Collection): v is readonly string[] => Array.isArray(v);
+
+/** The overload-impl bridge cannot see that the collection form always carries an id. */
+const requireId = (id: [...string[], string] | undefined): [...string[], string] => {
+  if (id === undefined) {
+    throw new Error('the collection form requires an id tuple');
+  }
+  return id;
+};
 
 /**
  * The value domain `constant()` accepts — everything with an unambiguous
@@ -202,7 +252,7 @@ export type ConstantScalar = string | number | boolean | null | Date | Uint8Arra
  * have no plain-JS representation of their own, their explicit nodes stand
  * in — `constant({ spot: geoPointValue(1, 3) })`.
  */
-export type ConstantLeafNode = GeoPointValue | VectorValue | DocRefValue;
+export type ConstantLeafNode = GeoPointValue | VectorValue | DocRefValue<Collection | 'unknown'>;
 /**
  * Non-empty (an empty literal has no element to infer a descriptor from) and
  * non-nested: directly nested arrays (`constant([1, [2, 3]])`) are excluded
@@ -228,8 +278,8 @@ export type ConstantTypeOf<V extends ConstantValue> = ConstantValue extends V
       ? TimestampType
       : V extends Uint8Array
         ? BytesType
-        : V extends DocRefValue
-          ? DocRefType<'unknown'>
+        : V extends DocRefValue<infer C>
+          ? DocRefType<C>
           : V extends GeoPointValue
             ? GeoPointType
             : V extends VectorValue
@@ -726,7 +776,7 @@ type TimestampOperandInput = TimestampOperand | Date | null;
 // `vectorValue`) are `ConstantValue` leaves that lift like any other raw.
 type ArrayOperandInput = ArrayOperand | ConstantArray | null;
 type MapOperandInput = MapOperand | ConstantMap | null;
-type ReferenceOperandInput = ReferenceOperand | DocRefValue | null;
+type ReferenceOperandInput = ReferenceOperand | DocRefValue<Collection | 'unknown'> | null;
 type VectorOperandInput = VectorOperand | VectorValue | null;
 
 export const equal = <const L extends OperandInput, const R extends OperandInput>(


### PR DESCRIPTION
## Summary

Implements the scoped-down shorthand backlog item: `docRefValue(authors, ['a1'])` — the collection+address constructor, typed `DocRefType<Authors>`.

```ts
docRefValue(['Authors', 'a1'])    // context-free: DocRefType<'unknown'>  (unchanged)
docRefValue(authors, ['a1'])      // typed: DocRefType<Authors>           (new)
```

- Receiving the collection **definition** is what makes known-collection typing possible — a segment tuple alone cannot recover the collection type (the reason the value form stays `'unknown'`).
- The address normalizes to the same segment-path payload via `refPath`, so **executors and the wire form are untouched**; `ConstantTypeOf` infers the typed descriptor.
- `DocRefValue` is sealed like `Constant` (private constructor + `of()`), making type/path coherence unforgeable, and regains its type parameter (default `'unknown'`).

## Scoped down (recorded in the plan)

The rest of the original shorthand idea is **rejected**: bare-id `__name__` operands are context-dependent input (the guideline's don't-widen rule — incomplete without the query parent, unexpandable for groups), and address TUPLES in `__name__` operands — though soundly disambiguable via the 2n-vs-n length parity — would give one `string[]` parameter two meanings a reader cannot tell apart without knowing the collection depth, for the price of one `refPath()` call.

## Verification

- `pnpm check` — 0 errors; emulator + live: 679 passed
- Type tests: typed descriptor claim (`expectTypedStrictEqual`), payload equivalence with the value form, depth-mismatched id tuples rejected, cross-flavor comparability

🤖 Generated with [Claude Code](https://claude.com/claude-code)