### PR TITLE
Pipeline aggregate stage

### DIFF
--- a/docs/pipeline-query-aggregate-research.md
+++ b/docs/pipeline-query-aggregate-research.md
@@ -51,6 +51,21 @@ absent]` sorted), `first` returns null (a skip would return `y1`) and
 - `count` / `countAll` / `countDistinct` / `countIf`: int64.
 - `minimum` / `maximum` / `first` / `last`: the operand's own kind.
 
+## Output shape restrictions (probed: `TOP_LEVEL_PROPERTY_PATH_ONLY`)
+
+- **`aggregate` assigns TOP-LEVEL fields only**: a dotted bare-path group
+  (`groups: ['a.b.c']`) AND a dotted alias (on a group or an accumulator)
+  are both INVALID_ARGUMENT. A nested field groups via an expression with a
+  top-level alias: `field('a.b.c').as('c')` — its rows carry `c: 'v1'` /
+  `c: null`, with absent-ancestor docs merging into the null group like any
+  other absent key. (The backend's backtick escape hatch — a literal dotted
+  KEY — conflicts with the library's dotted-key ban and is not supported.)
+- **A MAP-typed group key is compared and projected AS A VALUE**: inner
+  absences are preserved (`{ b: {} }` and `{ b: { c: 'v1' } }` form
+  DISTINCT groups); only the wholly-absent map merges into the null group.
+  Library consequence: the `AbsentMergesIntoNull` rewrite is SHALLOW —
+  nullable at the top of each group key, inner optionality untouched.
+
 ## `distinct` stage
 
 - Same projection and null/absent-merge rules as grouping; expression

--- a/docs/pipeline-query-aggregate-research.md
+++ b/docs/pipeline-query-aggregate-research.md
@@ -30,7 +30,13 @@
 | `arrayAgg` / `arrayAggDistinct`           | **kept as elements**                        | **skipped**                 | (not probed; presumably empty/null)   |
 
 - `first`/`last` follow the pipeline's `sort` order when one precedes the
-  stage; without a sort the order is backend-determined.
+  stage; without a sort the order is backend-determined. The keep-vs-skip
+  claims were verified DISCRIMINATINGLY (`probe-first-last.mjs`): with a
+  non-null neighbor adjacent to the null/absent end (`[null, y1, y2,
+absent]` sorted), `first` returns null (a skip would return `y1`) and
+  `last` returns null (a skip would return `y2`) — an arrangement where the
+  null/absent element neighbors another null cannot tell the hypotheses
+  apart.
 - Note the asymmetry: `arrayAgg` SKIPS absent but KEEPS null, while
   `first`/`last` merge absent into null.
 - **ERROR values inside an accumulator are not absorbed** — the query fails

--- a/docs/pipeline-query-aggregate-research.md
+++ b/docs/pipeline-query-aggregate-research.md
@@ -1,0 +1,68 @@
+# Pipeline Query — `aggregate` / `distinct` semantics
+
+> Empirical study of the aggregate stage, its accumulator functions, and the
+> `distinct` stage, probed against a real Firestore Enterprise database
+> (2026-07, `.ikenox/probe-aggregate.mjs` / `probe-aggregate2.mjs`).
+
+## Groups
+
+- **Group keys are projected into the result rows** (the row carries which
+  group it is), including aliased EXPRESSION groups
+  (`greaterThan(field('n'), 4).as('big')` → rows `{ big: true, ... }` /
+  `{ big: false, ... }`).
+- **Null and ABSENT group keys merge into ONE group**, and the key appears
+  in the row as `null` — the expression-side "absent merges into null" rule
+  applies to grouping too. Consequence for typing: a group key whose
+  descriptor is `X & Optional` reads back as `nullable(X)`, never absent.
+- **Empty input**: with groups → **zero rows**; without groups → exactly ONE
+  row (the whole-input group) carrying each accumulator's empty value.
+
+## Accumulators — null / absent / error
+
+| accumulator                               | null values                                 | absent values               | empty group (no-groups row)           |
+| ----------------------------------------- | ------------------------------------------- | --------------------------- | ------------------------------------- |
+| `sum` / `average` / `minimum` / `maximum` | ignored (avg divides by the non-null count) | ignored                     | **null** (NOT 0 for sum — unlike SQL) |
+| `count(expr)`                             | not counted                                 | not counted                 | 0                                     |
+| `countAll`                                | counts rows                                 | counts rows                 | 0                                     |
+| `countDistinct`                           | (distinct non-null values)                  | —                           | 0                                     |
+| `countIf(cond)`                           | a null condition is not true → not counted  | same                        | 0                                     |
+| `first` / `last`                          | **kept** (positional, not skipped)          | **merged into null** (kept) | null                                  |
+| `arrayAgg` / `arrayAggDistinct`           | **kept as elements**                        | **skipped**                 | (not probed; presumably empty/null)   |
+
+- `first`/`last` follow the pipeline's `sort` order when one precedes the
+  stage; without a sort the order is backend-determined.
+- Note the asymmetry: `arrayAgg` SKIPS absent but KEEPS null, while
+  `first`/`last` merge absent into null.
+- **ERROR values inside an accumulator are not absorbed** — the query fails
+  (`sum(divide(n, 0))` → INVALID_ARGUMENT), consistent with the expression
+  error channel.
+
+## Result kinds (probed via a following `addFields` + `type()`)
+
+- `sum`: int64 when every input value is a wire integer, float64 when any
+  double participates — the `NumericResult` rule.
+- `average`: **always float64**.
+- `count` / `countAll` / `countDistinct` / `countIf`: int64.
+- `minimum` / `maximum` / `first` / `last`: the operand's own kind.
+
+## `distinct` stage
+
+- Same projection and null/absent-merge rules as grouping; expression
+  aliases work. Semantically a grouped aggregate with zero accumulators —
+  the library can share the groups machinery.
+
+## Library consequences (design)
+
+Return descriptors:
+
+| factory                                                       | descriptor                                                                                    |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `countAll()` / `count(v)` / `countDistinct(v)` / `countIf(c)` | `Int64Type` (0 on empty — never null)                                                         |
+| `sum(v)`                                                      | `nullable(NumericResult<V>)` (the no-groups empty row)                                        |
+| `average(v)`                                                  | `nullable(DoubleType)`                                                                        |
+| `minimum(v)` / `maximum(v)` / `first(v)` / `last(v)`          | `nullable(WithoutOptional<V>)`                                                                |
+| `arrayAgg(v)` / `arrayAggDistinct(v)`                         | `ArrayType<WithoutOptional<V>>`-based (elements may include null iff the operand may be null) |
+
+Group-key schema: the groups' `BuildSelection` output with every
+`X & Optional` field rewritten to `nullable(X)` (absent merges into null —
+probed above).

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -307,14 +307,22 @@ Deferred to a later iteration (still tracked here, not currently in scope):
       translate to `field(path).ascending()/.descending()`. Only **field**
       orderings are supported (a computed-expression ordering throws in the
       executor). Verified live. See the spec `sort` tests.
-- [ ] `aggregate(...)` — needs:
-  - A separate `AggregateFunction` AST node (distinct from `Expression`).
-  - Aggregate function factories: `sum`, `count`, `countAll`,
-    `countDistinct`, `countIf`, `average`, `first`, `last`, `minimum`,
-    `maximum`, `arrayAgg`, `arrayAggDistinct`, `arraySum`.
-  - `aggregate({ accumulators, groups })` stage that:
-    - rebuilds Context from accumulator aliases + group field types,
-    - breaks identity (returns `UnidentifiedPipeline`).
+- [x] `aggregate(...)` — done (2026-07; semantics in
+      `../pipeline-query-aggregate-research.md`): `AggregateFunction` (SDK
+      name; payload-union like `FunctionCall`, NOT an `Expression` member so
+      misplacement is a type error) with all 12 factories (`arraySum` was an
+      expression, not an accumulator — dropped from this list); probed
+      return descriptors (count family plain int64; `sum`
+      nullable+NumericResult; `average` nullable double;
+      `minimum`/`maximum`/`first`/`last` `NullableStripped`; `arrayAgg*`
+      element drops Optional, keeps the null tag). The
+      `aggregate((field) => ({ accumulators, groups? }))` stage synthesizes
+      `AggregateSchema` = groups' BuildSelection output through
+      `AbsentMergesIntoNull` (null and absent group keys merge — probed) +
+      accumulator overlay (accumulator wins on collision), identity breaks
+      (`Id = undefined`). Executors: one `aggregateTranslators` mapped table
+      per adapter; groups translate like select selections. Live catalog
+      pins the probe matrix incl. empty-input and null/absent-merge cases.
 - [ ] `ascending(...)` / `descending(...)` — ordering factories used by
       `sort` (and by cursor lowering in `__PRIVATE_toPipeline`).
 - [ ] Type-level tests for `Ordering` / `AggregateFunction` along the lines

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -596,6 +596,18 @@ Items agreed in discussion but previously recorded only inline in DONE notes
       cost; the runtime twin mirrors branch-for-branch as usual. Scope is
       a cross-cutting refactor comparable to the payload-union one — its
       own PR, with the shape-oracle tests updated alongside.
+- [ ] **Refine accumulator nullability by groups presence** (noted 2026-07,
+      explicitly deferred as advanced). `sum`/`average`/`minimum`/`maximum`/
+      `first`/`last` are currently ALWAYS nullable — sound but wider than
+      the true rule, `operandMayBeNull OR noGroups`: with groups, an empty
+      group emits no row at all (probed), so a grouped aggregate over a
+      non-null operand can never be null. Sketch: split the operand-derived
+      nullability into a second type parameter
+      (`AggregateFunction<T, MayBeNull>`, `T` the null-free value kind) and
+      compose in the stage (`MayBeNull ? nullable(T) : HasGroups ? T :
+    nullable(T)`); count family unaffected. Also probe the un-probed
+      all-null-group cell (nullable operand, every value null in a group)
+      before relying on it.
 - [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):
       the aggregate node ships as `AggregateFunction` (the SDK's name), which
       makes the pair with the expression node asymmetric — rename

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -605,7 +605,7 @@ Items agreed in discussion but previously recorded only inline in DONE notes
       nullability into a second type parameter
       (`AggregateFunction<T, MayBeNull>`, `T` the null-free value kind) and
       compose in the stage (`MayBeNull ? nullable(T) : HasGroups ? T :
-    nullable(T)`); count family unaffected. Also probe the un-probed
+nullable(T)`); count family unaffected. Also probe the un-probed
       all-null-group cell (nullable operand, every value null in a group)
       before relying on it.
 - [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -569,6 +569,11 @@ Items agreed in discussion but previously recorded only inline in DONE notes
       `FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY`; the suite is
       skipIf-gated and has never executed against the real backend — the
       admin adapter covers the shared spec live today).
+- [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):
+      the aggregate node ships as `AggregateFunction` (the SDK's name), which
+      makes the pair with the expression node asymmetric — rename
+      `FunctionCall` to the SDK's `FunctionExpression` in a follow-up so the
+      internal naming rule becomes "SDK vocabulary", consistently.
 - [ ] **`ArrayType` fixed-part / tuple support** — tracked in issue #218
       (includes the arrayRemove/arrayUnion interaction constraint noted
       there).

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -577,6 +577,25 @@ Items agreed in discussion but previously recorded only inline in DONE notes
       `FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY`; the suite is
       skipIf-gated and has never executed against the real backend — the
       admin adapter covers the shared spec live today).
+- [ ] **Canonical union normalization — `UnionType` valid-by-construction**
+      (agreed 2026-07, NEXT UP after the aggregate stage lands). The
+      always-valid principle applied to descriptors: union normalization is
+      today re-implemented at every construction site (`EitherType` /
+      `LogicalExtreme` / `ElementUnion` / `ConcatElementUnion` /
+      `MapFieldUnion` dedups, `NullableStripped`'s strip-then-reattach,
+      and `arrayGet`'s pinned union-NESTING wrap), because nothing
+      guarantees a `UnionType` is canonical. Introduce ONE `Normalize`
+      (type + runtime twin) owned by the union constructors (`union()`,
+      `nullable()`, `RebuildUnion`, ...): 1. flatten nested unions; 2. dedup members by `DescriptorEquals` (first-occurrence order —
+      deterministic, matching the existing dedup rule); 3. drop `never` members; 4. unwrap a singleton to the bare descriptor.
+      Consequences: `NullableStripped` collapses to
+      `Normalize<[StripNull<T>, NullType]>`-composition; the per-helper
+      dedups become `Normalize` calls (N implementations → 1); `arrayGet`'s
+      nested-union pin flips to flattened (update that test as "fixed");
+      `nullable(nullable(x))` becomes idempotent. Watch TS recursion
+      cost; the runtime twin mirrors branch-for-branch as usual. Scope is
+      a cross-cutting refactor comparable to the payload-union one — its
+      own PR, with the shape-oracle tests updated alongside.
 - [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):
       the aggregate node ships as `AggregateFunction` (the SDK's name), which
       makes the pair with the expression node asymmetric — rename

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -97,6 +97,19 @@ import {
   trunc as sdkTrunc,
   type as sdkType,
   vectorLength as sdkVectorLength,
+  countAll as sdkCountAll,
+  count as sdkCount,
+  countDistinct as sdkCountDistinct,
+  countIf as sdkCountIf,
+  sum as sdkSum,
+  average as sdkAverage,
+  minimum as sdkMinimum,
+  maximum as sdkMaximum,
+  first as sdkFirst,
+  last as sdkLast,
+  arrayAgg as sdkArrayAgg,
+  arrayAggDistinct as sdkArrayAggDistinct,
+  type AggregateFunction as SdkAggregateFunction,
   type Expression as SdkExpression,
   type Pipeline as SdkPipeline,
   type Selectable as SdkSelectable,
@@ -110,6 +123,8 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type AggregateFunctionName,
+  type AggregatePayload,
   type FunctionName,
   type FunctionPayload,
 } from 'firestore-repository/pipelines/expression';
@@ -206,6 +221,17 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
       }
       return sdk.addFields(first, ...rest);
     }
+    case 'aggregate': {
+      // Always the options-object form (uniform; the variadic accumulator form
+      // is client sugar). `accumulators` are the aliased accumulator calls;
+      // `groups` translate like `select` selections — a bare path becomes a
+      // `Field`, an aliased expression becomes the translated expression `.as`.
+      const accumulators = stage.accumulators.map(({ aggregate, alias }) =>
+        dispatchAggregate(aggregate.call, (e) => toSdkExpression(db, e)).as(alias),
+      );
+      const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
+      return sdk.aggregate({ accumulators, groups });
+    }
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
@@ -215,7 +241,6 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
-    case 'aggregate':
     case 'distinct':
     case 'replaceWith':
     case 'union':
@@ -502,6 +527,47 @@ const functionTranslators: FunctionTranslators = {
   dotProduct: (c, t) => sdkDotProduct(t(c.left), t(c.right)),
   euclideanDistance: (c, t) => sdkEuclideanDistance(t(c.left), t(c.right)),
   vectorLength: (c, t) => sdkVectorLength(t(c.vector)),
+};
+
+/**
+ * Dispatches an accumulator payload to its {@link aggregateTranslators} entry —
+ * the aggregate counterpart of {@link dispatch}. The generic `K` ties the
+ * payload's `name` to the matching translator entry (the same single-type-
+ * variable trick that avoids a whole-union assertion).
+ */
+const dispatchAggregate = <K extends AggregateFunctionName>(
+  call: Extract<AggregatePayload, { name: K }>,
+  t: (e: Expression) => SdkExpression,
+): SdkAggregateFunction => aggregateTranslators[call.name](call, t);
+
+/**
+ * One translator per accumulator name — a mapped type over the name union
+ * requires every key, so a newly added accumulator fails to compile until
+ * translated (mirrors {@link functionTranslators}). Every accumulator has a
+ * standalone SDK factory taking an `Expression`; `countIf` takes a
+ * `BooleanExpression`, so its operand is wrapped with `asBoolean()` (a type-tag
+ * only, no wire change).
+ */
+type AggregateTranslators = {
+  [K in AggregateFunctionName]: (
+    call: Extract<AggregatePayload, { name: K }>,
+    t: (e: Expression) => SdkExpression,
+  ) => SdkAggregateFunction;
+};
+
+const aggregateTranslators: AggregateTranslators = {
+  countAll: () => sdkCountAll(),
+  count: (c, t) => sdkCount(t(c.value)),
+  countDistinct: (c, t) => sdkCountDistinct(t(c.value)),
+  countIf: (c, t) => sdkCountIf(t(c.condition).asBoolean()),
+  sum: (c, t) => sdkSum(t(c.value)),
+  average: (c, t) => sdkAverage(t(c.value)),
+  minimum: (c, t) => sdkMinimum(t(c.value)),
+  maximum: (c, t) => sdkMaximum(t(c.value)),
+  first: (c, t) => sdkFirst(t(c.value)),
+  last: (c, t) => sdkLast(t(c.value)),
+  arrayAgg: (c, t) => sdkArrayAgg(t(c.value)),
+  arrayAggDistinct: (c, t) => sdkArrayAggDistinct(t(c.value)),
 };
 
 const toSdkOrdering = (ordering: Ordering) => {

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -174,6 +174,32 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     },
   ];
 
+  /**
+   * Executes `pipeline` (however sourced) and asserts the result rows
+   * equal `expected`.
+   *
+   * Order-sensitive by default (the result order is part of what a query
+   * asserts — e.g. `sort` / `limit`). For queries whose order is unspecified
+   * (e.g. a bare `collection` input, whose order is Firestore-internal), pass
+   * `{ ordered: false }` to compare as a set.
+   */
+  const expectPipeline = async <S extends DocumentSchema, Id extends PipelineRowIdentity>(
+    pipeline: Pipeline<S, Id>,
+    // `NoInfer` so `S`/`Id` are inferred from `pipeline` only, not from the
+    // expected rows (which would otherwise widen `S` to its constraint).
+    expected: readonly NoInfer<PipelineResult<S, Id>>[],
+    options?: { ordered?: boolean },
+  ): Promise<void> => {
+    const results = await executor.execute(pipeline);
+    if (options?.ordered === false) {
+      // The result order of an unordered query is unspecified — compare as a
+      // set (order-independent deep equality).
+      assert.sameDeepMembers(results, [...expected]);
+    } else {
+      expect(results).toStrictEqual(expected);
+    }
+  };
+
   const setup = () => {
     let collection: AuthorsCollection;
     beforeEach(async () => {
@@ -185,43 +211,16 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     const source = (): Pipeline<AuthorsCollection['schema'], DocRef<AuthorsCollection>> =>
       collectionInput(collection);
 
-    /**
-     * Executes `pipeline` (built from {@link source}) and asserts the result rows
-     * equal `expected`.
-     *
-     * Order-sensitive by default (the result order is part of what a query
-     * asserts — e.g. `sort` / `limit`). For queries whose order is unspecified
-     * (e.g. a bare `collection` input, whose order is Firestore-internal), pass
-     * `{ ordered: false }` to compare as a set.
-     */
-    const expectPipeline = async <S extends DocumentSchema, Id extends PipelineRowIdentity>(
-      pipeline: Pipeline<S, Id>,
-      // `NoInfer` so `S`/`Id` are inferred from `pipeline` only, not from the
-      // expected rows (which would otherwise widen `S` to its constraint).
-      expected: readonly NoInfer<PipelineResult<S, Id>>[],
-      options?: { ordered?: boolean },
-    ): Promise<void> => {
-      const results = await executor.execute(pipeline);
-      if (options?.ordered === false) {
-        // The result order of an unordered query is unspecified — compare as a
-        // set (order-independent deep equality).
-        assert.sameDeepMembers(results, [...expected]);
-      } else {
-        expect(results).toStrictEqual(expected);
-      }
-    };
-
     return {
       items,
       source,
-      expectPipeline,
       collectionName: () => collection.name,
       liveCollection: () => collection,
     };
   };
 
   describe('pipeline specification', () => {
-    const { items, source, expectPipeline } = setup();
+    const { items, source } = setup();
 
     describe('input source (no transformation stages)', () => {
       it('fetches all documents of a collection with their ids', async () => {
@@ -426,7 +425,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     // its basic backend semantics in one round trip per family. Every future
     // slice MUST add its functions to this catalog.
     describe('function catalog (one straightforward evaluation per function)', () => {
-      const { items, source, expectPipeline, collectionName, liveCollection } = setup();
+      const { items, source, collectionName, liveCollection } = setup();
       /** A single-row source: the catalog evaluates constant expressions only. */
       const one = () => source().limit(1);
 
@@ -977,7 +976,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
     });
 
     describe('arithmetic and string functions', () => {
-      const { source, expectPipeline } = setup();
+      const { source } = setup();
 
       it('computes nested arithmetic over fields and constants', async () => {
         await expectPipeline(
@@ -1608,25 +1607,11 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
       const src = () => collectionInput(coll);
 
-      /** Executes and compares rows (unordered by default — grouped output has no defined order). */
-      const expectRows = async <S extends DocumentSchema, Id extends PipelineRowIdentity>(
-        pipeline: Pipeline<S, Id>,
-        expected: readonly NoInfer<PipelineResult<S, Id>>[],
-        options?: { ordered?: boolean },
-      ): Promise<void> => {
-        const results = await executor.execute(pipeline);
-        if (options?.ordered === true) {
-          expect(results).toStrictEqual(expected);
-        } else {
-          assert.sameDeepMembers(results, [...expected]);
-        }
-      };
-
       it('groups by a bare path; null and absent keys merge into one null group', async () => {
         // d4 (g=null) and d5 (g absent) collapse into ONE group whose key reads
         // back as `null` (not absent) — the "absent merges into null" rule for
         // grouping. sum ignores nothing here (all n present); countAll counts rows.
-        await expectRows(
+        await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [sum(field('n')).as('s'), countAll().as('c')],
             groups: ['g'],
@@ -1636,17 +1621,19 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             { data: { g: 'y', s: 4, c: 1 } },
             { data: { g: null, s: 30, c: 2 } },
           ],
+          { ordered: false },
         );
       });
 
       it('groups by an aliased expression (the computed key is projected)', async () => {
         // greaterThan(n, 5): d1/d2/d3 → false, d4/d5 → true.
-        await expectRows(
+        await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [countAll().as('c')],
             groups: [greaterThan(field('n'), constant(5)).as('big')],
           })),
           [{ data: { big: false, c: 3 } }, { data: { big: true, c: 2 } }],
+          { ordered: false },
         );
       });
 
@@ -1654,7 +1641,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         // countAll counts all 5 rows; count(m) counts only the 3 non-null,
         // present m values (d3 null, d5 absent excluded); average(m) divides by
         // that same non-null count (18 / 3 = 6), not by 5.
-        await expectRows(
+        await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [
               sum(field('n')).as('sumN'),
@@ -1670,7 +1657,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       });
 
       it('empty input WITH groups yields zero rows', async () => {
-        await expectRows(
+        await expectPipeline(
           collectionInput(emptyColl).aggregate(() => ({
             accumulators: [countAll().as('c')],
             groups: ['g'],
@@ -1682,7 +1669,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       it('empty input WITHOUT groups yields one row with the empty values (sum/average null, countAll 0)', async () => {
         // The whole-input group always emits one row; sum and average are NULL
         // over an empty group (NOT 0, unlike SQL), while countAll is 0.
-        await expectRows(
+        await expectPipeline(
           collectionInput(emptyColl).aggregate((field) => ({
             accumulators: [
               sum(field('n')).as('s'),
@@ -1697,7 +1684,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
       it('countDistinct / countIf over the whole input', async () => {
         // countDistinct(g): distinct non-null values {x, y} → 2.
         // countIf(n > 5): d4/d5 → 2.
-        await expectRows(
+        await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [
               countDistinct(field('g')).as('distinctG'),
@@ -1725,14 +1712,13 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         // Sorted by n asc: d1(g x), d2(g x), d3(g y), d4(g null), d5(g absent).
         // first(g) is 'x' (positional); last(g) is d5's absent key merged into
         // null (kept, not skipped).
-        await expectRows(
+        await expectPipeline(
           src()
             .sort((field) => [asc(field('n'))])
             .aggregate((field) => ({
               accumulators: [first(field('g')).as('first'), last(field('g')).as('last')],
             })),
           [{ data: { first: 'x', last: null } }],
-          { ordered: true },
         );
       });
 
@@ -1740,9 +1726,10 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         // Grouping by the optional `g` alone (a distinct-like aggregate): the
         // merged null/absent group decodes with `g: null` PRESENT — the key is
         // null, never missing.
-        await expectRows(
+        await expectPipeline(
           src().aggregate(() => ({ accumulators: [countAll().as('c')], groups: ['g'] })),
           [{ data: { g: 'x', c: 2 } }, { data: { g: 'y', c: 1 } }, { data: { g: null, c: 2 } }],
+          { ordered: false },
         );
       });
     });

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1593,7 +1593,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         { id: ['d1'], data: { g: 'x', n: 1, m: 5 } },
         { id: ['d2'], data: { g: 'x', n: 2, m: 7 } },
         { id: ['d3'], data: { g: 'y', n: 4, m: null } }, // m null
-        { id: ['d4'], data: { g: null, n: 10, m: 6 } }, // g null
+        { id: ['d4'], data: { g: null, n: 0, m: 6 } }, // g null; n places it FIRST under sort
         { id: ['d5'], data: { n: 20 } }, // g absent, m absent
       ];
 
@@ -1619,20 +1619,20 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
           [
             { data: { g: 'x', s: 3, c: 2 } },
             { data: { g: 'y', s: 4, c: 1 } },
-            { data: { g: null, s: 30, c: 2 } },
+            { data: { g: null, s: 20, c: 2 } },
           ],
           { ordered: false },
         );
       });
 
       it('groups by an aliased expression (the computed key is projected)', async () => {
-        // greaterThan(n, 5): d1/d2/d3 → false, d4/d5 → true.
+        // greaterThan(n, 5): d1/d2/d3/d4 → false, d5 → true.
         await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [countAll().as('c')],
             groups: [greaterThan(field('n'), constant(5)).as('big')],
           })),
-          [{ data: { big: false, c: 3 } }, { data: { big: true, c: 2 } }],
+          [{ data: { big: false, c: 4 } }, { data: { big: true, c: 1 } }],
           { ordered: false },
         );
       });
@@ -1652,7 +1652,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
               maximum(field('n')).as('maxN'),
             ],
           })),
-          [{ data: { sumN: 37, countAll: 5, countM: 3, avgM: 6, minN: 1, maxN: 20 } }],
+          [{ data: { sumN: 27, countAll: 5, countM: 3, avgM: 6, minN: 0, maxN: 20 } }],
         );
       });
 
@@ -1683,7 +1683,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
 
       it('countDistinct / countIf over the whole input', async () => {
         // countDistinct(g): distinct non-null values {x, y} → 2.
-        // countIf(n > 5): d4/d5 → 2.
+        // countIf(n > 5): d5 only → 1.
         await expectPipeline(
           src().aggregate((field) => ({
             accumulators: [
@@ -1691,7 +1691,7 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
               countIf(greaterThan(field('n'), constant(5))).as('bigN'),
             ],
           })),
-          [{ data: { distinctG: 2, bigN: 2 } }],
+          [{ data: { distinctG: 2, bigN: 1 } }],
         );
       });
 
@@ -1708,17 +1708,19 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         assert.sameDeepMembers(row.data.vals, ['x', 'x', 'y', null]);
       });
 
-      it('first / last follow a preceding sort; last of an absent key is null (merged)', async () => {
-        // Sorted by n asc: d1(g x), d2(g x), d3(g y), d4(g null), d5(g absent).
-        // first(g) is 'x' (positional); last(g) is d5's absent key merged into
-        // null (kept, not skipped).
+      it('first / last are positional: a null value and an absent (merged-to-null) value are KEPT', async () => {
+        // Sorted by n asc: d4(g null), d1(g x), d2(g x), d3(g y), d5(g absent).
+        // DISCRIMINATING at both ends (probed the same way —
+        // .ikenox/probe-first-last.mjs): if first SKIPPED nulls it would
+        // return d1's 'x'; if last skipped absent it would return d3's 'y'.
+        // Both return null instead: null is kept, absent merges into null.
         await expectPipeline(
           src()
             .sort((field) => [asc(field('n'))])
             .aggregate((field) => ({
               accumulators: [first(field('g')).as('first'), last(field('g')).as('last')],
             })),
-          [{ data: { first: 'x', last: null } }],
+          [{ data: { first: null, last: null } }],
         );
       });
 

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -5,6 +5,7 @@ import {
   abs,
   add,
   and,
+  arrayAgg,
   arrayConcat,
   arrayContains,
   arrayContainsAll,
@@ -13,6 +14,7 @@ import {
   arrayLength,
   arrayReverse,
   arrayValue,
+  average,
   byteLength,
   ceil,
   charLength,
@@ -20,6 +22,10 @@ import {
   conditional,
   constant,
   cosineDistance,
+  count,
+  countAll,
+  countDistinct,
+  countIf,
   currentTimestamp,
   divide,
   docRefValue,
@@ -33,6 +39,7 @@ import {
   exp,
   type Expression,
   field,
+  first,
   floor,
   geoPointValue,
   greaterThan,
@@ -43,6 +50,7 @@ import {
   isAbsent,
   isError,
   isType,
+  last,
   lessThan,
   lessThanOrEqual,
   like,
@@ -51,6 +59,8 @@ import {
   logicalMaximum,
   logicalMinimum,
   ltrim,
+  maximum,
+  minimum,
   mapEntries,
   mapGet,
   mapKeys,
@@ -84,6 +94,7 @@ import {
   stringReverse,
   substring,
   subtract,
+  sum,
   timestampAdd,
   timestampDiff,
   timestampExtract,
@@ -120,6 +131,7 @@ import {
   double,
   int64,
   map,
+  nullable,
   optional,
   rootCollection,
   string,
@@ -1561,6 +1573,176 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             { id: ['a2'], data: { name: 'bob', rank: 2, score: 2 } },
             { id: ['a1'], data: { name: 'alice', rank: 1, score: 1 } },
           ],
+        );
+      });
+    });
+
+    // The `aggregate` stage, seeded to reproduce the probe matrix in
+    // docs/pipeline-query-aggregate-research.md. Oracles are hand-written FROM
+    // that doc. `aggregate` breaks read-identity, so the rows carry no `id`.
+    describe('aggregate', () => {
+      // `g` is the group key: it holds a value, `null`, OR is absent — so that
+      // the null-key and absent-key docs can be shown merging into one `null`
+      // group (hence `optional(nullable(...))`). `m` exercises count(expr) /
+      // average denominators over null + absent.
+      const aggregateCollection = rootCollection({
+        name: 'Aggregate',
+        schema: { g: optional(nullable(string())), n: int64(), m: optional(nullable(int64())) },
+      });
+      type AggregateDoc = Doc<typeof aggregateCollection>;
+      const aggregateItems: AggregateDoc[] = [
+        { id: ['d1'], data: { g: 'x', n: 1, m: 5 } },
+        { id: ['d2'], data: { g: 'x', n: 2, m: 7 } },
+        { id: ['d3'], data: { g: 'y', n: 4, m: null } }, // m null
+        { id: ['d4'], data: { g: null, n: 10, m: 6 } }, // g null
+        { id: ['d5'], data: { n: 20 } }, // g absent, m absent
+      ];
+
+      let coll: typeof aggregateCollection;
+      let emptyColl: typeof aggregateCollection;
+      beforeEach(async () => {
+        coll = uniqueCollection(aggregateCollection);
+        await createRepository(coll).batchSet(aggregateItems);
+        // A separate collection left unseeded — the empty-input cases.
+        emptyColl = uniqueCollection(aggregateCollection);
+      });
+      const src = () => collectionInput(coll);
+
+      /** Executes and compares rows (unordered by default — grouped output has no defined order). */
+      const expectRows = async <S extends DocumentSchema, Id extends PipelineRowIdentity>(
+        pipeline: Pipeline<S, Id>,
+        expected: readonly NoInfer<PipelineResult<S, Id>>[],
+        options?: { ordered?: boolean },
+      ): Promise<void> => {
+        const results = await executor.execute(pipeline);
+        if (options?.ordered === true) {
+          expect(results).toStrictEqual(expected);
+        } else {
+          assert.sameDeepMembers(results, [...expected]);
+        }
+      };
+
+      it('groups by a bare path; null and absent keys merge into one null group', async () => {
+        // d4 (g=null) and d5 (g absent) collapse into ONE group whose key reads
+        // back as `null` (not absent) — the "absent merges into null" rule for
+        // grouping. sum ignores nothing here (all n present); countAll counts rows.
+        await expectRows(
+          src().aggregate((field) => ({
+            accumulators: [sum(field('n')).as('s'), countAll().as('c')],
+            groups: ['g'],
+          })),
+          [
+            { data: { g: 'x', s: 3, c: 2 } },
+            { data: { g: 'y', s: 4, c: 1 } },
+            { data: { g: null, s: 30, c: 2 } },
+          ],
+        );
+      });
+
+      it('groups by an aliased expression (the computed key is projected)', async () => {
+        // greaterThan(n, 5): d1/d2/d3 → false, d4/d5 → true.
+        await expectRows(
+          src().aggregate((field) => ({
+            accumulators: [countAll().as('c')],
+            groups: [greaterThan(field('n'), constant(5)).as('big')],
+          })),
+          [{ data: { big: false, c: 3 } }, { data: { big: true, c: 2 } }],
+        );
+      });
+
+      it('no groups: one whole-input row (null excluded from count(expr) and the average denominator)', async () => {
+        // countAll counts all 5 rows; count(m) counts only the 3 non-null,
+        // present m values (d3 null, d5 absent excluded); average(m) divides by
+        // that same non-null count (18 / 3 = 6), not by 5.
+        await expectRows(
+          src().aggregate((field) => ({
+            accumulators: [
+              sum(field('n')).as('sumN'),
+              countAll().as('countAll'),
+              count(field('m')).as('countM'),
+              average(field('m')).as('avgM'),
+              minimum(field('n')).as('minN'),
+              maximum(field('n')).as('maxN'),
+            ],
+          })),
+          [{ data: { sumN: 37, countAll: 5, countM: 3, avgM: 6, minN: 1, maxN: 20 } }],
+        );
+      });
+
+      it('empty input WITH groups yields zero rows', async () => {
+        await expectRows(
+          collectionInput(emptyColl).aggregate(() => ({
+            accumulators: [countAll().as('c')],
+            groups: ['g'],
+          })),
+          [],
+        );
+      });
+
+      it('empty input WITHOUT groups yields one row with the empty values (sum/average null, countAll 0)', async () => {
+        // The whole-input group always emits one row; sum and average are NULL
+        // over an empty group (NOT 0, unlike SQL), while countAll is 0.
+        await expectRows(
+          collectionInput(emptyColl).aggregate((field) => ({
+            accumulators: [
+              sum(field('n')).as('s'),
+              countAll().as('c'),
+              average(field('n')).as('a'),
+            ],
+          })),
+          [{ data: { s: null, c: 0, a: null } }],
+        );
+      });
+
+      it('countDistinct / countIf over the whole input', async () => {
+        // countDistinct(g): distinct non-null values {x, y} → 2.
+        // countIf(n > 5): d4/d5 → 2.
+        await expectRows(
+          src().aggregate((field) => ({
+            accumulators: [
+              countDistinct(field('g')).as('distinctG'),
+              countIf(greaterThan(field('n'), constant(5))).as('bigN'),
+            ],
+          })),
+          [{ data: { distinctG: 2, bigN: 2 } }],
+        );
+      });
+
+      it('arrayAgg keeps null values as elements but skips absent ones', async () => {
+        // g over the five docs: 'x','x','y', null (d4), absent (d5). arrayAgg
+        // KEEPS the null but SKIPS the absent → a 4-element bag. Its order is
+        // backend-determined without a sort, so compare as a multiset.
+        const results = await executor.execute(
+          src().aggregate((field) => ({ accumulators: [arrayAgg(field('g')).as('vals')] })),
+        );
+        expect(results).toHaveLength(1);
+        const [row] = results;
+        assert(row !== undefined);
+        assert.sameDeepMembers(row.data.vals, ['x', 'x', 'y', null]);
+      });
+
+      it('first / last follow a preceding sort; last of an absent key is null (merged)', async () => {
+        // Sorted by n asc: d1(g x), d2(g x), d3(g y), d4(g null), d5(g absent).
+        // first(g) is 'x' (positional); last(g) is d5's absent key merged into
+        // null (kept, not skipped).
+        await expectRows(
+          src()
+            .sort((field) => [asc(field('n'))])
+            .aggregate((field) => ({
+              accumulators: [first(field('g')).as('first'), last(field('g')).as('last')],
+            })),
+          [{ data: { first: 'x', last: null } }],
+          { ordered: true },
+        );
+      });
+
+      it('an optional group key round-trips as null (present, not absent) in the decoded row', async () => {
+        // Grouping by the optional `g` alone (a distinct-like aggregate): the
+        // merged null/absent group decodes with `g: null` PRESENT — the key is
+        // null, never missing.
+        await expectRows(
+          src().aggregate(() => ({ accumulators: [countAll().as('c')], groups: ['g'] })),
+          [{ data: { g: 'x', c: 2 } }, { data: { g: 'y', c: 1 } }, { data: { g: null, c: 2 } }],
         );
       });
     });

--- a/packages/firestore-repository/src/pipelines/aggregate.ts
+++ b/packages/firestore-repository/src/pipelines/aggregate.ts
@@ -1,8 +1,0 @@
-import { FieldType } from '../schema.js';
-
-export type AggregateWithAlias<T extends FieldType = FieldType, Alias extends string = string> = {
-  aggregate: Aggregate<T>;
-  alias: Alias;
-};
-
-export type Aggregate<T extends FieldType> = { type: T };

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -31,7 +31,11 @@ import {
 import {
   abs,
   add,
+  AggregateFunction,
+  type AggregateWithAlias,
   and,
+  arrayAgg,
+  arrayAggDistinct,
   arrayConcat,
   arrayContains,
   arrayContainsAll,
@@ -41,6 +45,7 @@ import {
   arrayReverse,
   arrayValue,
   byteLength,
+  average,
   ceil,
   charLength,
   collectionId,
@@ -48,6 +53,10 @@ import {
   constant,
   Constant,
   cosineDistance,
+  count,
+  countAll,
+  countDistinct,
+  countIf,
   currentTimestamp,
   divide,
   DocRefValue,
@@ -63,6 +72,7 @@ import {
   type Expression,
   Field,
   field,
+  first,
   floor,
   FunctionCall,
   geoPointValue,
@@ -74,6 +84,7 @@ import {
   isAbsent,
   isError,
   isType,
+  last,
   lessThan,
   lessThanOrEqual,
   like,
@@ -82,6 +93,8 @@ import {
   logicalMaximum,
   logicalMinimum,
   ltrim,
+  maximum,
+  minimum,
   mapEntries,
   mapGet,
   mapKeys,
@@ -115,6 +128,7 @@ import {
   stringReverse,
   substring,
   subtract,
+  sum,
   timestampAdd,
   timestampDiff,
   timestampExtract,
@@ -1484,5 +1498,134 @@ describe('operand lifting mechanism (toOperand / liftOperands / liftFields)', ()
       // An expression field passes through by identity.
       expect(node.call.fields['b']).toBe(num);
     }
+  });
+});
+
+// The accumulator factories' RETURN descriptors, derived from the type
+// definitions (`AggregatePayload` members × the operand nullability the
+// `NullableStripped` / `NumericResult` / `WithoutOptional` operators fold over).
+// Oracles come from docs/pipeline-query-aggregate-research.md.
+describe('aggregate factories', () => {
+  // Representative operands across the presence/nullability axis.
+  const str = field(string(), 'name'); // plain
+  const nstr = field(nullable(string()), 'ns'); // nullable
+  const ostr = field(optional(string()), 'os'); // optional (possibly absent)
+  const pnull = field(nullType(), 'z'); // pure-null
+  const i = field(int64(), 'i'); // declared int64
+  const d = field(double(), 'd'); // declared double
+  const ni = field(nullable(int64()), 'ni'); // nullable int64
+  const mixed = field(union(int64(), double()), 'mix'); // int64 | double
+  const flag = field(bool(), 'flag');
+
+  describe('count family is always plain int64 (never null, even over nullable operands)', () => {
+    it('countAll / count / countDistinct / countIf → int64()', () => {
+      expectTypedStrictEqual(countAll().type, int64());
+      // Even over a nullable / optional operand the count itself is a plain
+      // int64 (0 on empty, never null — probed).
+      expectTypedStrictEqual(count(nstr).type, int64());
+      expectTypedStrictEqual(countDistinct(nstr).type, int64());
+      expectTypedStrictEqual(countIf(field(nullable(bool()), 'nb')).type, int64());
+      expectTypedStrictEqual(countIf(flag).type, int64());
+    });
+  });
+
+  describe('sum: nullable(NumericResult) with no double-nesting', () => {
+    it('int64 operand → nullable(int64())', () => {
+      expectTypedStrictEqual(sum(i).type, nullable(int64()));
+    });
+    it('double / mixed operand → nullable(double())', () => {
+      expectTypedStrictEqual(sum(d).type, nullable(double()));
+      expectTypedStrictEqual(sum(mixed).type, nullable(double()));
+    });
+    it('nullable(int64()) operand stays nullable(int64()) — the operand null is stripped before re-adding', () => {
+      expectTypedStrictEqual(sum(ni).type, nullable(int64()));
+    });
+  });
+
+  describe('average is always nullable(double())', () => {
+    it('over int64 and over nullable(double()) operands alike', () => {
+      expectTypedStrictEqual(average(i).type, nullable(double()));
+      expectTypedStrictEqual(average(field(nullable(double()), 'nd')).type, nullable(double()));
+    });
+  });
+
+  describe('minimum / maximum / first / last: nullable(stripped operand), pure-null degenerates to nullType()', () => {
+    // All four share the `NullableStripped` return shape — table the factories
+    // and run the operand-nullability matrix over each.
+    const extremes = [
+      ['minimum', minimum],
+      ['maximum', maximum],
+      ['first', first],
+      ['last', last],
+    ] as const;
+
+    it('plain / nullable / optional operands all yield nullable(stripped)', () => {
+      for (const [, fn] of extremes) {
+        expectTypedStrictEqual(fn(str).type, nullable(string()));
+        // A nullable operand's null is stripped then re-added — no double nest.
+        expectTypedStrictEqual(fn(nstr).type, nullable(string()));
+        // The Optional presence marker is dropped; the empty-group null re-added.
+        expectTypedStrictEqual(fn(ostr).type, nullable(string()));
+      }
+    });
+
+    it('a pure-null operand degenerates to nullType() (nothing survives stripping)', () => {
+      for (const [, fn] of extremes) {
+        expectTypedStrictEqual(fn(pnull).type, nullType());
+      }
+    });
+  });
+
+  describe('arrayAgg / arrayAggDistinct: array element drops Optional, keeps the null tag', () => {
+    const collectors = [
+      ['arrayAgg', arrayAgg],
+      ['arrayAggDistinct', arrayAggDistinct],
+    ] as const;
+
+    it('plain operand → array of the plain element', () => {
+      for (const [, fn] of collectors) {
+        expectTypedStrictEqual(fn(str).type, array(string()));
+      }
+    });
+    it('optional operand → the Optional marker is dropped from the element', () => {
+      for (const [, fn] of collectors) {
+        expectTypedStrictEqual(fn(ostr).type, array(string()));
+      }
+    });
+    it('nullable operand → the null tag is KEPT as a possible element (absent skipped, null kept — probed)', () => {
+      for (const [, fn] of collectors) {
+        expectTypedStrictEqual(fn(nstr).type, array(nullable(string())));
+      }
+    });
+  });
+
+  describe('operand-domain negatives', () => {
+    it('rejects out-of-domain operands', () => {
+      // @ts-expect-error -- sum's operand domain is numeric, not string
+      sum(str);
+      // @ts-expect-error -- countIf's condition must be boolean-valued
+      countIf(str);
+    });
+  });
+
+  describe('direct-literal lifting (factories accept raw OperandInput)', () => {
+    it('a raw numeric operand lifts exactly like its constant() form', () => {
+      // ONE representative: `sum(5)` lifts the raw 5 via constant(), so it is
+      // the SAME node (value + descriptor) as `sum(constant(5))`.
+      expectTypedStrictEqual(sum(5), sum(constant(5)));
+    });
+  });
+
+  describe('aliasing (.as) forms the aggregate selectable', () => {
+    it('wraps the accumulator in an { aggregate, alias } pair, keeping the result descriptor', () => {
+      const acc = sum(i).as('total');
+      // The alias is a literal, the aggregate is the accumulator node, and the
+      // pair shape is the aggregate selectable (a DIFFERENT shape from an
+      // expression's `{ expression, alias }`).
+      expectTypeOf(acc).toMatchTypeOf<AggregateWithAlias>();
+      expectTypeOf(acc.alias).toEqualTypeOf<'total'>();
+      expectTypedStrictEqual(acc.aggregate.type, nullable(int64()));
+      expect(acc.aggregate).toBeInstanceOf(AggregateFunction);
+    });
   });
 });

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -2822,9 +2822,11 @@ export class AggregateFunction<T extends FieldType = FieldType> {
    * `{ aggregate, alias }` selectable — the counterpart of
    * {@link ExpressionBase.as} for expressions (a distinct return type,
    * {@link AggregateWithAlias}, keeps accumulators and expressions from mixing
-   * in a selection list).
+   * in a selection list). Unlike expression aliases, the alias must be
+   * UNDOTTED: the backend rejects dotted assignment targets in `aggregate`
+   * (`TOP_LEVEL_PROPERTY_PATH_ONLY` — probed).
    */
-  as<Alias extends string>(alias: Alias): AggregateWithAlias<this, Alias> {
+  as<Alias extends string>(alias: Alias & UndottedKey<Alias>): AggregateWithAlias<this, Alias> {
     return { aggregate: this, alias };
   }
 }

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -951,10 +951,10 @@ const mayBeAbsent = (t: FieldType & { optional?: boolean }): boolean => t.option
  * that flows through a function is expressed by the `PropagateAbsence`
  * family instead.
  */
-type WithoutOptional<T extends FieldType> = T extends Optional ? Omit<T, 'optional'> : T;
+export type WithoutOptional<T extends FieldType> = T extends Optional ? Omit<T, 'optional'> : T;
 
 /** Runtime counterpart of {@link WithoutOptional}. */
-const withoutOptional = (t: FieldType & { optional?: boolean }): FieldType => {
+export const withoutOptional = (t: FieldType & { optional?: boolean }): FieldType => {
   if (t.optional !== true) {
     return t;
   }
@@ -2789,3 +2789,221 @@ export const vectorLength = <const Op extends VectorOperandInput>(
   const v = toOperand(vector);
   return new FunctionCall(propagateNull([v], int64()), { name: 'vectorLength', vector: v });
 };
+
+// ---- aggregates ----
+// Accumulator functions of the `aggregate` stage — the SDK's
+// `AggregateFunction`. Kept a SEPARATE mini-tree, NOT an `Expression` member,
+// so misplacing an accumulator where a value expression is expected
+// (`where(sum(...))`, `select(...)`) is a type error rather than a runtime
+// failure. Return descriptors follow the probed accumulator semantics —
+// docs/pipeline-query-aggregate-research.md.
+
+/**
+ * An accumulator-call AST node — the aggregate counterpart of
+ * {@link FunctionCall} (the SDK's `AggregateFunction`). Deliberately NOT an
+ * {@link Expression}: an accumulator only makes sense inside `aggregate`, so
+ * keeping it off the expression union makes misplacement
+ * (`where(sum(...))` / a `select` selection) a compile error. Named after the
+ * SDK class. Per-accumulator structure lives in the {@link AggregatePayload}
+ * union (discriminated by `name`), so executors translate a call with one
+ * exhaustive `switch (call.name)`, mirroring `FunctionCall`.
+ */
+export class AggregateFunction<T extends FieldType = FieldType> {
+  readonly kind = 'aggregateFunction';
+  readonly type: T;
+  readonly call: AggregatePayload;
+  constructor(type: T, call: AggregatePayload) {
+    this.type = type;
+    this.call = call;
+  }
+
+  /**
+   * Binds this accumulator to an output name, forming the `aggregate` stage's
+   * `{ aggregate, alias }` selectable — the counterpart of
+   * {@link ExpressionBase.as} for expressions (a distinct return type,
+   * {@link AggregateWithAlias}, keeps accumulators and expressions from mixing
+   * in a selection list).
+   */
+  as<Alias extends string>(alias: Alias): AggregateWithAlias<this, Alias> {
+    return { aggregate: this, alias };
+  }
+}
+
+/**
+ * The per-accumulator payload union, discriminated by `name`: each member
+ * states the exact named operands its accumulator takes, so an executor
+ * destructures a narrowed payload without arity checks (the
+ * {@link FunctionPayload} precedent). Operand fields are lifted `Expression`s.
+ */
+export type AggregatePayload =
+  | { name: 'countAll' }
+  | { name: 'count'; value: Expression }
+  | { name: 'countDistinct'; value: Expression }
+  | { name: 'countIf'; condition: Expression }
+  | { name: 'sum'; value: Expression }
+  | { name: 'average'; value: Expression }
+  | { name: 'minimum'; value: Expression }
+  | { name: 'maximum'; value: Expression }
+  | { name: 'first'; value: Expression }
+  | { name: 'last'; value: Expression }
+  | { name: 'arrayAgg'; value: Expression }
+  | { name: 'arrayAggDistinct'; value: Expression };
+
+/** The name vocabulary of every supported accumulator — {@link AggregatePayload}'s discriminant. */
+export type AggregateFunctionName = AggregatePayload['name'];
+
+/**
+ * An accumulator bound to an output name — the `aggregate` stage's selectable,
+ * built with {@link AggregateFunction.as}. The counterpart of
+ * {@link ExpressionWithAlias}, deliberately a DIFFERENT shape (`aggregate` vs
+ * `expression`) so the two cannot be interchanged in a selection list.
+ */
+export type AggregateWithAlias<
+  F extends AggregateFunction = AggregateFunction,
+  Alias extends string = string,
+> = { aggregate: F; alias: Alias };
+
+/**
+ * An accumulator's RESULT descriptor over the group: the operand's
+ * null-stripped payload plus `NullType`, or `NullType` alone for a pure-null
+ * operand. One helper covers every "may be empty / ignores nulls / keeps
+ * nulls" accumulator uniformly:
+ *
+ * - `minimum` / `maximum` ignore null and absent inputs, `first` / `last`
+ *   keep them, and every one of them is `null` over an empty group (probed) —
+ *   all three shapes collapse to "the value's kind, or null", so stripping the
+ *   operand's own null before re-adding one avoids double-nesting
+ *   (`minimum(nullable(string))` is `nullable(string)`, not
+ *   `nullable(nullable(string))`).
+ * - `sum` / `average` reuse it too: their payload
+ *   (`NumericResult` / `DoubleType`) is never itself nullable, so
+ *   null-stripping is a no-op and this yields exactly `nullable(payload)` —
+ *   the one empty-group null the no-groups row can carry (probed).
+ */
+type NullableStripped<T extends FieldType> = [StripNull<T>] extends [never]
+  ? NullType
+  : UnionType<[StripNull<T>, NullType]>;
+
+/** Runtime counterpart of {@link NullableStripped} (same bridge shape as `propagateNull`; `never` is `undefined`). */
+function nullableStripped<T extends FieldType>(t: T): NullableStripped<T>;
+function nullableStripped(t: FieldType): FieldType {
+  const stripped = stripNull(t);
+  return stripped === undefined ? nullType() : nullable(stripped);
+}
+
+/**
+ * Row count of the group — 0 over an empty group, never null (probed). No
+ * operand: it counts rows, not values.
+ */
+export const countAll = (): AggregateFunction<Int64Type> =>
+  new AggregateFunction(int64(), { name: 'countAll' });
+
+/** Counts the group's non-null values of `value` (null and absent are not counted — probed); int64, 0 on empty. */
+export const count = <const V extends OperandInput>(value: V): AggregateFunction<Int64Type> =>
+  new AggregateFunction(int64(), { name: 'count', value: toOperand(value) });
+
+/** Counts the group's DISTINCT non-null values of `value` (probed); int64, 0 on empty. */
+export const countDistinct = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<Int64Type> =>
+  new AggregateFunction(int64(), { name: 'countDistinct', value: toOperand(value) });
+
+/** Counts the rows where `condition` is exactly `true` (a null/absent/false condition is not counted — probed); int64, 0 on empty. */
+export const countIf = <const C extends BooleanOperandInput>(
+  condition: C,
+): AggregateFunction<Int64Type> =>
+  new AggregateFunction(int64(), { name: 'countIf', condition: toOperand(condition) });
+
+/**
+ * Sums the group's non-null values (nulls and absent ignored — probed).
+ * `null` (NOT 0, unlike SQL) over an empty or all-null group, so the
+ * descriptor is nullable; int64 is preserved when every value is a declared
+ * int64, double otherwise (the `NumericResult` rule — probed).
+ */
+export const sum = <const V extends NumericOperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<NumericResult<TypeOfOperand<V>>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(numericResultType([v])), { name: 'sum', value: v });
+};
+
+/**
+ * The mean of the group's non-null values (divides by the non-null count —
+ * probed). ALWAYS float64 (probed), and `null` over an empty or all-null
+ * group, so the descriptor is `nullable(double())`.
+ */
+export const average = <const V extends NumericOperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<DoubleType>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(double()), { name: 'average', value: v });
+};
+
+/**
+ * The smallest non-null value under the backend's value ordering (nulls and
+ * absent ignored — probed); `null` over an empty or all-null group. The
+ * operand's own kind, made nullable (see {@link NullableStripped}).
+ */
+export const minimum = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<TypeOfOperand<V>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(v.type), { name: 'minimum', value: v });
+};
+
+/** The largest non-null value — see {@link minimum}. */
+export const maximum = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<TypeOfOperand<V>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(v.type), { name: 'maximum', value: v });
+};
+
+/**
+ * The first value in the group (following a preceding `sort`, else
+ * backend-determined — probed). Null values are KEPT positionally (not
+ * skipped like `minimum`), absent merges into null, and an empty group is
+ * null — the operand's kind made nullable (see {@link NullableStripped}).
+ */
+export const first = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<TypeOfOperand<V>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(v.type), { name: 'first', value: v });
+};
+
+/** The last value in the group — see {@link first}. */
+export const last = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<NullableStripped<TypeOfOperand<V>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(nullableStripped(v.type), { name: 'last', value: v });
+};
+
+/**
+ * Collects the group's values into an array. Absent values are SKIPPED but
+ * null values are KEPT as elements (probed — note the asymmetry with
+ * `first`/`last`, which merge absent into null), so the element keeps the
+ * operand's null tag while dropping its `Optional` presence marker
+ * ({@link WithoutOptional}).
+ */
+export const arrayAgg = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<ArrayType<WithoutOptional<TypeOfOperand<V>>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(arrayAggType(v), { name: 'arrayAgg', value: v });
+};
+
+/** Collects the group's DISTINCT values into an array — see {@link arrayAgg}. */
+export const arrayAggDistinct = <const V extends OperandInput>(
+  value: V,
+): AggregateFunction<ArrayType<WithoutOptional<TypeOfOperand<V>>>> => {
+  const v = toOperand(value);
+  return new AggregateFunction(arrayAggType(v), { name: 'arrayAggDistinct', value: v });
+};
+
+/** Runtime counterpart of `ArrayType<WithoutOptional<V['type']>>` (same bridge shape as `propagateNull`). */
+function arrayAggType<V extends Expression>(value: V): ArrayType<WithoutOptional<V['type']>>;
+function arrayAggType(value: Expression): FieldType {
+  return array(withoutOptional(value.type));
+}

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../__test__/specification.js';
 import type { DocRef } from '../repository.js';
 import type { StringType } from '../schema.js';
-import { documentId, equal } from './expression.js';
+import { countAll, documentId, equal, sum } from './expression.js';
 import { collection, type Pipeline, type PipelineResult } from './index.js';
 import { asc } from './ordering.js';
 
@@ -95,5 +95,36 @@ describe('pipeline', () => {
     base.where((field) => equal(documentId(field('__name__')), field('name')));
     // @ts-expect-error -- a reference does not compare against a string field
     base.where((field) => equal(field('__name__'), field('name')));
+  });
+
+  it('aggregate is identity-breaking (Id = undefined): a grouped row is not a source document', () => {
+    type RowOf<P> = P extends Pipeline<infer S, infer I> ? PipelineResult<S, I> : never;
+
+    const grouped = base.aggregate((field) => ({
+      accumulators: [sum(field('rank')).as('total')],
+      groups: ['name'],
+    }));
+    // No `id` on the result rows — the identity ratchet dropped it.
+    expectTypeOf<RowOf<typeof grouped>>().not.toHaveProperty('id');
+
+    // @ts-expect-error -- an aggregate pipeline cannot pose as identity-preserving
+    const _lie: Pipeline<AuthorsCollection['schema'], DocRef<AuthorsCollection>> = grouped;
+  });
+
+  it('accumulators and expressions do not interchange across stages (misplacement is a type error)', () => {
+    // An accumulator is deliberately NOT an Expression: it only makes sense
+    // inside `aggregate`, so misplacing one where a value expression / a
+    // selection is expected is a compile error, not a runtime failure. These
+    // are compile-time claims only — the closure is never invoked, since
+    // `select`/`addFields` would eagerly fold the (ill-typed) selection.
+    const _misplacements = () => {
+      // @ts-expect-error -- an AggregateFunction is not a boolean-valued condition
+      base.where(() => countAll());
+      // @ts-expect-error -- an aggregate selectable is not a select selection
+      base.select(() => [countAll().as('n')]);
+      // @ts-expect-error -- an aggregate selectable is not an addFields selection
+      base.addFields((field) => [sum(field('rank')).as('total')]);
+    };
+    void _misplacements;
   });
 });

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -12,10 +12,12 @@ import {
   type OmitPaths,
   omitPaths,
 } from '../schema.js';
-import { AggregateWithAlias } from './aggregate.js';
+import type { AggregateWithAlias } from './expression.js';
 import { field, type Expression, type Field, type Valued } from './expression.js';
 import { Ordering } from './ordering.js';
 import {
+  type AggregateSchema,
+  buildAggregateSchema,
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
   type BuildSelectionSchema,
@@ -203,13 +205,32 @@ export class Pipeline<
   unnest(..._args: unknown[]): Pipeline<Fields, Id> {
     return unimplemented();
   }
-  aggregate(
-    _aggreate: (field: FieldProvider<Schema>) => {
-      accumulators: AggregateWithAlias[];
-      options?: { groupBy: Expression[] };
-    },
-  ): Pipeline<Fields, undefined> {
-    return unimplemented();
+  /**
+   * Groups the rows by the `groups` keys (the whole input when omitted) and
+   * reduces each group to one row of the `accumulators`. Identity-breaking
+   * (`Id = undefined`): a grouped row is not a source document.
+   *
+   * The result schema is the group keys (each made nullable — null and absent
+   * keys merge into one `null` group, probed) overlaid with the accumulator
+   * results (an accumulator alias colliding with a group name wins). With
+   * groups, an empty input yields ZERO rows; without groups, exactly ONE row
+   * carrying each accumulator's empty value (probed). See {@link AggregateSchema}.
+   */
+  // At least one accumulator is required (an aggregate with none is `distinct`).
+  aggregate<
+    const Accs extends readonly [AggregateWithAlias, ...AggregateWithAlias[]],
+    const Groups extends readonly Selection<Schema>[] = readonly [],
+  >(
+    spec: (field: FieldProvider<Schema>) => { accumulators: Accs; groups?: Groups },
+  ): Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined> {
+    const { accumulators, groups } = spec(fieldProvider(this.node.schema));
+    return new Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined>({
+      schema: buildAggregateSchema<Schema, Accs, Groups>(this.node.schema, accumulators, groups),
+      // Resolve last-wins on the groups here so the stage carries a
+      // conflict-free list that matches the schema (executors translate 1:1).
+      stage: { kind: 'aggregate', accumulators, groups: dropOverriddenSelections(groups ?? []) },
+      parent: this.node,
+    });
   }
   distinct<const Selections extends readonly Selection<Schema>[]>(
     _groups: (field: FieldProvider<Schema>) => Selections,

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -16,15 +16,17 @@ import type { AggregateWithAlias } from './expression.js';
 import { field, type Expression, type Field, type Valued } from './expression.js';
 import { Ordering } from './ordering.js';
 import {
+  type AggregateGroup,
   type AggregateSchema,
-  buildAggregateSchema,
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
-  type BuildSelectionSchema,
+  buildAggregateSchema,
   buildSelectionSchema,
+  type BuildSelectionSchema,
   dropOverriddenSelections,
   type ExpressionWithAlias,
   type Selection,
+  type UndottedGroupAliases,
 } from './selection.js';
 import type { InputStage, TransformStage } from './stage.js';
 
@@ -219,9 +221,12 @@ export class Pipeline<
   // At least one accumulator is required (an aggregate with none is `distinct`).
   aggregate<
     const Accs extends readonly [AggregateWithAlias, ...AggregateWithAlias[]],
-    const Groups extends readonly Selection<Schema>[] = readonly [],
+    const Groups extends readonly AggregateGroup<Schema>[] = readonly [],
   >(
-    spec: (field: FieldProvider<Schema>) => { accumulators: Accs; groups?: Groups },
+    spec: (field: FieldProvider<Schema>) => {
+      accumulators: Accs;
+      groups?: Groups & UndottedGroupAliases<Groups>;
+    },
   ): Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined> {
     const { accumulators, groups } = spec(fieldProvider(this.node.schema));
     return new Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined>({

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -563,11 +563,54 @@ describe('buildAggregateSchema (runtime)', () => {
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });
 
-  it('a nested (dotted) optional group key is rewritten to nullable in place', () => {
-    const oracle = { n: int64(), profile: map({ gender: nullable(literal('male', 'female')) }) };
-    const actual = buildAggregateSchema(schema, [n], ['profile.gender']);
+  it('a nested field groups via an EXPRESSION with a top-level alias; dotted forms are rejected', () => {
+    // The backend rejects dotted assignment targets in aggregate
+    // (TOP_LEVEL_PROPERTY_PATH_ONLY — probed): no dotted bare-path groups, no
+    // dotted aliases. A nested field groups through an expression whose alias
+    // is top-level; the optional LEAF still reads back nullable.
+    const genderField = field(gender, 'profile.gender');
+    const oracle = { n: int64(), gender: nullable(literal('male', 'female')) };
+    const actual = buildAggregateSchema(schema, [n], [genderField.as('gender')]);
     expect(actual).toStrictEqual(oracle);
     expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('a REQUIRED leaf under an optional ancestor reads back nullable (via the expression form)', () => {
+    // The a?.b.c shape: the leaf's nullability comes from the path CROSSING an
+    // optional ancestor (`WithConditionality`), not from the leaf's own
+    // marker — a distinct matrix cell from the leaf-optional case above.
+    // Probed live: field('a.b.c').as('c') groups the nested value and the
+    // absent-ancestor rows land in the null group.
+    const deep = { a: optional(map({ b: map({ c: string() }) })), n: int64() };
+    const nAcc = countAll().as('n');
+    const cField = field(string(), 'a.b.c');
+    const oracle = { n: int64(), c: nullable(string()) };
+    const actual = buildAggregateSchema(deep, [nAcc], [cField.as('c')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('a MAP-typed group key keeps its INNER absences; only the whole-map absence merges', () => {
+    // Probed: { b: {} } and { b: { c: 'v1' } } form DISTINCT groups (the map
+    // is compared and projected as a value), while a wholly-absent map merges
+    // into the null group — so the rewrite is SHALLOW: nullable at the top,
+    // inner optionality preserved.
+    const deep = { a: optional(map({ b: map({ c: optional(string()) }) })), n: int64() };
+    const nAcc = countAll().as('n');
+    const oracle = { n: int64(), a: nullable(map({ b: map({ c: optional(string()) }) })) };
+    const actual = buildAggregateSchema(deep, [nAcc], ['a']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('dotted group forms are rejected at the type level', () => {
+    void (() => {
+      const nAcc = countAll().as('n');
+      // @ts-expect-error -- a dotted BARE path is not a top-level group key
+      void buildAggregateSchema(schema, [nAcc], ['profile.gender']);
+      // @ts-expect-error -- a dotted accumulator alias is rejected (TOP_LEVEL_PROPERTY_PATH_ONLY)
+      void countAll().as('agg.cnt');
+    });
   });
 
   it('an accumulator alias colliding with a group name wins', () => {

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -7,19 +7,22 @@ import {
   type DocumentSchema,
   double,
   type DoubleType,
+  int64,
   literal,
   type LiteralType,
   map,
   type MapType,
+  nullable,
   optional,
   type Optional,
   string,
   type StringType,
 } from '../schema.js';
-import { constant, equal, field } from './expression.js';
+import { constant, countAll, equal, field, greaterThan, sum } from './expression.js';
 import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
+  buildAggregateSchema,
   type BuildSelectionSchema,
   buildSelectionSchema,
   type ExpressionWithAlias,
@@ -498,6 +501,80 @@ describe('buildSelectionSchema (runtime)', () => {
     // keys. See `ExpressionBase.as`.
     const oracle = { a: map({ __name__: schema.name }) };
     const actual = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+});
+
+// Stage-schema synthesis of the `aggregate` stage. Each case asserts one
+// hand-written oracle on BOTH sides — `toStrictEqual` for the runtime value and
+// `expectTypeOf(...).toEqualTypeOf(oracle)` for the type-level computation (the
+// return type IS `AggregateSchema<...>`) — the safety net for the bridging
+// assertion inside `buildAggregateSchema`. Oracles derive from the
+// `AggregateSchema` operators: `AccumulatorSchema` merged (A-wins) on top of
+// `AbsentMergesIntoNull<BuildSelectionSchema<groups>>`.
+describe('buildAggregateSchema (runtime)', () => {
+  const gender = optional(literal('male', 'female'));
+  const profile = map({ age: double(), gender });
+  const schema = {
+    name: string(),
+    g: string(),
+    opt: optional(string()),
+    profile,
+    rank: double(),
+  } satisfies DocumentSchema;
+
+  const total = sum(field(schema.rank, 'rank')).as('total');
+  const n = countAll().as('n');
+
+  it('accumulators only (no groups): a flat alias -> descriptor record', () => {
+    // sum(double) is nullable (the empty no-groups row carries null); countAll
+    // is a plain int64 (0, never null).
+    const oracle = { total: nullable(double()), n: int64() };
+    const actual = buildAggregateSchema(schema, [total, n]);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('a bare-path group key passes through unchanged (non-optional stays as-is)', () => {
+    const oracle = { n: int64(), g: string() };
+    const actual = buildAggregateSchema(schema, [n], ['g']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('an aliased-expression group projects the expression at its alias', () => {
+    const oracle = { n: int64(), big: bool() };
+    const actual = buildAggregateSchema(
+      schema,
+      [n],
+      [greaterThan(field(schema.rank, 'rank'), constant(4)).as('big')],
+    );
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('a top-level optional group key merges absent into null (nullable, never absent)', () => {
+    // null and absent group keys merge into ONE null group (probed) — the
+    // `& Optional` field is rewritten to nullable.
+    const oracle = { n: int64(), opt: nullable(string()) };
+    const actual = buildAggregateSchema(schema, [n], ['opt']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('a nested (dotted) optional group key is rewritten to nullable in place', () => {
+    const oracle = { n: int64(), profile: map({ gender: nullable(literal('male', 'female')) }) };
+    const actual = buildAggregateSchema(schema, [n], ['profile.gender']);
+    expect(actual).toStrictEqual(oracle);
+    expectTypeOf(actual).toEqualTypeOf(oracle);
+  });
+
+  it('an accumulator alias colliding with a group name wins', () => {
+    // `MergeSchemas` puts the accumulator record first, so its `g` overlays the
+    // group key `g` — the accumulator is the more specific intent.
+    const oracle = { g: int64() };
+    const actual = buildAggregateSchema(schema, [countAll().as('g')], ['g']);
     expect(actual).toStrictEqual(oracle);
     expectTypeOf(actual).toEqualTypeOf(oracle);
   });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
 
+import { expectTypedStrictEqual } from '../__test__/assertion.js';
 import {
   array,
   type ArrayType,
@@ -342,12 +343,12 @@ describe('BuildAddFieldsSchema', () => {
 });
 
 // Runtime mirror of the `BuildSelectionSchema` type tests above. Each case
-// asserts the SAME hand-written oracle on both sides — `toStrictEqual` checks
-// the runtime value and `expectTypeOf(...).toEqualTypeOf(oracle)` checks the
-// type-level computation (the function's return type IS
-// `BuildSelectionSchema<...>`) — so a divergence between the type operators
-// and their runtime counterparts fails one of the two assertions. This is the
-// safety net for the bridging assertion inside `buildSelectionSchema`.
+// pins the SAME hand-written oracle on both sides via
+// `expectTypedStrictEqual` — the runtime value and the type-level computation
+// (the function's return type IS `BuildSelectionSchema<...>`) — so a
+// divergence between the type operators and their runtime counterparts fails
+// the assertion. This is the safety net for the bridging assertion inside
+// `buildSelectionSchema`.
 describe('buildSelectionSchema (runtime)', () => {
   const gender = optional(literal('male', 'female'));
   const profile = map({ age: double(), gender });
@@ -361,57 +362,49 @@ describe('buildSelectionSchema (runtime)', () => {
   it('returns {} for an empty selection list', () => {
     const oracle = {};
     const actual = buildSelectionSchema(schema, []);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('picks top-level fields (the exact descriptors)', () => {
     const oracle = { name: schema.name, rank: schema.rank };
     const actual = buildSelectionSchema(schema, ['name', 'rank']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('builds a nested map from a dotted path', () => {
     const oracle = { profile: map({ age: profile.fields.age }) };
     const actual = buildSelectionSchema(schema, ['profile.age']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('merges sibling dotted paths into one map', () => {
     const oracle = { profile: map({ age: profile.fields.age, gender }) };
     const actual = buildSelectionSchema(schema, ['profile.age', 'profile.gender']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('resolves an aliased expression to its expression type at the alias', () => {
     const oracle = { name: schema.name, points: schema.rank };
     const actual = buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('points')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('last-wins: the same output name selected twice', () => {
     const oracle = { name: schema.rank };
     const actual = buildSelectionSchema(schema, ['name', field(schema.rank, 'rank').as('name')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('last-wins: a child path after its parent replaces the parent subtree', () => {
     const oracle = { profile: map({ age: profile.fields.age }) };
     const actual = buildSelectionSchema(schema, ['profile', 'profile.age']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('last-wins: a parent path after its child replaces with the full subtree', () => {
     const oracle = { profile };
     const actual = buildSelectionSchema(schema, ['profile.age', 'profile']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('addFields: keeps the context and adds the selection schema on top', () => {
@@ -423,15 +416,13 @@ describe('buildSelectionSchema (runtime)', () => {
       points: schema.rank,
     };
     const actual = buildAddFieldsSchema(schema, [field(schema.rank, 'rank').as('points')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('addFields: an added field wins over an existing one on name overlap', () => {
     const oracle = { name: schema.name, profile, rank: schema.name, tag: schema.tag };
     const actual = buildAddFieldsSchema(schema, [field(schema.name, 'name').as('rank')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('addFields: a dotted alias deep-merges into the existing map', () => {
@@ -442,8 +433,7 @@ describe('buildSelectionSchema (runtime)', () => {
       tag: schema.tag,
     };
     const actual = buildAddFieldsSchema(schema, [field(schema.name, 'name').as('profile.author')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('propagates an ancestor Optional marker to the selected leaf', () => {
@@ -452,8 +442,7 @@ describe('buildSelectionSchema (runtime)', () => {
     // the projected `meta` is required while `x` becomes optional.
     const oracle = { meta: map({ x: optional(double()) }) };
     const actual = buildSelectionSchema(s, ['meta.x']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('propagates a mid-path Optional marker from deeper nesting', () => {
@@ -462,8 +451,7 @@ describe('buildSelectionSchema (runtime)', () => {
     // only the leaf carries the conditionality.
     const oracle = { a: map({ b: map({ c: optional(double()) }) }) };
     const actual = buildSelectionSchema(s, ['a.b.c']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('marks an aliased Field of a conditional path optional; computed expressions stay required', () => {
@@ -471,16 +459,14 @@ describe('buildSelectionSchema (runtime)', () => {
 
     const aliased = buildSelectionSchema(s, [field(s.meta.fields.x, 'meta.x').as('mx')]);
     const aliasedOracle = { mx: optional(double()) };
-    expect(aliased).toStrictEqual(aliasedOracle);
-    expectTypeOf(aliased).toEqualTypeOf(aliasedOracle);
+    expectTypedStrictEqual(aliased, aliasedOracle);
 
     // A computed expression always produces a value — no conditionality.
     const computed = buildSelectionSchema(s, [
       equal(field(s.meta.fields.x, 'meta.x'), constant(1)).as('isOne'),
     ]);
     const computedOracle = { isOne: bool() };
-    expect(computed).toStrictEqual(computedOracle);
-    expectTypeOf(computed).toEqualTypeOf(computedOracle);
+    expectTypedStrictEqual(computed, computedOracle);
   });
 
   it('selecting a whole optional map keeps the key itself optional', () => {
@@ -489,8 +475,7 @@ describe('buildSelectionSchema (runtime)', () => {
     // not on the leaves inside.
     const oracle = { meta: s.meta };
     const actual = buildSelectionSchema(s, ['meta']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it("treats '__name__' in an alias like any other key (no special-casing)", () => {
@@ -501,16 +486,15 @@ describe('buildSelectionSchema (runtime)', () => {
     // keys. See `ExpressionBase.as`.
     const oracle = { a: map({ __name__: schema.name }) };
     const actual = buildSelectionSchema(schema, [field(schema.name, 'name').as('a.__name__')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 });
 
-// Stage-schema synthesis of the `aggregate` stage. Each case asserts one
-// hand-written oracle on BOTH sides — `toStrictEqual` for the runtime value and
-// `expectTypeOf(...).toEqualTypeOf(oracle)` for the type-level computation (the
-// return type IS `AggregateSchema<...>`) — the safety net for the bridging
-// assertion inside `buildAggregateSchema`. Oracles derive from the
+// Stage-schema synthesis of the `aggregate` stage. Each case pins one
+// hand-written oracle on BOTH sides via `expectTypedStrictEqual` — the runtime
+// value and the type-level computation (the return type IS
+// `AggregateSchema<...>`) — the safety net for the bridging assertion inside
+// `buildAggregateSchema`. Oracles derive from the
 // `AggregateSchema` operators: `AccumulatorSchema` merged (A-wins) on top of
 // `AbsentMergesIntoNull<BuildSelectionSchema<groups>>`.
 describe('buildAggregateSchema (runtime)', () => {
@@ -532,15 +516,13 @@ describe('buildAggregateSchema (runtime)', () => {
     // is a plain int64 (0, never null).
     const oracle = { total: nullable(double()), n: int64() };
     const actual = buildAggregateSchema(schema, [total, n]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('a bare-path group key passes through unchanged (non-optional stays as-is)', () => {
     const oracle = { n: int64(), g: string() };
     const actual = buildAggregateSchema(schema, [n], ['g']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('an aliased-expression group projects the expression at its alias', () => {
@@ -550,8 +532,7 @@ describe('buildAggregateSchema (runtime)', () => {
       [n],
       [greaterThan(field(schema.rank, 'rank'), constant(4)).as('big')],
     );
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('a top-level optional group key merges absent into null (nullable, never absent)', () => {
@@ -559,8 +540,7 @@ describe('buildAggregateSchema (runtime)', () => {
     // `& Optional` field is rewritten to nullable.
     const oracle = { n: int64(), opt: nullable(string()) };
     const actual = buildAggregateSchema(schema, [n], ['opt']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('a nested field groups via an EXPRESSION with a top-level alias; dotted forms are rejected', () => {
@@ -571,8 +551,7 @@ describe('buildAggregateSchema (runtime)', () => {
     const genderField = field(gender, 'profile.gender');
     const oracle = { n: int64(), gender: nullable(literal('male', 'female')) };
     const actual = buildAggregateSchema(schema, [n], [genderField.as('gender')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('a REQUIRED leaf under an optional ancestor reads back nullable (via the expression form)', () => {
@@ -586,8 +565,7 @@ describe('buildAggregateSchema (runtime)', () => {
     const cField = field(string(), 'a.b.c');
     const oracle = { n: int64(), c: nullable(string()) };
     const actual = buildAggregateSchema(deep, [nAcc], [cField.as('c')]);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('a MAP-typed group key keeps its INNER absences; only the whole-map absence merges', () => {
@@ -599,8 +577,7 @@ describe('buildAggregateSchema (runtime)', () => {
     const nAcc = countAll().as('n');
     const oracle = { n: int64(), a: nullable(map({ b: map({ c: optional(string()) }) })) };
     const actual = buildAggregateSchema(deep, [nAcc], ['a']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 
   it('dotted group forms are rejected at the type level', () => {
@@ -618,7 +595,6 @@ describe('buildAggregateSchema (runtime)', () => {
     // group key `g` — the accumulator is the more specific intent.
     const oracle = { g: int64() };
     const actual = buildAggregateSchema(schema, [countAll().as('g')], ['g']);
-    expect(actual).toStrictEqual(oracle);
-    expectTypeOf(actual).toEqualTypeOf(oracle);
+    expectTypedStrictEqual(actual, oracle);
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -7,11 +7,20 @@ import {
   map,
   type MapFieldPath,
   type MapType,
+  nullable,
+  type NullType,
   type Optional,
   optional,
+  type UnionType,
 } from '../schema.js';
 import { assertNever } from '../util.js';
-import type { ExpressionWithAlias, Field } from './expression.js';
+import {
+  type AggregateWithAlias,
+  type ExpressionWithAlias,
+  type Field,
+  type WithoutOptional,
+  withoutOptional,
+} from './expression.js';
 
 // Re-exported for consumers of the selection model; the type itself lives in
 // `expression.ts` (it is produced by `Expression.as(...)`).
@@ -110,6 +119,81 @@ export type BuildAddFieldsSchema<
 > = Args extends readonly ExpressionWithAlias[]
   ? MergeSchemas<BuildSelectionSchema<Context, Args>, Context>
   : never;
+
+/**
+ * Output schema of the `aggregate` stage: the group keys' schema, transformed
+ * so no key can be absent ({@link AbsentMergesIntoNull}), with the accumulator
+ * results overlaid on top.
+ *
+ * The groups' {@link BuildSelectionSchema} output (identical projection rules
+ * to `distinct` — probed) is passed through {@link AbsentMergesIntoNull}
+ * because null and absent group keys merge into one `null` group (probed), so
+ * a group key reads back as nullable, never absent. The accumulator record is
+ * then merged ON TOP: an accumulator alias colliding with a group name **wins**
+ * (the accumulator is the more specific intent, and `MergeSchemas`'s
+ * first-argument-wins rule expresses it). Empty groups yield an
+ * accumulators-only schema (the whole-input group).
+ */
+export type AggregateSchema<
+  Context extends Fields,
+  Accs extends readonly AggregateWithAlias[],
+  Groups extends readonly Selection<Context>[],
+  // The `Accs extends ...` guard is always true; it defers evaluation so the
+  // result is accepted as a `DocumentSchema` (same trick as BuildAddFieldsSchema).
+> = Accs extends readonly AggregateWithAlias[]
+  ? MergeSchemas<
+      AccumulatorSchema<Accs>,
+      AbsentMergesIntoNull<BuildSelectionSchema<Context, Groups>>
+    > extends infer R extends Fields
+    ? // The `infer R extends Fields` re-binding discharges the `MapFields`
+      // constraint lazily: the merged mapped type's value positions are not
+      // PROVABLY `FieldType` while `Accs`/`Groups` are unresolved generics,
+      // so a direct use fails `Pipeline`'s schema bound.
+      R
+    : never
+  : never;
+
+/**
+ * Folds the accumulators into a flat `alias -> result descriptor` record. A
+ * later accumulator with a repeated alias wins (plain overwrite — accumulator
+ * aliases are always top-level names, so there is nothing to deep-merge,
+ * unlike the group schema).
+ */
+type AccumulatorSchema<Accs extends readonly AggregateWithAlias[]> = Accs extends readonly [
+  infer H extends AggregateWithAlias,
+  ...infer R extends readonly AggregateWithAlias[],
+]
+  ? OverwriteMerge<AccumulatorEntry<H>, AccumulatorSchema<R>>
+  : {};
+
+/** The single-entry schema an accumulator contributes: its alias mapped to its result descriptor. */
+type AccumulatorEntry<A extends AggregateWithAlias> = { [K in A['alias']]: A['aggregate']['type'] };
+
+/** Shallow overwrite merge (`B` wins per key; no deep map merge) — the accumulator fold's combiner. */
+type OverwriteMerge<A, B> = {
+  [K in keyof A | keyof B]: K extends keyof B ? B[K] : K extends keyof A ? A[K] : never;
+};
+
+/**
+ * Rewrites every `X & Optional` field — at ANY map depth — to
+ * `UnionType<[WithoutOptional<X>, NullType]>`: null and absent group keys
+ * merge into one `null` group (probed), so a group key is never absent in the
+ * result schema. Recurses through nested maps (a required map may hold an
+ * optional descendant, e.g. a `profile.gender` group key), and an optional map
+ * itself is made nullable in addition to its descendants being rewritten.
+ */
+export type AbsentMergesIntoNull<S extends Fields> = {
+  [K in keyof S]: RewriteAbsentField<S[K]>;
+};
+
+type RewriteAbsentField<T extends FieldType> =
+  T extends MapType<infer F>
+    ? T extends Optional
+      ? UnionType<[MapType<AbsentMergesIntoNull<F>>, NullType]>
+      : MapType<AbsentMergesIntoNull<F>>
+    : T extends Optional
+      ? UnionType<[WithoutOptional<T>, NullType]>
+      : T;
 
 /**
  * Resolves one selection into the partial schema it contributes to the output.
@@ -238,6 +322,60 @@ export const buildAddFieldsSchema = <
     foldSelections(schema, dropOverriddenSelections(selections)),
     schema,
   ) as BuildAddFieldsSchema<Context, Selections>;
+
+/**
+ * Runtime counterpart of {@link AggregateSchema}: computed with the same
+ * decomposition as the type —
+ * `mergeSchemas(accumulatorSchema(...), absentMergesIntoNull(buildSelectionSchema(...)))`
+ * mirrors `MergeSchemas<AccumulatorSchema<...>, AbsentMergesIntoNull<BuildSelectionSchema<...>>>`,
+ * so each step can be checked against its type-level twin. The result feeds
+ * the executors' row decoding, so it must mirror the type exactly — the tests
+ * in `selection.test.ts` are the safety net for the bridging assertion.
+ */
+export const buildAggregateSchema = <
+  Context extends Fields,
+  const Accs extends readonly AggregateWithAlias[],
+  const Groups extends readonly Selection<Context>[] = readonly [],
+>(
+  schema: Context,
+  accumulators: Accs,
+  groups?: Groups,
+): AggregateSchema<Context, Accs, Groups> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `AggregateSchema`, but the compiler cannot connect a runtime schema value to the type-level result
+  mergeSchemas(
+    accumulatorSchema(accumulators),
+    absentMergesIntoNull(buildSelectionSchema(schema, groups ?? [])),
+  ) as AggregateSchema<Context, Accs, Groups>;
+
+/**
+ * Runtime counterpart of {@link AccumulatorSchema}: a flat `alias -> descriptor`
+ * record built by iterating in order, so a repeated alias's later entry wins
+ * (mirrors the type's `OverwriteMerge` fold).
+ */
+const accumulatorSchema = (accumulators: readonly AggregateWithAlias[]): Fields => {
+  const result: Record<string, FieldType> = {};
+  for (const { aggregate, alias } of accumulators) {
+    result[alias] = aggregate.type;
+  }
+  return result;
+};
+
+/** Runtime counterpart of {@link AbsentMergesIntoNull}. */
+const absentMergesIntoNull = (schema: Fields): Fields =>
+  Object.fromEntries(Object.entries(schema).map(([k, v]) => [k, rewriteAbsentField(v)]));
+
+/** Runtime counterpart of {@link RewriteAbsentField}. */
+const rewriteAbsentField = (t: FieldType & { optional?: boolean }): FieldType => {
+  // Read the marker before `isMapType` narrows the descriptor to `AnyMapType`
+  // (narrowing drops the `optional?` part of the intersection) — the
+  // `isConditionalPath` precedent.
+  const isOptional = t.optional === true;
+  if (isMapType(t)) {
+    const inner = map(absentMergesIntoNull(t.fields));
+    return isOptional ? nullable(inner) : inner;
+  }
+  return isOptional ? nullable(withoutOptional(t)) : t;
+};
 
 /**
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -43,6 +43,30 @@ type Fields = DocumentSchema;
 export type Selection<Context extends Fields> = MapFieldPath<Context> | ExpressionWithAlias;
 
 /**
+ * A group selection of the `aggregate` stage: a TOP-LEVEL bare field path, or
+ * an aliased expression whose alias is undotted. The backend rejects dotted
+ * assignment targets in `aggregate` (`TOP_LEVEL_PROPERTY_PATH_ONLY` — probed:
+ * both a dotted bare path AND a dotted alias are INVALID_ARGUMENT), so unlike
+ * `select`'s {@link Selection} there is no nested output form — group a
+ * NESTED field via an expression with a top-level alias:
+ * `field('a.b.c').as('c')`.
+ */
+export type AggregateGroup<Context extends Fields> = (keyof Context & string) | ExpressionWithAlias;
+
+/**
+ * The undotted-alias guard for a groups tuple (applied as a parameter
+ * intersection, the `WithoutDottedKeys` precedent): an aliased group whose
+ * alias contains the path separator collapses to `never`.
+ */
+export type UndottedGroupAliases<G> = {
+  [I in keyof G]: G[I] extends { alias: infer A extends string }
+    ? A extends `${string}.${string}`
+      ? never
+      : G[I]
+    : G[I];
+};
+
+/**
  * Folds a tuple of selections into a single nested output schema.
  *
  * Conflicting paths follow **last-wins**: when one path equals or is a dotted
@@ -137,7 +161,7 @@ export type BuildAddFieldsSchema<
 export type AggregateSchema<
   Context extends Fields,
   Accs extends readonly AggregateWithAlias[],
-  Groups extends readonly Selection<Context>[],
+  Groups extends readonly AggregateGroup<Context>[],
   // The `Accs extends ...` guard is always true; it defers evaluation so the
   // result is accepted as a `DocumentSchema` (same trick as BuildAddFieldsSchema).
 > = Accs extends readonly AggregateWithAlias[]
@@ -178,22 +202,20 @@ type OverwriteMerge<A, B> = {
  * Rewrites every `X & Optional` field — at ANY map depth — to
  * `UnionType<[WithoutOptional<X>, NullType]>`: null and absent group keys
  * merge into one `null` group (probed), so a group key is never absent in the
- * result schema. Recurses through nested maps (a required map may hold an
- * optional descendant, e.g. a `profile.gender` group key), and an optional map
- * itself is made nullable in addition to its descendants being rewritten.
+ * result schema. SHALLOW by design: group outputs are always TOP-LEVEL keys
+ * (the backend rejects dotted assignment targets in `aggregate` —
+ * `TOP_LEVEL_PROPERTY_PATH_ONLY`, probed), and a MAP-typed group key keeps
+ * its inner absences intact — the map is compared and projected AS A VALUE
+ * (probed: `{ b: {} }` and `{ b: { c: 'v1' } }` form distinct groups; only
+ * the wholly-absent map merges into the null group).
  */
 export type AbsentMergesIntoNull<S extends Fields> = {
   [K in keyof S]: RewriteAbsentField<S[K]>;
 };
 
-type RewriteAbsentField<T extends FieldType> =
-  T extends MapType<infer F>
-    ? T extends Optional
-      ? UnionType<[MapType<AbsentMergesIntoNull<F>>, NullType]>
-      : MapType<AbsentMergesIntoNull<F>>
-    : T extends Optional
-      ? UnionType<[WithoutOptional<T>, NullType]>
-      : T;
+type RewriteAbsentField<T extends FieldType> = T extends Optional
+  ? UnionType<[WithoutOptional<T>, NullType]>
+  : T;
 
 /**
  * Resolves one selection into the partial schema it contributes to the output.
@@ -335,7 +357,7 @@ export const buildAddFieldsSchema = <
 export const buildAggregateSchema = <
   Context extends Fields,
   const Accs extends readonly AggregateWithAlias[],
-  const Groups extends readonly Selection<Context>[] = readonly [],
+  const Groups extends readonly AggregateGroup<Context>[] = readonly [],
 >(
   schema: Context,
   accumulators: Accs,
@@ -365,17 +387,8 @@ const absentMergesIntoNull = (schema: Fields): Fields =>
   Object.fromEntries(Object.entries(schema).map(([k, v]) => [k, rewriteAbsentField(v)]));
 
 /** Runtime counterpart of {@link RewriteAbsentField}. */
-const rewriteAbsentField = (t: FieldType & { optional?: boolean }): FieldType => {
-  // Read the marker before `isMapType` narrows the descriptor to `AnyMapType`
-  // (narrowing drops the `optional?` part of the intersection) — the
-  // `isConditionalPath` precedent.
-  const isOptional = t.optional === true;
-  if (isMapType(t)) {
-    const inner = map(absentMergesIntoNull(t.fields));
-    return isOptional ? nullable(inner) : inner;
-  }
-  return isOptional ? nullable(withoutOptional(t)) : t;
-};
+const rewriteAbsentField = (t: FieldType & { optional?: boolean }): FieldType =>
+  t.optional === true ? nullable(withoutOptional(t)) : t;
 
 /**
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,5 +1,5 @@
 import type { Collection } from '../schema.js';
-import type { Expression, ExpressionWithAlias, Valued } from './expression.js';
+import type { AggregateWithAlias, Expression, ExpressionWithAlias, Valued } from './expression.js';
 import type { Ordering } from './ordering.js';
 
 /**
@@ -44,7 +44,16 @@ export type TransformStage =
   | { kind: 'limit'; limit: number }
   | { kind: 'offset'; offset: number }
   | { kind: 'unnest' }
-  | { kind: 'aggregate' }
+  // `accumulators` are the aliased accumulator calls; `groups` are the group
+  // keys post-conflict-resolution (last-wins applied by `Pipeline.aggregate`,
+  // mirroring `select`), so an executor translates both 1:1. Empty `groups`
+  // means the whole-input group (one row; empty input yields exactly one row —
+  // probed).
+  | {
+      kind: 'aggregate';
+      accumulators: readonly AggregateWithAlias[];
+      groups: readonly (string | ExpressionWithAlias)[];
+    }
   | { kind: 'distinct' }
   | { kind: 'replaceWith' }
   | { kind: 'union' }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -8,6 +8,8 @@ import {
   GeoPointValue,
   VectorValue,
   ExpressionWithAlias,
+  type AggregateFunctionName,
+  type AggregatePayload,
   type FunctionName,
   type FunctionPayload,
 } from 'firestore-repository/pipelines/expression';
@@ -108,6 +110,17 @@ const applyStage = (
       }
       return sdk.addFields(first, ...rest);
     }
+    case 'aggregate': {
+      // Always the options-object form (uniform; the variadic accumulator form
+      // is client sugar). `accumulators` are the aliased accumulator calls;
+      // `groups` translate like `select` selections — a bare path becomes a
+      // `Field`, an aliased expression becomes the translated expression `.as`.
+      const accumulators = stage.accumulators.map(({ aggregate, alias }) =>
+        dispatchAggregate(aggregate.call, (e) => toSdkExpression(db, e)).as(alias),
+      );
+      const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
+      return sdk.aggregate({ accumulators, groups });
+    }
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
@@ -117,7 +130,6 @@ const applyStage = (
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
-    case 'aggregate':
     case 'distinct':
     case 'replaceWith':
     case 'union':
@@ -440,6 +452,48 @@ const functionTranslators: FunctionTranslators = {
   dotProduct: (c, t) => Pipelines.dotProduct(t(c.left), t(c.right)),
   euclideanDistance: (c, t) => Pipelines.euclideanDistance(t(c.left), t(c.right)),
   vectorLength: (c, t) => Pipelines.vectorLength(t(c.vector)),
+};
+
+/**
+ * Dispatches an accumulator payload to its {@link aggregateTranslators} entry —
+ * the aggregate counterpart of {@link dispatchFunctionCall}. Generic over the
+ * concrete accumulator name `K` so the indexed table lookup and the narrowed
+ * payload stay correlated against the SAME `Extract<AggregatePayload,
+ * { name: K }>` (no type assertion).
+ */
+const dispatchAggregate = <K extends AggregateFunctionName>(
+  call: Extract<AggregatePayload, { name: K }>,
+  translate: Translate,
+): Pipelines.AggregateFunction => aggregateTranslators[call.name](call, translate);
+
+/**
+ * Per-accumulator translation into the SDK, keyed by accumulator name — the
+ * single source a newly added {@link AggregateFunctionName} must extend (a
+ * missing key fails to compile), mirroring {@link functionTranslators}. Every
+ * accumulator has a standalone SDK factory taking an `Expression`; `countIf`
+ * takes a `BooleanExpression`, so its operand is wrapped with `asBoolean()` (a
+ * type-tag only, no wire change).
+ */
+type AggregateTranslators = {
+  [K in AggregateFunctionName]: (
+    call: Extract<AggregatePayload, { name: K }>,
+    t: Translate,
+  ) => Pipelines.AggregateFunction;
+};
+
+const aggregateTranslators: AggregateTranslators = {
+  countAll: () => Pipelines.countAll(),
+  count: (c, t) => Pipelines.count(t(c.value)),
+  countDistinct: (c, t) => Pipelines.countDistinct(t(c.value)),
+  countIf: (c, t) => Pipelines.countIf(t(c.condition).asBoolean()),
+  sum: (c, t) => Pipelines.sum(t(c.value)),
+  average: (c, t) => Pipelines.average(t(c.value)),
+  minimum: (c, t) => Pipelines.minimum(t(c.value)),
+  maximum: (c, t) => Pipelines.maximum(t(c.value)),
+  first: (c, t) => Pipelines.first(t(c.value)),
+  last: (c, t) => Pipelines.last(t(c.value)),
+  arrayAgg: (c, t) => Pipelines.arrayAgg(t(c.value)),
+  arrayAggDistinct: (c, t) => Pipelines.arrayAggDistinct(t(c.value)),
 };
 
 /** `Array.isArray` narrows poorly over readonly-array unions — a dedicated guard does. */


### PR DESCRIPTION
## Summary

Implements the `aggregate` stage end-to-end: the `AggregateFunction` accumulator mini-tree, the stage with grouped-schema synthesis, both executors, and a live catalog pinning the probed semantics (see the new `docs/pipeline-query-aggregate-research.md` from the probe session).

## Design

- **`AggregateFunction`** (the SDK's name) — a payload-union mini-tree like `FunctionCall`, deliberately NOT an `Expression` member: `where(sum(...))` is a type error. All 12 factories (`sum`/`average`/`count`/`countAll`/`countDistinct`/`countIf`/`minimum`/`maximum`/`first`/`last`/`arrayAgg`/`arrayAggDistinct`), operands riding the direct-literal lifting rule.
- **Probed return descriptors**: count family plain `int64()` (0 on empty, never null); `sum` → `nullable(NumericResult)` (null over an empty group — NOT 0, unlike SQL); `average` → `nullable(double())`; `minimum`/`maximum`/`first`/`last` → `NullableStripped` (strip-then-one-null — ignored nulls, kept nulls, and the empty group in one shape); `arrayAgg*` element drops `Optional`, keeps the null tag (absent skipped, null kept).
- **Stage**: `aggregate((field) => ({ accumulators, groups? }))` → `Pipeline<AggregateSchema, undefined>`. `AggregateSchema` = the groups' `BuildSelection` output through **`AbsentMergesIntoNull`** (probed: null and absent group keys merge into ONE null group, so a group key is never absent — every `X & Optional` becomes `nullable(X)` at any depth) + the accumulator overlay (accumulator wins on alias collision). The `MapFields` bound is discharged lazily (`infer R extends Fields`) — the merged mapped type isn't provably `FieldType`-valued over unresolved generics.
- **Executors**: one `aggregateTranslators` mapped table per adapter (generic dispatch, no assertions, exhaustive over `AggregateFunctionName`); groups translate like select selections; always the options-object SDK form.

## Verification

- `pnpm check` — 0 errors
- Emulator + **live** pipeline spec: **709 passed** — the live aggregate catalog reproduces the probe matrix (grouped null/absent-key merge into one `null` row, empty input ×(groups/no-groups), `count` vs `countAll` null exclusion, `first`/`last` after `sort`, `arrayAgg` null-kept/absent-skipped)

## Process

Design settled in dialogue (naming per SDK, descriptor table from the probe session); implemented by two Opus subagents with one hand-resolved type-constraint discharge; reviewed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)