### PR TITLE
Pipeline distinct stage

### DIFF
--- a/docs/coding-guideline.md
+++ b/docs/coding-guideline.md
@@ -189,15 +189,30 @@ the types lie about runtime values. To keep them checkable:
   step can be reviewed against its twin, including branch-for-branch behavior
   (e.g. a per-recursion-level guard in the type must sit at the same level in
   the runtime helper).
-- **Confine the bridging assertion to the entry point** (the one function that
-  returns the type-level result), never inside the helpers.
+- **Keep the correspondence element by element: type each runtime helper as its
+  own type-level twin.** `dropOverriddenSelections` returns
+  `DropOverriddenSelections<Args>`, `foldSelections` returns
+  `FoldSelections<...>`, and so on — so each helper's assertion claims exactly
+  ONE step, and the compiler verifies that the steps COMPOSE. Do not type the
+  helpers loosely (`Fields`, `S[]`) and bridge only at the entry point: one
+  assertion spanning a whole chain swallows a divergence anywhere inside it,
+  and the loose signatures hide the mismatches that matter most (a type-level
+  operator that drops tuple elements paired with a runtime whose value type
+  drops nothing). This is the "isolate the assertion to the narrowest spot"
+  rule of §Type assertions, applied to mirrored computations.
+- **More assertions is the right trade here.** Optimize for WHERE the
+  type↔value correspondence is checked, not for how few assertions there are:
+  a step-local assertion fails at the step that broke, while a single top-level
+  one is bug-prone precisely because it cannot. Expect the constraint-discharge
+  idiom (`... extends infer R extends Fields ? R : never`) at several steps —
+  over unresolved generics a mapped type's value positions are not provably
+  `FieldType`.
 - **Test both sides against one oracle.** For each case, write a single
-  hand-written expected value and assert it twice: `toStrictEqual(oracle)`
-  checks the runtime value, `expectTypeOf(actual).toEqualTypeOf(oracle)`
-  checks the type-level computation (the function's return type IS the
-  type-level operator applied to the inputs). If either side drifts, one of
-  the two assertions fails. See `buildSelectionSchema (runtime)` in
-  `pipelines/selection.test.ts`.
+  hand-written expected value and pin it with `expectTypedStrictEqual(actual,
+oracle)` — the runtime value and the type-level computation together (the
+  function's return type IS the type-level operator applied to the inputs). If
+  either side drifts, the assertion fails. See §Test assertions and
+  `buildSelectionSchema (runtime)` in `pipelines/selection.test.ts`.
 
 ## Declaration order
 

--- a/docs/pipeline-query-aggregate-research.md
+++ b/docs/pipeline-query-aggregate-research.md
@@ -66,11 +66,20 @@ absent]` sorted), `first` returns null (a skip would return `y1`) and
   Library consequence: the `AbsentMergesIntoNull` rewrite is SHALLOW —
   nullable at the top of each group key, inner optionality untouched.
 
-## `distinct` stage
+## `distinct` stage (probed: `.ikenox/probe-distinct.mjs`)
 
-- Same projection and null/absent-merge rules as grouping; expression
-  aliases work. Semantically a grouped aggregate with zero accumulators —
-  the library can share the groups machinery.
+- Semantically a grouped aggregate with zero accumulators — EVERY probed
+  group rule carries over verbatim, so the library shares the groups
+  machinery:
+  - dotted bare-path groups AND dotted aliases → INVALID_ARGUMENT
+    (TOP_LEVEL_PROPERTY_PATH_ONLY); nested fields go through an expression
+    with a top-level alias (`field('a.b.c').as('c')`).
+  - null and absent keys merge into ONE null row (including
+    absent-ancestor docs under the expression form).
+  - a MAP-typed key is compared as a value — inner absences preserved
+    (`{b:{}}` vs `{b:{c:'v1'}}` are distinct rows); only the wholly-absent
+    map merges into the null row.
+  - empty input → zero rows.
 
 ## Library consequences (design)
 

--- a/docs/pipeline-query-aggregate-research.md
+++ b/docs/pipeline-query-aggregate-research.md
@@ -54,12 +54,20 @@ absent]` sorted), `first` returns null (a skip would return `y1`) and
 ## Output shape restrictions (probed: `TOP_LEVEL_PROPERTY_PATH_ONLY`)
 
 - **`aggregate` assigns TOP-LEVEL fields only**: a dotted bare-path group
-  (`groups: ['a.b.c']`) AND a dotted alias (on a group or an accumulator)
-  are both INVALID_ARGUMENT. A nested field groups via an expression with a
-  top-level alias: `field('a.b.c').as('c')` — its rows carry `c: 'v1'` /
-  `c: null`, with absent-ancestor docs merging into the null group like any
-  other absent key. (The backend's backtick escape hatch — a literal dotted
-  KEY — conflicts with the library's dotted-key ban and is not supported.)
+  (`groups: ['a.b.c']`), a dotted UNALIASED `field('a.b.c')` group, AND a
+  dotted alias (on a group or an accumulator) are all INVALID_ARGUMENT. A
+  nested field groups via an expression with a top-level alias:
+  `field('a.b.c').as('c')` — its rows carry `c: 'v1'` / `c: null`, with
+  absent-ancestor docs merging into the null group like any other absent key.
+  (The backend's backtick escape hatch — a literal dotted KEY — conflicts with
+  the library's dotted-key ban and is not supported.)
+- **An UNALIASED `Field` IS a valid group** when its path is top-level
+  (probed: `.ikenox/probe-distinct-barefield.mjs` — a bare `field('g')` is
+  accepted in both `aggregate` and `distinct`, and its row key is `g`). A
+  `Field` is inherently aliased: its path is its output name (the SDK models
+  it as a `Selectable`). The restriction is purely the top-level one above, so
+  the library accepts a bare `Field` wherever a selection is accepted and
+  rejects a dotted one through the same guard that rejects a dotted alias.
 - **A MAP-typed group key is compared and projected AS A VALUE**: inner
   absences are preserved (`{ b: {} }` and `{ b: { c: 'v1' } }` form
   DISTINCT groups); only the wholly-absent map merges into the null group.
@@ -71,9 +79,11 @@ absent]` sorted), `first` returns null (a skip would return `y1`) and
 - Semantically a grouped aggregate with zero accumulators — EVERY probed
   group rule carries over verbatim, so the library shares the groups
   machinery:
-  - dotted bare-path groups AND dotted aliases → INVALID_ARGUMENT
-    (TOP_LEVEL_PROPERTY_PATH_ONLY); nested fields go through an expression
-    with a top-level alias (`field('a.b.c').as('c')`).
+  - dotted bare-path groups, dotted UNALIASED `field(...)` groups AND dotted
+    aliases → INVALID_ARGUMENT (TOP_LEVEL_PROPERTY_PATH_ONLY); nested fields
+    go through an expression with a top-level alias (`field('a.b.c').as('c')`).
+  - an unaliased TOP-LEVEL `field('g')` group is accepted, keyed by its own
+    path (`.ikenox/probe-distinct-barefield.mjs`).
   - null and absent keys merge into ONE null row (including
     absent-ancestor docs under the expression form).
   - a MAP-typed key is compared as a value — inner absences preserved

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -613,6 +613,33 @@ Items agreed in discussion but previously recorded only inline in DONE notes
 nullable(T)`); count family unaffected. Also probe the un-probed
       all-null-group cell (nullable operand, every value null in a group)
       before relying on it.
+- [ ] **Make "a selectable" a first-class concept** (agreed 2026-07, after the
+      bare-`Field` selection landed). A `Field` is NOT a kind of
+      `ExpressionWithAlias`: the latter is a BINDING (`{ expression, alias }`),
+      the former is a NODE — different layers, so neither contains the other.
+      What they share is "something that names ONE output", which the official
+      SDK models as the `Selectable` interface that `Field` and
+      `AliasedExpression` implement INDEPENDENTLY. This library has the same
+      concept, but it is currently spelled as a type-erased implementation
+      detail (`SelectionNode = string | Field | ExpressionWithAlias`; the string
+      path is our third form, which the SDK lacks) — so the same "which output
+      name, which schema contribution" judgment is re-derived at SIX sites: the
+      types `SelectionPath` / `SelectionToSchema` / `UndottedGroupAliases`, the
+      runtime `selectionPath` / `selectionToSchema`, and both executors'
+      `toSdkSelectable`. Fix: promote the concept (name it for what it is, not
+      for its erasure) and define its two operations — output path, and schema
+      contribution — ONCE, with every call site delegating to them; the
+      per-form arms then live inside those operations instead of being
+      rewritten per site. NOT the alternative considered and rejected:
+      normalizing `Field` into `{ expression: f, alias: f.path }` at the stage
+      boundary — it collapses the node/binding layers to save arms, and it also
+      loses what the user wrote in the stage payload. Also rejected: giving
+      `Field` `expression`/`alias` members so it structurally satisfies
+      `ExpressionWithAlias` — that would silently let a bare `Field` into
+      `addFields`, whose bare-form exclusion is deliberate (see
+      `BuildAddFieldsSchema`). Note one arm is irreducible: `UndottedGroupAliases`
+      is a parameter intersection over the user's un-normalized tuple, so it
+      must keep matching the input forms directly.
 - [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):
       the aggregate node ships as `AggregateFunction` (the SDK's name), which
       makes the pair with the expression node asymmetric — rename

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -283,7 +283,12 @@ Transformation stages already stubbed:
       mirror of `OmitPaths`, incl. the Optional marker and the empty-map cascade),
       stage carries the field paths, executors translate to `sdk.removeFields(...)`,
       identity preserved (`Id` threads through). Verified live.
-- [ ] `distinct(...)` — Context shrinkage + identity break.
+- [x] `distinct(...)` — a grouped aggregate with ZERO accumulators, sharing the
+      group machinery (probed: every group rule carries over —
+      TOP_LEVEL_PROPERTY_PATH_ONLY, null/absent merge, shallow map rewrite,
+      empty input → zero rows). `DistinctSchema` = the shared `GroupSchema`
+      operator; nonempty `AggregateGroup` tuple + `UndottedGroupAliases`;
+      identity break. Both executors via `sdk.distinct({ groups })`. Verified live.
 - [x] `limit(N)` / `offset(N)` — stages carry the count, executors translate
       to `sdk.limit/offset`, schema unchanged, identity preserved. Verified live
       incl. offset+limit paging and an over-sized limit.

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -122,7 +122,6 @@ import {
   DocRefValue,
   GeoPointValue,
   VectorValue,
-  ExpressionWithAlias,
   type AggregateFunctionName,
   type AggregatePayload,
   type FunctionName,
@@ -135,6 +134,7 @@ import type {
   PipelineResult,
   PipelineRowIdentity,
 } from 'firestore-repository/pipelines/pipeline';
+import type { SelectionNode } from 'firestore-repository/pipelines/selection';
 import type { TransformStage } from 'firestore-repository/pipelines/stage';
 import type { Collection, DocumentSchema } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
@@ -260,13 +260,17 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
 };
 
 /**
- * Translates a selection (bare path or aliased expression) into an SDK
- * selectable. A bare path becomes a `Field`, which implements `Selectable`
- * with its own path as the alias — the same wire proto as the SDK's string
- * handling for `select`, in the form `addFields` also accepts.
+ * Translates a selection (bare path, bare `Field`, or aliased expression) into
+ * an SDK selectable. Both bare forms become an SDK `Field`, which implements
+ * `Selectable` with its own path as the alias — the same wire proto as the
+ * SDK's string handling for `select`, in the form `addFields` also accepts.
  */
-const toSdkSelectable = (db: Firestore, s: string | ExpressionWithAlias): SdkSelectable =>
-  typeof s === 'string' ? field(s) : toSdkExpression(db, s.expression).as(s.alias);
+const toSdkSelectable = (db: Firestore, s: SelectionNode): SdkSelectable =>
+  typeof s === 'string'
+    ? field(s)
+    : 'alias' in s
+      ? toSdkExpression(db, s.expression).as(s.alias)
+      : field(s.path);
 
 /**
  * Translates the repository expression AST into an SDK expression. Threads

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -232,6 +232,12 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
       const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
       return sdk.aggregate({ accumulators, groups });
     }
+    case 'distinct': {
+      // A grouped aggregate with zero accumulators — the options-object form
+      // takes `groups`, translated exactly like the aggregate arm's groups.
+      const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
+      return sdk.distinct({ groups });
+    }
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
@@ -241,7 +247,6 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
-    case 'distinct':
     case 'replaceWith':
     case 'union':
     case 'findNearest':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1735,5 +1735,95 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
     });
+
+    // The `distinct` stage, seeded to reproduce the probe rules in
+    // docs/pipeline-query-aggregate-research.md's `distinct` section. `distinct`
+    // is a grouped aggregate with zero accumulators, so it breaks read-identity
+    // (rows carry no `id`) and every group rule carries over. Oracles are
+    // hand-written FROM that doc; multi-row outputs are order-independent
+    // (`{ ordered: false }`).
+    describe('distinct', () => {
+      // `cat` is always present (no null) — the clean duplicate-collapse key.
+      // `g` holds a value, `null`, OR is absent — so the null-key and
+      // absent-key docs demonstrate merging into one `null` row. `p.q` (an
+      // optional leaf under a required map) is grouped via the EXPRESSION form
+      // (dotted bare paths are rejected — TOP_LEVEL_PROPERTY_PATH_ONLY).
+      const distinctCollection = rootCollection({
+        name: 'Distinct',
+        schema: {
+          cat: string(),
+          g: optional(nullable(string())),
+          n: int64(),
+          p: map({ q: optional(string()) }),
+        },
+      });
+      type DistinctDoc = Doc<typeof distinctCollection>;
+      const distinctItems: DistinctDoc[] = [
+        { id: ['d1'], data: { cat: 'x', g: 'k', n: 1, p: { q: 'a' } } },
+        { id: ['d2'], data: { cat: 'x', g: 'k', n: 2, p: { q: 'a' } } }, // dup of d1 on cat/g/q
+        { id: ['d3'], data: { cat: 'y', g: 'm', n: 8, p: { q: 'b' } } },
+        { id: ['d4'], data: { cat: 'y', g: null, n: 3, p: {} } }, // g null; q absent
+        { id: ['d5'], data: { cat: 'z', n: 9, p: { q: 'a' } } }, // g absent
+      ];
+
+      let coll: typeof distinctCollection;
+      beforeEach(async () => {
+        coll = uniqueCollection(distinctCollection);
+        await createRepository(coll).batchSet(distinctItems);
+      });
+      const src = () => collectionInput(coll);
+
+      it('collapses duplicate group values to one row per distinct value', async () => {
+        // cat: x (d1, d2), y (d3, d4), z (d5) → three distinct rows.
+        await expectPipeline(
+          src().distinct(() => ['cat']),
+          [{ data: { cat: 'x' } }, { data: { cat: 'y' } }, { data: { cat: 'z' } }],
+          { ordered: false },
+        );
+      });
+
+      it('null and absent keys merge into ONE null row', async () => {
+        // g: k (d1, d2), m (d3), null (d4), absent (d5). The null-value and the
+        // absent-key doc collapse into a single row whose key reads back `null`.
+        await expectPipeline(
+          src().distinct(() => ['g']),
+          [{ data: { g: 'k' } }, { data: { g: 'm' } }, { data: { g: null } }],
+          { ordered: false },
+        );
+      });
+
+      it('groups by an aliased expression (the computed key is projected)', async () => {
+        // greaterThan(n, 5): d1/d2/d4 → false, d3/d5 → true.
+        await expectPipeline(
+          src().distinct((field) => [greaterThan(field('n'), constant(5)).as('big')]),
+          [{ data: { big: false } }, { data: { big: true } }],
+          { ordered: false },
+        );
+      });
+
+      it('groups a nested field via the expression form; absent leaf merges into null', async () => {
+        // p.q: a (d1, d2, d5), b (d3), absent (d4 → null). A dotted bare path is
+        // rejected, so the nested field is grouped through `field('p.q').as('q')`.
+        await expectPipeline(
+          src().distinct((field) => [field('p.q').as('q')]),
+          [{ data: { q: 'a' } }, { data: { q: 'b' } }, { data: { q: null } }],
+          { ordered: false },
+        );
+      });
+
+      it('groups by multiple keys (distinct combinations)', async () => {
+        // (cat, p.q): (x,a) d1/d2, (y,b) d3, (y,null) d4, (z,a) d5 → four combos.
+        await expectPipeline(
+          src().distinct((field) => ['cat', field('p.q').as('q')]),
+          [
+            { data: { cat: 'x', q: 'a' } },
+            { data: { cat: 'y', q: 'b' } },
+            { data: { cat: 'y', q: null } },
+            { data: { cat: 'z', q: 'a' } },
+          ],
+          { ordered: false },
+        );
+      });
+    });
   });
 };

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1186,6 +1186,22 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
+      it('projects an UNALIASED field expression exactly like the bare path', async () => {
+        // A `Field` is its own alias (its path IS the output name — the SDK's
+        // `Selectable` model), so `field('profile.age')` needs no `.as(...)`
+        // and lands at the same nested position the string `'profile.age'`
+        // does. The rows below are byte-identical to the dotted-path case above.
+        await expectPipeline(
+          source().select((field) => [field('name'), field('profile.age')]),
+          [
+            { data: { name: 'alice', profile: { age: 20 } } },
+            { data: { name: 'bob', profile: { age: 30 } } },
+            { data: { name: 'carol', profile: { age: 40 } } },
+          ],
+          { ordered: false },
+        );
+      });
+
       it('projects a computed expression bound to an alias', async () => {
         await expectPipeline(
           source().select((field) => ['name', equal(field('rank'), constant(2)).as('isSecond')]),
@@ -1807,6 +1823,18 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         await expectPipeline(
           src().distinct((field) => [field('p.q').as('q')]),
           [{ data: { q: 'a' } }, { data: { q: 'b' } }, { data: { q: null } }],
+          { ordered: false },
+        );
+      });
+
+      it('groups by an UNALIASED top-level field expression, like the bare path', async () => {
+        // Probed: an unaliased top-level `field('cat')` is accepted and its row
+        // key is `cat` — the same rows the bare-path form produces above. (A
+        // dotted bare `Field` would be TOP_LEVEL_PROPERTY_PATH_ONLY, which is
+        // why it is rejected at the type level instead.)
+        await expectPipeline(
+          src().distinct((field) => [field('cat')]),
+          [{ data: { cat: 'x' } }, { data: { cat: 'y' } }, { data: { cat: 'z' } }],
           { ordered: false },
         );
       });

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -111,6 +111,35 @@ describe('pipeline', () => {
     const _lie: Pipeline<AuthorsCollection['schema'], DocRef<AuthorsCollection>> = grouped;
   });
 
+  it('distinct is identity-breaking (Id = undefined) and carries a distinct stage node', () => {
+    type RowOf<P> = P extends Pipeline<infer S, infer I> ? PipelineResult<S, I> : never;
+    type SchemaOf<P> = P extends Pipeline<infer S, infer _I> ? S : never;
+
+    const distinct = base.distinct(() => ['name']);
+    // No `id` on the result rows — a distinct row is not a source document.
+    expectTypeOf<RowOf<typeof distinct>>().not.toHaveProperty('id');
+    // The schema is EXACTLY the group key (distinct is an aggregate with zero
+    // accumulators — nothing is overlaid).
+    expectTypeOf<SchemaOf<typeof distinct>>().toEqualTypeOf<{ name: StringType }>();
+
+    // The stage node an executor walks: kind + the conflict-resolved groups.
+    expect(distinct.stages().transforms).toEqual([{ kind: 'distinct', groups: ['name'] }]);
+
+    // @ts-expect-error -- a distinct pipeline cannot pose as identity-preserving
+    const _lie: Pipeline<{ name: StringType }, DocRef<AuthorsCollection>> = distinct;
+    void _lie;
+  });
+
+  it('distinct requires at least one group and rejects dotted group aliases', () => {
+    const _rejections = () => {
+      // @ts-expect-error -- at least one group is required (an empty distinct is meaningless)
+      base.distinct(() => []);
+      // @ts-expect-error -- a dotted group alias is rejected (TOP_LEVEL_PROPERTY_PATH_ONLY)
+      base.distinct((field) => [field('profile.age').as('deep.alias')]);
+    };
+    void _rejections;
+  });
+
   it('accumulators and expressions do not interchange across stages (misplacement is a type error)', () => {
     // An accumulator is deliberately NOT an Expression: it only makes sense
     // inside `aggregate`, so misplacing one where a value expression / a

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -140,6 +140,36 @@ describe('pipeline', () => {
     void _rejections;
   });
 
+  it('an unaliased Field is a selection: accepted by select, top-level-only in groups', () => {
+    // A `Field<T, Path>` is inherently aliased — its `path` IS its alias (the
+    // SDK's `Selectable` model) — so no `.as(...)` is needed to select it.
+    // `select` allows any data path (dotted output nests); `aggregate` /
+    // `distinct` groups are TOP-LEVEL outputs only, so a dotted bare `Field`
+    // collapses through the same guard a dotted alias does
+    // (TOP_LEVEL_PROPERTY_PATH_ONLY — probed).
+    const selected = base.select((field) => [field('profile.age')]);
+    // Identical to the string form, schema and stage node alike.
+    expectTypeOf(selected).toEqualTypeOf(base.select(() => ['profile.age']));
+
+    base.distinct((field) => [field('name')]); // top-level bare Field: ok
+    base.aggregate((field) => ({ accumulators: [countAll().as('n')], groups: [field('name')] })); // top-level bare Field: ok
+
+    const _rejections = () => {
+      // @ts-expect-error -- a dotted bare Field is not a top-level group key
+      base.distinct((field) => [field('profile.age')]);
+      base.aggregate((field) => ({
+        accumulators: [countAll().as('n')],
+        // @ts-expect-error -- a dotted bare Field is not a top-level group key
+        groups: [field('profile.age')],
+      }));
+      // `addFields` deliberately keeps excluding BOTH bare forms — re-adding an
+      // existing field under its own name is meaningless. See BuildAddFieldsSchema.
+      // @ts-expect-error -- addFields takes aliased expressions only
+      base.addFields((field) => [field('rank')]);
+    };
+    void _rejections;
+  });
+
   it('accumulators and expressions do not interchange across stages (misplacement is a type error)', () => {
     // An accumulator is deliberately NOT an Expression: it only makes sense
     // inside `aggregate`, so misplacing one where a value expression / a

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -142,7 +142,7 @@ export class Pipeline<
   ): Pipeline<BuildSelectionSchema<Schema, Selections>, undefined> {
     const resolved = selections(fieldProvider(this.node.schema));
     return new Pipeline<BuildSelectionSchema<Schema, Selections>, undefined>({
-      schema: buildSelectionSchema(this.node.schema, resolved),
+      schema: buildSelectionSchema<Schema, Selections>(this.node.schema, resolved),
       // Resolve last-wins here so the stage carries a conflict-free list that
       // matches the schema (and executors translate it 1:1).
       stage: { kind: 'select', selections: dropOverriddenSelections(resolved) },
@@ -163,7 +163,7 @@ export class Pipeline<
   ): Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id> {
     const resolved = fields(fieldProvider(this.node.schema));
     return new Pipeline<BuildAddFieldsSchema<Schema, Selections>, Id>({
-      schema: buildAddFieldsSchema(this.node.schema, resolved),
+      schema: buildAddFieldsSchema<Schema, Selections>(this.node.schema, resolved),
       // Resolve last-wins here so the stage carries a conflict-free list that
       // matches the schema (and executors translate it 1:1).
       stage: { kind: 'addFields', selections: dropOverriddenSelections(resolved) },
@@ -231,11 +231,15 @@ export class Pipeline<
     },
   ): Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined> {
     const { accumulators, groups } = spec(fieldProvider(this.node.schema));
+    // Dropped to the plain `Groups` (the `UndottedGroupAliases` guard has done
+    // its work at the call site): the intersection blocks the element-type
+    // constraint of `DropOverriddenSelections` from being inferred.
+    const groupList: Groups | readonly [] = groups ?? [];
     return new Pipeline<AggregateSchema<Schema, Accs, Groups>, undefined>({
       schema: buildAggregateSchema<Schema, Accs, Groups>(this.node.schema, accumulators, groups),
       // Resolve last-wins on the groups here so the stage carries a
       // conflict-free list that matches the schema (executors translate 1:1).
-      stage: { kind: 'aggregate', accumulators, groups: dropOverriddenSelections(groups ?? []) },
+      stage: { kind: 'aggregate', accumulators, groups: dropOverriddenSelections(groupList) },
       parent: this.node,
     });
   }
@@ -258,11 +262,15 @@ export class Pipeline<
     spec: (field: FieldProvider<Schema>) => Groups & UndottedGroupAliases<Groups>,
   ): Pipeline<DistinctSchema<Schema, Groups>, undefined> {
     const groups = spec(fieldProvider(this.node.schema));
+    // Dropped to the plain `Groups` (the `UndottedGroupAliases` guard has done
+    // its work at the call site): the intersection blocks the element-type
+    // constraint of `DropOverriddenSelections` from being inferred.
+    const groupList: Groups = groups;
     return new Pipeline<DistinctSchema<Schema, Groups>, undefined>({
       schema: buildDistinctSchema<Schema, Groups>(this.node.schema, groups),
       // Resolve last-wins on the groups here so the stage carries a
       // conflict-free list that matches the schema (executors translate 1:1).
-      stage: { kind: 'distinct', groups: dropOverriddenSelections(groups) },
+      stage: { kind: 'distinct', groups: dropOverriddenSelections(groupList) },
       parent: this.node,
     });
   }

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -21,8 +21,10 @@ import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
   buildAggregateSchema,
+  buildDistinctSchema,
   buildSelectionSchema,
   type BuildSelectionSchema,
+  type DistinctSchema,
   dropOverriddenSelections,
   type ExpressionWithAlias,
   type Selection,
@@ -237,10 +239,32 @@ export class Pipeline<
       parent: this.node,
     });
   }
-  distinct<const Selections extends readonly Selection<Schema>[]>(
-    _groups: (field: FieldProvider<Schema>) => Selections,
-  ): Pipeline<Fields, undefined> {
-    return unimplemented();
+  /**
+   * Collapses the rows to the distinct combinations of the `groups` keys —
+   * semantically an `aggregate` with ZERO accumulators, so it shares the group
+   * model entirely. Identity-breaking (`Id = undefined`): a distinct row is not
+   * a source document.
+   *
+   * The result schema is exactly the group keys, each made nullable (null and
+   * absent keys merge into one `null` row, probed — never absent). Groups are
+   * TOP-LEVEL outputs only: a dotted bare path AND a dotted alias are rejected
+   * at the type level (the backend's `TOP_LEVEL_PROPERTY_PATH_ONLY`), so a
+   * nested field is grouped via an expression with a top-level alias
+   * (`field('a.b.c').as('c')`). Empty input yields ZERO rows. See
+   * {@link DistinctSchema}.
+   */
+  // At least one group is required (a distinct with no keys is meaningless).
+  distinct<const Groups extends readonly [AggregateGroup<Schema>, ...AggregateGroup<Schema>[]]>(
+    spec: (field: FieldProvider<Schema>) => Groups & UndottedGroupAliases<Groups>,
+  ): Pipeline<DistinctSchema<Schema, Groups>, undefined> {
+    const groups = spec(fieldProvider(this.node.schema));
+    return new Pipeline<DistinctSchema<Schema, Groups>, undefined>({
+      schema: buildDistinctSchema<Schema, Groups>(this.node.schema, groups),
+      // Resolve last-wins on the groups here so the stage carries a
+      // conflict-free list that matches the schema (executors translate 1:1).
+      stage: { kind: 'distinct', groups: dropOverriddenSelections(groups) },
+      parent: this.node,
+    });
   }
   /** `full_replace`: the document becomes the given map value. */
   fullReplaceWith<M extends MapFields>(

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -24,6 +24,7 @@ import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
   buildAggregateSchema,
+  buildDistinctSchema,
   type BuildSelectionSchema,
   buildSelectionSchema,
   type ExpressionWithAlias,
@@ -596,5 +597,80 @@ describe('buildAggregateSchema (runtime)', () => {
     const oracle = { g: int64() };
     const actual = buildAggregateSchema(schema, [countAll().as('g')], ['g']);
     expectTypedStrictEqual(actual, oracle);
+  });
+});
+
+// Stage-schema synthesis of the `distinct` stage. `distinct` is a grouped
+// aggregate with ZERO accumulators, so its schema IS the group half —
+// `DistinctSchema` reuses the very `GroupSchema` operator that
+// `AggregateSchema` merges its accumulators onto. The per-cell group-projection
+// matrix (bare key, aliased expression, nested-via-expression, optional leaf,
+// required-leaf-under-optional-ancestor, map-typed shallow rewrite) is already
+// exercised exhaustively by `buildAggregateSchema (runtime)` above, so here we
+// cover the distinct-SPECIFIC surface — the schema is EXACTLY the group keys
+// (no accumulator record overlaid) and multiple groups compose — plus one
+// representative shared-path case (optional -> nullable) that proves
+// `absentMergesIntoNull` runs, and the type-level dotted-group rejections.
+// Each case pins one oracle on BOTH sides via `expectTypedStrictEqual` (the
+// return type IS `DistinctSchema<...>`), the safety net for the bridging
+// assertion inside `buildDistinctSchema`.
+describe('buildDistinctSchema (runtime)', () => {
+  const gender = optional(literal('male', 'female'));
+  const profile = map({ age: double(), gender });
+  const schema = {
+    name: string(),
+    g: string(),
+    opt: optional(string()),
+    profile,
+    rank: double(),
+  } satisfies DocumentSchema;
+
+  it('a single bare-path group is the whole schema (no accumulator record)', () => {
+    // The distinct-specific shape: unlike aggregate, nothing is overlaid — the
+    // result is exactly the group key.
+    const oracle = { g: string() };
+    const actual = buildDistinctSchema(schema, ['g']);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('a top-level optional group key merges absent into null (representative shared path)', () => {
+    // null and absent keys merge into ONE null row (probed) — the `& Optional`
+    // field is rewritten to nullable. This exercises the `GroupSchema` path
+    // shared with aggregate.
+    const oracle = { opt: nullable(string()) };
+    const actual = buildDistinctSchema(schema, ['opt']);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('multiple groups compose (bare key + aliased expression)', () => {
+    const oracle = { g: string(), big: bool() };
+    const actual = buildDistinctSchema(schema, [
+      'g',
+      greaterThan(field(schema.rank, 'rank'), constant(4)).as('big'),
+    ]);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('a MAP-typed group key keeps its INNER absences; only the whole-map absence merges', () => {
+    // Probed: the map is compared and projected as a VALUE, so the rewrite is
+    // SHALLOW — nullable at the top, inner optionality preserved.
+    const deep = {
+      a: optional(map({ b: map({ c: optional(string()) }) })),
+    } satisfies DocumentSchema;
+    const oracle = { a: nullable(map({ b: map({ c: optional(string()) }) })) };
+    const actual = buildDistinctSchema(deep, ['a']);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('a dotted bare-path group is rejected at the type level', () => {
+    // A dotted bare path is not a top-level group key (TOP_LEVEL_PROPERTY_PATH_ONLY).
+    // The complementary dotted-ALIAS rejection is enforced one level up, at the
+    // `Pipeline.distinct` parameter via `UndottedGroupAliases` (expression `.as`
+    // itself allows dotted aliases, for `select`/`addFields` nesting) — asserted
+    // in `pipeline.test.ts`.
+    void (() => {
+      // @ts-expect-error -- a dotted BARE path is not a top-level group key
+      void buildDistinctSchema(schema, ['profile.gender']);
+    });
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -19,7 +19,7 @@ import {
   string,
   type StringType,
 } from '../schema.js';
-import { constant, countAll, equal, field, greaterThan, sum } from './expression.js';
+import { constant, countAll, equal, field, type Field, greaterThan, sum } from './expression.js';
 import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
@@ -137,6 +137,43 @@ describe('BuildSelectionSchema', () => {
       type AgeAlias = ExpressionWithAlias<DoubleType, 'stats.age'>;
       expectTypeOf<BuildSelectionSchema<Schema, [DeepAlias, AgeAlias]>>().toEqualTypeOf<{
         stats: MapType<{ score: DoubleType; age: DoubleType }>;
+      }>();
+    });
+  });
+
+  // A bare `Field` is the third selection form: it carries its own alias (its
+  // `path`), so every case here states the SAME schema the equivalent string
+  // path produces above — that equivalence IS the feature.
+  describe('bare Field', () => {
+    type NameField = Field<StringType, 'name'>;
+    type AgeField = Field<DoubleType, 'profile.age'>;
+
+    it('picks a top-level field, like the string form', () => {
+      expectTypeOf<BuildSelectionSchema<Schema, [NameField]>>().toEqualTypeOf<
+        BuildSelectionSchema<Schema, ['name']>
+      >();
+      expectTypeOf<BuildSelectionSchema<Schema, [NameField]>>().toEqualTypeOf<{
+        name: StringType;
+      }>();
+    });
+
+    it('builds a nested MapType from a dotted path (allowed in select)', () => {
+      expectTypeOf<BuildSelectionSchema<Schema, [AgeField]>>().toEqualTypeOf<
+        BuildSelectionSchema<Schema, ['profile.age']>
+      >();
+      expectTypeOf<BuildSelectionSchema<Schema, [AgeField]>>().toEqualTypeOf<{
+        profile: MapType<{ age: DoubleType }>;
+      }>();
+    });
+
+    it('conflict-resolves against the string form as the same output path', () => {
+      // Both orders collapse to one entry: a bare `Field` at path P and the
+      // string P name the same output.
+      expectTypeOf<BuildSelectionSchema<Schema, ['name', NameField]>>().toEqualTypeOf<{
+        name: StringType;
+      }>();
+      expectTypeOf<BuildSelectionSchema<Schema, [NameField, 'name']>>().toEqualTypeOf<{
+        name: StringType;
       }>();
     });
   });
@@ -479,6 +516,53 @@ describe('buildSelectionSchema (runtime)', () => {
     expectTypedStrictEqual(actual, oracle);
   });
 
+  it('a bare Field equals the string form at a top-level path', () => {
+    const oracle = { name: schema.name };
+    const actual = buildSelectionSchema(schema, [field(schema.name, 'name')]);
+    expectTypedStrictEqual(actual, oracle);
+    expectTypedStrictEqual(actual, buildSelectionSchema(schema, ['name']));
+  });
+
+  it('a bare Field at a DOTTED path builds the nested schema (allowed in select)', () => {
+    const oracle = { profile: map({ age: profile.fields.age }) };
+    const actual = buildSelectionSchema(schema, [field(profile.fields.age, 'profile.age')]);
+    expectTypedStrictEqual(actual, oracle);
+    expectTypedStrictEqual(actual, buildSelectionSchema(schema, ['profile.age']));
+  });
+
+  it('a bare Field crossing an optional ancestor marks the leaf optional', () => {
+    // Same `WithConditionality` treatment as the string form and the aliased
+    // `Field` form: the ancestor's optionality lands on the projected leaf.
+    const s = { name: string(), meta: optional(map({ x: double() })) } satisfies DocumentSchema;
+    const oracle = { meta: map({ x: optional(double()) }) };
+    const actual = buildSelectionSchema(s, [field(s.meta.fields.x, 'meta.x')]);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('last-wins treats a bare Field and the string path as the same output (both orders)', () => {
+    const rankField = field(schema.rank, 'rank');
+    // String first, Field later: the Field wins — but both name `rank`, so the
+    // observable claim is the single collapsed entry.
+    const stringFirst = buildSelectionSchema(schema, ['rank', rankField]);
+    expectTypedStrictEqual(stringFirst, { rank: schema.rank });
+    const fieldFirst = buildSelectionSchema(schema, [rankField, 'rank']);
+    expectTypedStrictEqual(fieldFirst, { rank: schema.rank });
+
+    // Discriminating variant: a parent/child conflict, where the winner and
+    // the loser produce DIFFERENT schemas — so the assertions above cannot
+    // pass by accident.
+    const childThenParent = buildSelectionSchema(schema, [
+      field(profile.fields.age, 'profile.age'),
+      'profile',
+    ]);
+    expectTypedStrictEqual(childThenParent, { profile });
+    const parentThenChild = buildSelectionSchema(schema, [
+      'profile',
+      field(profile.fields.age, 'profile.age'),
+    ]);
+    expectTypedStrictEqual(parentThenChild, { profile: map({ age: profile.fields.age }) });
+  });
+
   it("treats '__name__' in an alias like any other key (no special-casing)", () => {
     // The reserved-name rule is deliberately not modelled client-side:
     // aliasing to top-level `'__name__'` is rejected by the backend itself
@@ -591,6 +675,20 @@ describe('buildAggregateSchema (runtime)', () => {
     });
   });
 
+  it('a bare Field group key equals the bare-path form', () => {
+    // Probed: an unaliased top-level `field('g')` groups under the row key `g`.
+    const oracle = { n: int64(), g: string() };
+    const actual = buildAggregateSchema(schema, [n], [field(schema.g, 'g')]);
+    expectTypedStrictEqual(actual, oracle);
+    expectTypedStrictEqual(actual, buildAggregateSchema(schema, [n], ['g']));
+  });
+
+  it('an OPTIONAL field grouped as a bare Field reads back nullable', () => {
+    const oracle = { n: int64(), opt: nullable(string()) };
+    const actual = buildAggregateSchema(schema, [n], [field(schema.opt, 'opt')]);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
   it('an accumulator alias colliding with a group name wins', () => {
     // `MergeSchemas` puts the accumulator record first, so its `g` overlays the
     // group key `g` — the accumulator is the more specific intent.
@@ -659,6 +757,23 @@ describe('buildDistinctSchema (runtime)', () => {
     } satisfies DocumentSchema;
     const oracle = { a: nullable(map({ b: map({ c: optional(string()) }) })) };
     const actual = buildDistinctSchema(deep, ['a']);
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('a bare Field group key equals the bare-path form; last-wins collapses the two', () => {
+    const gField = field(schema.g, 'g');
+    const oracle = { g: string() };
+    const actual = buildDistinctSchema(schema, [gField]);
+    expectTypedStrictEqual(actual, oracle);
+    expectTypedStrictEqual(actual, buildDistinctSchema(schema, ['g']));
+    // The two forms name the same output, so a list holding both collapses.
+    expectTypedStrictEqual(buildDistinctSchema(schema, ['g', gField]), oracle);
+    expectTypedStrictEqual(buildDistinctSchema(schema, [gField, 'g']), oracle);
+  });
+
+  it('an OPTIONAL field grouped as a bare Field reads back nullable', () => {
+    const oracle = { opt: nullable(string()) };
+    const actual = buildDistinctSchema(schema, [field(schema.opt, 'opt')]);
     expectTypedStrictEqual(actual, oracle);
   });
 

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -29,41 +29,91 @@ export type { ExpressionWithAlias } from './expression.js';
 type Fields = DocumentSchema;
 
 /**
- * A single select argument: either a data field path or an aliased expression.
+ * A single select argument: a data field path, a bare {@link Field}, or an
+ * aliased expression.
  *
- * Uses {@link MapFieldPath} (data fields only), **not** the document-level
- * `DocFieldPath` — the reserved key `"__name__"` is intentionally not
- * projectable here. Projecting `"__name__"` un-aliased would preserve the row's
+ * A bare `Field` needs no `.as(...)`: a `Field<T, Path>` is inherently aliased —
+ * its `path` IS its output name — which is why the official SDK's `Field`
+ * implements `Selectable`. So `select((f) => [f('profile.age')])` and
+ * `select(() => ['profile.age'])` produce the same schema, and the two forms
+ * conflict-resolve against each other as one and the same output path.
+ *
+ * Uses {@link MapFieldPath} (data fields only) for BOTH bare forms, **not** the
+ * document-level `DocFieldPath` — the reserved key `"__name__"` is
+ * intentionally not projectable here, whether written as a string or as
+ * `f('__name__')`. Projecting `"__name__"` un-aliased would preserve the row's
  * read-identity at runtime, but `select` is typed to always drop it
  * (`Id = undefined`), so allowing it would make the type lie. Keep identity
  * while reshaping via `addFields` / `removeFields`; `"__name__"` stays usable in
  * `where` / `sort` (they go through `FieldProvider`, not `Selection`). See
  * `docs/pipeline-query-identity-research.md`.
  */
-export type Selection<Context extends Fields> = MapFieldPath<Context> | ExpressionWithAlias;
+export type Selection<Context extends Fields> =
+  | MapFieldPath<Context>
+  | BareField<Context>
+  | ExpressionWithAlias;
 
 /**
- * A group selection of the `aggregate` stage: a TOP-LEVEL bare field path, or
- * an aliased expression whose alias is undotted. The backend rejects dotted
- * assignment targets in `aggregate` (`TOP_LEVEL_PROPERTY_PATH_ONLY` — probed:
- * both a dotted bare path AND a dotted alias are INVALID_ARGUMENT), so unlike
+ * A group selection of the `aggregate` stage: a TOP-LEVEL bare field path, a
+ * bare {@link Field} whose path is top-level, or an aliased expression whose
+ * alias is undotted. The backend rejects dotted assignment targets in
+ * `aggregate` (`TOP_LEVEL_PROPERTY_PATH_ONLY` — probed: a dotted bare path, a
+ * dotted bare `Field` and a dotted alias are all INVALID_ARGUMENT), so unlike
  * `select`'s {@link Selection} there is no nested output form — group a
  * NESTED field via an expression with a top-level alias:
  * `field('a.b.c').as('c')`.
+ *
+ * A bare `Field` is accepted here for the same reason as in {@link Selection}
+ * (its `path` is its alias — probed: an unaliased top-level `field('g')` groups
+ * under the row key `g`). Its top-level restriction is NOT expressed in this
+ * union but in the {@link UndottedGroupAliases} tuple guard, so a dotted bare
+ * `Field` and a dotted alias fail the same way.
  */
-export type AggregateGroup<Context extends Fields> = (keyof Context & string) | ExpressionWithAlias;
+export type AggregateGroup<Context extends Fields> =
+  | (keyof Context & string)
+  | BareField<Context>
+  | ExpressionWithAlias;
 
 /**
- * The undotted-alias guard for a groups tuple (applied as a parameter
- * intersection, the `WithoutDottedKeys` precedent): an aliased group whose
- * alias contains the path separator collapses to `never`.
+ * A `Field` usable as an un-aliased selection: any of the context's **data**
+ * field paths. `'__name__'` is excluded so the bare `Field` form allows exactly
+ * what the bare string form allows (see {@link Selection}) — `FieldProvider`
+ * itself resolves the reserved key, so the exclusion has to happen here.
+ */
+type BareField<Context extends Fields> = Field<FieldType, MapFieldPath<Context>>;
+
+/**
+ * The context-free shape of a single selection, as the stage payloads and the
+ * runtime folds see it: a bare field path, a bare `Field`, or an aliased
+ * expression. The type-erased counterpart of {@link Selection} /
+ * {@link AggregateGroup} — the context-dependent narrowing (which paths are
+ * legal, which output names are top-level) has already been discharged by the
+ * typed `Pipeline` methods, so nothing downstream needs to re-check it.
+ */
+export type SelectionNode = string | Field | ExpressionWithAlias;
+
+/**
+ * The top-level-output guard for a groups tuple (applied as a parameter
+ * intersection, the `WithoutDottedKeys` precedent): a group whose output name
+ * contains the path separator collapses to `never` — an aliased group by its
+ * `alias`, a bare {@link Field} by its `path` (which is its alias). Both
+ * collapse through this one guard so the two dotted forms produce the same
+ * error at the same place.
+ *
+ * The bare STRING form needs no guard: {@link AggregateGroup} already narrows it
+ * to `keyof Context`, which is dot-free by construction
+ * (`WithoutDottedFieldNames`).
  */
 export type UndottedGroupAliases<G> = {
   [I in keyof G]: G[I] extends { alias: infer A extends string }
     ? A extends `${string}.${string}`
       ? never
       : G[I]
-    : G[I];
+    : G[I] extends Field<FieldType, infer P>
+      ? P extends `${string}.${string}`
+        ? never
+        : G[I]
+      : G[I];
 };
 
 /**
@@ -87,9 +137,18 @@ type FoldSelections<
   ? MergeSchemas<SelectionToSchema<Context, First>, FoldSelections<Context, Rest>>
   : {};
 
-/** The output path a selection contributes to (a field path, or an alias's path). */
+/**
+ * The output path a selection contributes to: an alias's path, a bare `Field`'s
+ * own path (a `Field` is its own alias), or a bare path string.
+ */
 type SelectionPath<S> =
-  S extends ExpressionWithAlias<infer _T, infer P> ? P : S extends string ? S : never;
+  S extends ExpressionWithAlias<infer _T, infer P>
+    ? P
+    : S extends Field<infer _T, infer P>
+      ? P
+      : S extends string
+        ? S
+        : never;
 
 /** Whether two paths collide: equal, or one is a dotted prefix of the other. */
 type PathsConflict<A extends string, B extends string> = A extends B
@@ -128,12 +187,15 @@ type DropOverriddenSelections<Args extends readonly unknown[]> = Args extends re
  * all existing fields; on name overlap the added field wins, matching the
  * official SDK's "overwrite existing ones" behavior.
  *
- * Accepts **aliased expressions only** — no bare field paths (unlike
- * `select`). A bare path would be a schema no-op at best, and for a path
- * through an optional map it would silently mutate rows (the backend
- * materializes the missing intermediate layers as empty maps — verified
- * live), so the schema would lie. The official SDK's `addFields` accepts only
- * `Selectable`s too.
+ * Accepts **aliased expressions only** — neither bare form of `select`'s
+ * {@link Selection} (a path string, or a bare `Field`) is allowed here, and
+ * that exclusion is deliberate: both name an EXISTING field, so re-adding it
+ * under its own name is a schema no-op at best, and for a path through an
+ * optional map it would silently mutate rows (the backend materializes the
+ * missing intermediate layers as empty maps — verified live), so the schema
+ * would lie. Write the intent explicitly with an alias instead. (The official
+ * SDK does accept a bare `Field` here, since its `Field` is a `Selectable`; we
+ * narrow it away for the reason above.)
  */
 export type BuildAddFieldsSchema<
   Context extends Fields,
@@ -252,10 +314,16 @@ type RewriteAbsentField<T extends FieldType> = T extends Optional
 
 /**
  * Resolves one selection into the partial schema it contributes to the output.
- * Selections that read a source **field path** (bare paths, and aliases whose
- * expression is a `Field`) mark the projected leaf `Optional` when the path
- * crosses an optional ancestor ({@link WithConditionality}); computed
- * expressions always produce a value and stay as-is.
+ * Selections that read a source **field path** (bare paths, bare `Field`s, and
+ * aliases whose expression is a `Field`) mark the projected leaf `Optional`
+ * when the path crosses an optional ancestor ({@link WithConditionality});
+ * computed expressions always produce a value and stay as-is.
+ *
+ * A bare `Field` folds exactly as `field(p).as(p)` would: output path = its
+ * `path`, descriptor = its own `type`. The descriptor comes from the node, not
+ * from a fresh `FieldTypeOfPath` lookup, so the bare and aliased `Field` forms
+ * cannot drift apart — and `FieldProvider` resolves the node's `type` from the
+ * very same schema, which is what makes a bare `Field` equal the bare string.
  */
 type SelectionToSchema<Context extends Fields, S> = S extends {
   expression: Field<infer T, infer P>;
@@ -264,11 +332,13 @@ type SelectionToSchema<Context extends Fields, S> = S extends {
   ? PathToSchema<A, WithConditionality<Context, P, T>>
   : S extends ExpressionWithAlias<infer T, infer P>
     ? PathToSchema<P, T>
-    : S extends string
-      ? S extends MapFieldPath<Context>
-        ? PathToSchema<S, WithConditionality<Context, S, FieldTypeOfPath<Context, S>>>
-        : {}
-      : {};
+    : S extends Field<infer T, infer P>
+      ? PathToSchema<P, WithConditionality<Context, P, T>>
+      : S extends string
+        ? S extends MapFieldPath<Context>
+          ? PathToSchema<S, WithConditionality<Context, S, FieldTypeOfPath<Context, S>>>
+          : {}
+        : {};
 
 /**
  * Marks the resolved leaf type `Optional` when its source path is conditional
@@ -426,7 +496,7 @@ export const buildDistinctSchema = <
  * `absentMergesIntoNull`. Kept loosely typed so both callers reuse it without
  * re-threading their `Groups` constraint.
  */
-const groupSchema = (schema: Fields, groups: readonly (string | ExpressionWithAlias)[]): Fields =>
+const groupSchema = (schema: Fields, groups: readonly SelectionNode[]): Fields =>
   absentMergesIntoNull(foldSelections(schema, dropOverriddenSelections(groups)));
 
 /**
@@ -454,9 +524,7 @@ const rewriteAbsentField = (t: FieldType & { optional?: boolean }): FieldType =>
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection
  * only if no later selection conflicts with it (last-wins).
  */
-export const dropOverriddenSelections = <S extends string | ExpressionWithAlias>(
-  selections: readonly S[],
-): S[] =>
+export const dropOverriddenSelections = <S extends SelectionNode>(selections: readonly S[]): S[] =>
   selections.filter(
     (s, i) =>
       !selections
@@ -468,10 +536,7 @@ export const dropOverriddenSelections = <S extends string | ExpressionWithAlias>
  * Runtime counterpart of {@link FoldSelections}: the same
  * `MergeSchemas<SelectionToSchema<First>, FoldSelections<Rest>>` recursion.
  */
-const foldSelections = (
-  schema: Fields,
-  selections: readonly (string | ExpressionWithAlias)[],
-): Fields => {
+const foldSelections = (schema: Fields, selections: readonly SelectionNode[]): Fields => {
   const [first, ...rest] = selections;
   return first === undefined
     ? {}
@@ -485,12 +550,17 @@ const foldSelections = (
  * strings is unreachable through the typed API, so a throw is the defensive
  * equivalent).
  */
-const selectionToSchema = (schema: Fields, s: string | ExpressionWithAlias): Fields => {
+const selectionToSchema = (schema: Fields, s: SelectionNode): Fields => {
   if (typeof s === 'string') {
     return pathToSchema(
       s,
       withConditionality(schema, s, fieldTypeOfPath<Fields, string>(schema, s)),
     );
+  }
+  if (!('alias' in s)) {
+    // A bare `Field`: its `path` is its output name, and its own `type` is the
+    // descriptor — the exact fold the aliased `field(p).as(p)` arm below runs.
+    return pathToSchema(s.path, withConditionality(schema, s.path, s.type));
   }
   const { expression, alias } = s;
   switch (expression.kind) {
@@ -527,8 +597,8 @@ const isConditionalPath = (schema: Fields, path: string): boolean => {
 };
 
 /** Runtime counterpart of {@link SelectionPath}. */
-const selectionPath = (s: string | ExpressionWithAlias): string =>
-  typeof s === 'string' ? s : s.alias;
+const selectionPath = (s: SelectionNode): string =>
+  typeof s === 'string' ? s : 'alias' in s ? s.alias : s.path;
 
 /** Runtime counterpart of {@link PathsConflict}. */
 const pathsConflict = (a: string, b: string): boolean =>

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -165,10 +165,8 @@ export type AggregateSchema<
   // The `Accs extends ...` guard is always true; it defers evaluation so the
   // result is accepted as a `DocumentSchema` (same trick as BuildAddFieldsSchema).
 > = Accs extends readonly AggregateWithAlias[]
-  ? MergeSchemas<
-      AccumulatorSchema<Accs>,
-      AbsentMergesIntoNull<BuildSelectionSchema<Context, Groups>>
-    > extends infer R extends Fields
+  ? MergeSchemas<AccumulatorSchema<Accs>, GroupSchema<Context, Groups>> extends infer R extends
+      Fields
     ? // The `infer R extends Fields` re-binding discharges the `MapFields`
       // constraint lazily: the merged mapped type's value positions are not
       // PROVABLY `FieldType` while `Accs`/`Groups` are unresolved generics,
@@ -176,6 +174,41 @@ export type AggregateSchema<
       R
     : never
   : never;
+
+/**
+ * The group-key half of the aggregate/distinct output schema: the groups'
+ * {@link BuildSelectionSchema} projection with every `X & Optional` key
+ * rewritten to `nullable(X)` ({@link AbsentMergesIntoNull} — null and absent
+ * group keys merge into one `null` group, probed). Shared by
+ * {@link AggregateSchema} (as its group half, under the accumulator record) and
+ * {@link DistinctSchema} (as the whole schema — `distinct` is a grouped
+ * aggregate with zero accumulators), so both stages compute group keys
+ * identically.
+ */
+type GroupSchema<
+  Context extends Fields,
+  Groups extends readonly AggregateGroup<Context>[],
+> = AbsentMergesIntoNull<BuildSelectionSchema<Context, Groups>>;
+
+/**
+ * Output schema of the `distinct` stage: the {@link GroupSchema} of its group
+ * keys, and nothing else — `distinct` is semantically a grouped aggregate with
+ * ZERO accumulators, so EVERY group rule carries over (probed): null and absent
+ * keys merge into one `null` group (each `X & Optional` key reads back nullable,
+ * never absent), a nested field groups only via an expression with a TOP-LEVEL
+ * alias (the backend rejects dotted assignment targets —
+ * `TOP_LEVEL_PROPERTY_PATH_ONLY`), and a MAP-typed key is compared as a value
+ * (inner absences preserved — the rewrite is shallow). The rows are not source
+ * documents, so the pipeline's `Id` becomes `undefined`.
+ */
+export type DistinctSchema<
+  Context extends Fields,
+  Groups extends readonly AggregateGroup<Context>[],
+  // The `infer R extends Fields` re-binding discharges the `MapFields`
+  // constraint lazily (same trick as AggregateSchema): the mapped type's value
+  // positions are not PROVABLY `FieldType` while `Groups` is an unresolved
+  // generic, so a direct use fails `Pipeline`'s schema bound.
+> = GroupSchema<Context, Groups> extends infer R extends Fields ? R : never;
 
 /**
  * Folds the accumulators into a flat `alias -> result descriptor` record. A
@@ -366,8 +399,35 @@ export const buildAggregateSchema = <
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `AggregateSchema`, but the compiler cannot connect a runtime schema value to the type-level result
   mergeSchemas(
     accumulatorSchema(accumulators),
-    absentMergesIntoNull(buildSelectionSchema(schema, groups ?? [])),
+    groupSchema(schema, groups ?? []),
   ) as AggregateSchema<Context, Accs, Groups>;
+
+/**
+ * Runtime counterpart of {@link DistinctSchema}: the group-key schema and
+ * nothing else — `distinct` is a grouped aggregate with zero accumulators, so
+ * this is just {@link groupSchema}. The result feeds the executors' row
+ * decoding, so it must mirror the type exactly — the tests in
+ * `selection.test.ts` are the safety net for the bridging assertion.
+ */
+export const buildDistinctSchema = <
+  Context extends Fields,
+  const Groups extends readonly AggregateGroup<Context>[],
+>(
+  schema: Context,
+  groups: Groups,
+): DistinctSchema<Context, Groups> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `DistinctSchema`, but the compiler cannot connect a runtime schema value to the type-level result
+  groupSchema(schema, groups) as DistinctSchema<Context, Groups>;
+
+/**
+ * Runtime counterpart of {@link GroupSchema}, shared by `buildAggregateSchema`
+ * and `buildDistinctSchema`: the groups' selection schema (last-wins resolved,
+ * as `buildSelectionSchema` does) with each key passed through
+ * `absentMergesIntoNull`. Kept loosely typed so both callers reuse it without
+ * re-threading their `Groups` constraint.
+ */
+const groupSchema = (schema: Fields, groups: readonly (string | ExpressionWithAlias)[]): Fields =>
+  absentMergesIntoNull(foldSelections(schema, dropOverriddenSelections(groups)));
 
 /**
  * Runtime counterpart of {@link AccumulatorSchema}: a flat `alias -> descriptor`

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -499,12 +499,15 @@ export const buildDistinctSchema = <
  * that the signature does — like every other runtime twin in this file, the
  * return is the widened `Fields`, and the two public wrappers are where the
  * bridging assertion to the computed type lives. Typing this one
- * `GroupSchema<Context, Groups>` instead does not remove an assertion, it adds
- * one (tried): over an unresolved `Groups`, `absentMergesIntoNull`'s argument
- * stops satisfying `MapFields` (the same non-provable-`FieldType` mapped-type
- * problem `AggregateSchema` discharges with `infer R extends Fields`), and the
- * result still is not assignable to `DistinctSchema`, whose deferred
- * conditional the compiler will not resolve.
+ * `GroupSchema<Context, Groups>` instead does not remove an assertion — the
+ * tighter return poisons BOTH callers (tried, so no one has to try again):
+ * in `buildAggregateSchema` the value stops satisfying `mergeSchemas`'s
+ * `MapFields` parameter over an unresolved `Groups` (the same
+ * non-provable-`FieldType` mapped-type problem `AggregateSchema` discharges
+ * with `infer R extends Fields`), needing a NEW assertion there, and in
+ * `buildDistinctSchema` the existing assertion degrades to a double
+ * `as unknown as` because `DistinctSchema`'s deferred conditional no longer
+ * sufficiently overlaps. Widening here keeps that one bridge per wrapper.
  */
 const groupSchema = (schema: Fields, groups: readonly SelectionNode[]): Fields =>
   absentMergesIntoNull(foldSelections(schema, dropOverriddenSelections(groups)));

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -493,8 +493,18 @@ export const buildDistinctSchema = <
  * Runtime counterpart of {@link GroupSchema}, shared by `buildAggregateSchema`
  * and `buildDistinctSchema`: the groups' selection schema (last-wins resolved,
  * as `buildSelectionSchema` does) with each key passed through
- * `absentMergesIntoNull`. Kept loosely typed so both callers reuse it without
- * re-threading their `Groups` constraint.
+ * `absentMergesIntoNull`.
+ *
+ * "Counterpart" here means the COMPUTATION mirrors the type step for step, not
+ * that the signature does — like every other runtime twin in this file, the
+ * return is the widened `Fields`, and the two public wrappers are where the
+ * bridging assertion to the computed type lives. Typing this one
+ * `GroupSchema<Context, Groups>` instead does not remove an assertion, it adds
+ * one (tried): over an unresolved `Groups`, `absentMergesIntoNull`'s argument
+ * stops satisfying `MapFields` (the same non-provable-`FieldType` mapped-type
+ * problem `AggregateSchema` discharges with `infer R extends Fields`), and the
+ * result still is not assignable to `DistinctSchema`, whose deferred
+ * conditional the compiler will not resolve.
  */
 const groupSchema = (schema: Fields, groups: readonly SelectionNode[]): Fields =>
   absentMergesIntoNull(foldSelections(schema, dropOverriddenSelections(groups)));

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -200,11 +200,7 @@ type DropOverriddenSelections<Args extends readonly unknown[]> = Args extends re
 export type BuildAddFieldsSchema<
   Context extends Fields,
   Args extends readonly ExpressionWithAlias[],
-  // The `Args extends ...` guard is always true; it defers evaluation so the
-  // result is accepted as a `DocumentSchema` (same trick as BuildSelectionSchema).
-> = Args extends readonly ExpressionWithAlias[]
-  ? MergeSchemas<BuildSelectionSchema<Context, Args>, Context>
-  : never;
+> = MergeSchemas<BuildSelectionSchema<Context, Args>, Context>;
 
 /**
  * Output schema of the `aggregate` stage: the group keys' schema, transformed
@@ -224,18 +220,7 @@ export type AggregateSchema<
   Context extends Fields,
   Accs extends readonly AggregateWithAlias[],
   Groups extends readonly AggregateGroup<Context>[],
-  // The `Accs extends ...` guard is always true; it defers evaluation so the
-  // result is accepted as a `DocumentSchema` (same trick as BuildAddFieldsSchema).
-> = Accs extends readonly AggregateWithAlias[]
-  ? MergeSchemas<AccumulatorSchema<Accs>, GroupSchema<Context, Groups>> extends infer R extends
-      Fields
-    ? // The `infer R extends Fields` re-binding discharges the `MapFields`
-      // constraint lazily: the merged mapped type's value positions are not
-      // PROVABLY `FieldType` while `Accs`/`Groups` are unresolved generics,
-      // so a direct use fails `Pipeline`'s schema bound.
-      R
-    : never
-  : never;
+> = MergeSchemas<AccumulatorSchema<Accs>, GroupSchema<Context, Groups>>;
 
 /**
  * The group-key half of the aggregate/distinct output schema: the groups'
@@ -266,11 +251,7 @@ type GroupSchema<
 export type DistinctSchema<
   Context extends Fields,
   Groups extends readonly AggregateGroup<Context>[],
-  // The `infer R extends Fields` re-binding discharges the `MapFields`
-  // constraint lazily (same trick as AggregateSchema): the mapped type's value
-  // positions are not PROVABLY `FieldType` while `Groups` is an unresolved
-  // generic, so a direct use fails `Pipeline`'s schema bound.
-> = GroupSchema<Context, Groups> extends infer R extends Fields ? R : never;
+> = GroupSchema<Context, Groups>;
 
 /**
  * Folds the accumulators into a flat `alias -> result descriptor` record. A
@@ -306,7 +287,15 @@ type OverwriteMerge<A, B> = {
  */
 export type AbsentMergesIntoNull<S extends Fields> = {
   [K in keyof S]: RewriteAbsentField<S[K]>;
-};
+  // The `infer R extends Fields` re-binding discharges the schema constraint
+  // lazily: over an unresolved `S` the mapped type's value positions are not
+  // PROVABLY `FieldType`, so without it the result is rejected wherever a
+  // schema is required. Identity on every instantiation (`S extends Fields`
+  // and `RewriteAbsentField` returns a `FieldType`), so the operator is a
+  // `Fields` by construction and its callers need no re-binding of their own.
+} extends infer R extends Fields
+  ? R
+  : never;
 
 type RewriteAbsentField<T extends FieldType> = T extends Optional
   ? UnionType<[WithoutOptional<T>, NullType]>
@@ -399,22 +388,31 @@ type MergeSchemas<A, B> = {
     : K extends keyof B
       ? B[K]
       : never;
-};
+  // Re-bound to `Fields` for the same reason as {@link AbsentMergesIntoNull}:
+  // over unresolved operands the mapped type's value positions are not
+  // PROVABLY `FieldType`. Every operand in this file is a schema, so the
+  // re-binding is an identity and the result is a `Fields` by construction.
+} extends infer R extends Fields
+  ? R
+  : never;
 
 // ---------------------------------------------------------------------------
-// Runtime counterparts. Each helper mirrors the type-level operator of the same
-// name above; `buildSelectionSchema` is the entry point used by
-// `Pipeline.select` to compute the projected runtime schema.
+// Runtime counterparts. Each helper is DECLARED AS the type-level operator of
+// the same name applied to its own arguments, so the assertion inside it claims
+// exactly one step and the COMPOSITION of the steps is checked by the compiler:
+// a helper whose runtime result stops matching its twin's shape breaks the
+// callers that feed it, instead of being absorbed by one assertion at the top.
+// The `build*` functions are the entry points the `Pipeline` stages call.
 // ---------------------------------------------------------------------------
 
 /**
  * Runtime counterpart of {@link BuildSelectionSchema}: computed with the same
  * decomposition as the type — `foldSelections(schema, dropOverriddenSelections(args))`
- * mirrors `FoldSelections<Context, DropOverriddenSelections<Args>>`, so each
- * step can be checked against its type-level twin. The result feeds the next
+ * IS `FoldSelections<Context, DropOverriddenSelections<Args>>`, which is why
+ * this composition needs no assertion of its own. The result feeds the next
  * stage's field resolution and the executors' row decoding, so it must mirror
  * the type-level result exactly — the type tests in `selection.test.ts` plus
- * the pipeline spec are the safety net for the bridging assertion.
+ * the pipeline spec pin both halves.
  */
 export const buildSelectionSchema = <
   Context extends Fields,
@@ -423,11 +421,7 @@ export const buildSelectionSchema = <
   schema: Context,
   selections: Selections,
 ): BuildSelectionSchema<Context, Selections> =>
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `BuildSelectionSchema`, but the compiler cannot connect a runtime schema value to the type-level result
-  foldSelections(schema, dropOverriddenSelections(selections)) as BuildSelectionSchema<
-    Context,
-    Selections
-  >;
+  foldSelections(schema, dropOverriddenSelections(selections));
 
 /**
  * Runtime counterpart of {@link BuildAddFieldsSchema}: the same
@@ -442,20 +436,15 @@ export const buildAddFieldsSchema = <
   schema: Context,
   selections: Selections,
 ): BuildAddFieldsSchema<Context, Selections> =>
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `BuildAddFieldsSchema`, but the compiler cannot connect a runtime schema value to the type-level result
-  mergeSchemas(
-    foldSelections(schema, dropOverriddenSelections(selections)),
-    schema,
-  ) as BuildAddFieldsSchema<Context, Selections>;
+  mergeSchemas(foldSelections(schema, dropOverriddenSelections(selections)), schema);
 
 /**
  * Runtime counterpart of {@link AggregateSchema}: computed with the same
- * decomposition as the type —
- * `mergeSchemas(accumulatorSchema(...), absentMergesIntoNull(buildSelectionSchema(...)))`
- * mirrors `MergeSchemas<AccumulatorSchema<...>, AbsentMergesIntoNull<BuildSelectionSchema<...>>>`,
- * so each step can be checked against its type-level twin. The result feeds
- * the executors' row decoding, so it must mirror the type exactly — the tests
- * in `selection.test.ts` are the safety net for the bridging assertion.
+ * decomposition as the type — `mergeSchemas(accumulatorSchema(...), groupSchema(...))`
+ * IS `MergeSchemas<AccumulatorSchema<Accs>, GroupSchema<Context, Groups>>`, so
+ * the composition itself carries no assertion. The result feeds the executors'
+ * row decoding, so it must mirror the type exactly — the tests in
+ * `selection.test.ts` pin both halves.
  */
 export const buildAggregateSchema = <
   Context extends Fields,
@@ -465,19 +454,19 @@ export const buildAggregateSchema = <
   schema: Context,
   accumulators: Accs,
   groups?: Groups,
-): AggregateSchema<Context, Accs, Groups> =>
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `AggregateSchema`, but the compiler cannot connect a runtime schema value to the type-level result
-  mergeSchemas(
-    accumulatorSchema(accumulators),
-    groupSchema(schema, groups ?? []),
-  ) as AggregateSchema<Context, Accs, Groups>;
+): AggregateSchema<Context, Accs, Groups> => {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: an omitted `groups` argument means the empty group list and leaves `Groups` at its `readonly []` default, but the compiler does not tie a parameter's runtime default to a type parameter's default.
+  const groupList = (groups ?? []) as Groups;
+  return mergeSchemas(accumulatorSchema(accumulators), groupSchema(schema, groupList));
+};
 
 /**
  * Runtime counterpart of {@link DistinctSchema}: the group-key schema and
  * nothing else — `distinct` is a grouped aggregate with zero accumulators, so
- * this is just {@link groupSchema}. The result feeds the executors' row
- * decoding, so it must mirror the type exactly — the tests in
- * `selection.test.ts` are the safety net for the bridging assertion.
+ * this is just {@link groupSchema}, whose declared return type IS
+ * {@link GroupSchema} — so no assertion is needed here at all. The result feeds
+ * the executors' row decoding, so it must mirror the type exactly — the tests
+ * in `selection.test.ts` pin both halves.
  */
 export const buildDistinctSchema = <
   Context extends Fields,
@@ -485,9 +474,7 @@ export const buildDistinctSchema = <
 >(
   schema: Context,
   groups: Groups,
-): DistinctSchema<Context, Groups> =>
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the runtime fold mirrors the type-level `DistinctSchema`, but the compiler cannot connect a runtime schema value to the type-level result
-  groupSchema(schema, groups) as DistinctSchema<Context, Groups>;
+): DistinctSchema<Context, Groups> => groupSchema(schema, groups);
 
 /**
  * Runtime counterpart of {@link GroupSchema}, shared by `buildAggregateSchema`
@@ -495,21 +482,14 @@ export const buildDistinctSchema = <
  * as `buildSelectionSchema` does) with each key passed through
  * `absentMergesIntoNull`.
  *
- * "Counterpart" here means the COMPUTATION mirrors the type step for step, not
- * that the signature does — like every other runtime twin in this file, the
- * return is the widened `Fields`, and the two public wrappers are where the
- * bridging assertion to the computed type lives. Typing this one
- * `GroupSchema<Context, Groups>` instead does not remove an assertion — the
- * tighter return poisons BOTH callers (tried, so no one has to try again):
- * in `buildAggregateSchema` the value stops satisfying `mergeSchemas`'s
- * `MapFields` parameter over an unresolved `Groups` (the same
- * non-provable-`FieldType` mapped-type problem `AggregateSchema` discharges
- * with `infer R extends Fields`), needing a NEW assertion there, and in
- * `buildDistinctSchema` the existing assertion degrades to a double
- * `as unknown as` because `DistinctSchema`'s deferred conditional no longer
- * sufficiently overlaps. Widening here keeps that one bridge per wrapper.
+ * Typed as `GroupSchema<Context, Groups>` and computed from helpers that are
+ * each typed as their own type-level twin, so the compiler — not a comment —
+ * checks that the composition matches the type's decomposition.
  */
-const groupSchema = (schema: Fields, groups: readonly SelectionNode[]): Fields =>
+const groupSchema = <Context extends Fields, Groups extends readonly AggregateGroup<Context>[]>(
+  schema: Context,
+  groups: Groups,
+): GroupSchema<Context, Groups> =>
   absentMergesIntoNull(foldSelections(schema, dropOverriddenSelections(groups)));
 
 /**
@@ -517,43 +497,67 @@ const groupSchema = (schema: Fields, groups: readonly SelectionNode[]): Fields =
  * record built by iterating in order, so a repeated alias's later entry wins
  * (mirrors the type's `OverwriteMerge` fold).
  */
-const accumulatorSchema = (accumulators: readonly AggregateWithAlias[]): Fields => {
+const accumulatorSchema = <const Accs extends readonly AggregateWithAlias[]>(
+  accumulators: Accs,
+): AccumulatorSchema<Accs> => {
   const result: Record<string, FieldType> = {};
   for (const { aggregate, alias } of accumulators) {
     result[alias] = aggregate.type;
   }
-  return result;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `AccumulatorSchema` folds the TUPLE `Accs` with `OverwriteMerge`, which the compiler cannot match against the in-order loop that overwrites repeated aliases.
+  return result as AccumulatorSchema<Accs>;
 };
 
-/** Runtime counterpart of {@link AbsentMergesIntoNull}. */
-const absentMergesIntoNull = (schema: Fields): Fields =>
-  Object.fromEntries(Object.entries(schema).map(([k, v]) => [k, rewriteAbsentField(v)]));
+/** Runtime counterpart of {@link AbsentMergesIntoNull}, typed as that operator applied to its input. */
+const absentMergesIntoNull = <S extends Fields>(schema: S): AbsentMergesIntoNull<S> => {
+  const result = Object.fromEntries(
+    Object.entries(schema).map(([k, v]) => [k, rewriteAbsentField(v)]),
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `AbsentMergesIntoNull` is a mapped type over `keyof S`, which the compiler cannot match against an `Object.entries`/`fromEntries` rebuild.
+  return result as AbsentMergesIntoNull<S>;
+};
 
-/** Runtime counterpart of {@link RewriteAbsentField}. */
-const rewriteAbsentField = (t: FieldType & { optional?: boolean }): FieldType =>
-  t.optional === true ? nullable(withoutOptional(t)) : t;
+/** Runtime counterpart of {@link RewriteAbsentField}, typed as that operator applied to its input. */
+const rewriteAbsentField = <T extends FieldType>(
+  t: T & { optional?: boolean },
+): RewriteAbsentField<T> => {
+  const result = t.optional === true ? nullable(withoutOptional(t)) : t;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `RewriteAbsentField` branches on `T extends Optional`, a type-level test the runtime performs by reading the `optional` marker; the compiler does not relate the two.
+  return result as RewriteAbsentField<T>;
+};
 
 /**
  * Runtime counterpart of {@link DropOverriddenSelections}: keeps each selection
  * only if no later selection conflicts with it (last-wins).
  */
-export const dropOverriddenSelections = <S extends SelectionNode>(selections: readonly S[]): S[] =>
-  selections.filter(
+export const dropOverriddenSelections = <const Args extends readonly SelectionNode[]>(
+  selections: Args,
+): DropOverriddenSelections<Args> => {
+  const result = selections.filter(
     (s, i) =>
       !selections
         .slice(i + 1)
         .some((later) => pathsConflict(selectionPath(s), selectionPath(later))),
   );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `DropOverriddenSelections` builds a FILTERED TUPLE by recursing on `Args`, while the runtime filters an array; the compiler cannot see that the kept elements are exactly the tuple's members.
+  return result as DropOverriddenSelections<Args>;
+};
 
 /**
  * Runtime counterpart of {@link FoldSelections}: the same
  * `MergeSchemas<SelectionToSchema<First>, FoldSelections<Rest>>` recursion.
  */
-const foldSelections = (schema: Fields, selections: readonly SelectionNode[]): Fields => {
+const foldSelections = <Context extends Fields, Args extends readonly SelectionNode[]>(
+  schema: Context,
+  selections: Args,
+): FoldSelections<Context, Args> => {
   const [first, ...rest] = selections;
-  return first === undefined
-    ? {}
-    : mergeSchemas(selectionToSchema(schema, first), foldSelections(schema, rest));
+  const result =
+    first === undefined
+      ? {}
+      : mergeSchemas(selectionToSchema(schema, first), foldSelections(schema, rest));
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `FoldSelections` recurses by destructuring the TUPLE `Args`, while the runtime destructures an array value; the compiler cannot see that `rest` is the type-level `Rest`.
+  return result as FoldSelections<Context, Args>;
 };
 
 /**
@@ -563,33 +567,50 @@ const foldSelections = (schema: Fields, selections: readonly SelectionNode[]): F
  * strings is unreachable through the typed API, so a throw is the defensive
  * equivalent).
  */
-const selectionToSchema = (schema: Fields, s: SelectionNode): Fields => {
-  if (typeof s === 'string') {
-    return pathToSchema(
-      s,
-      withConditionality(schema, s, fieldTypeOfPath<Fields, string>(schema, s)),
-    );
-  }
-  if (!('alias' in s)) {
-    // A bare `Field`: its `path` is its output name, and its own `type` is the
-    // descriptor — the exact fold the aliased `field(p).as(p)` arm below runs.
-    return pathToSchema(s.path, withConditionality(schema, s.path, s.type));
-  }
-  const { expression, alias } = s;
-  switch (expression.kind) {
-    case 'field':
-      return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
-    case 'constant':
-    case 'functionCall':
-      return pathToSchema(alias, expression.type);
-    default:
-      return assertNever(expression);
-  }
+const selectionToSchema = <Context extends Fields, S extends SelectionNode>(
+  schema: Context,
+  s: S,
+): SelectionToSchema<Context, S> => {
+  // Widened to the union first: narrowing a generic `S` in place leaves it an
+  // object-or-string type parameter that `typeof` / `in` cannot discriminate.
+  const node: SelectionNode = s;
+  const result = ((): Fields => {
+    if (typeof node === 'string') {
+      return pathToSchema(
+        node,
+        withConditionality(schema, node, fieldTypeOfPath<Fields, string>(schema, node)),
+      );
+    }
+    if (!('alias' in node)) {
+      // A bare `Field`: its `path` is its output name, and its own `type` is the
+      // descriptor — the exact fold the aliased `field(p).as(p)` arm below runs.
+      return pathToSchema(node.path, withConditionality(schema, node.path, node.type));
+    }
+    const { expression, alias } = node;
+    switch (expression.kind) {
+      case 'field':
+        return pathToSchema(alias, withConditionality(schema, expression.path, expression.type));
+      case 'constant':
+      case 'functionCall':
+        return pathToSchema(alias, expression.type);
+      default:
+        return assertNever(expression);
+    }
+  })();
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `SelectionToSchema` dispatches on the shape of `S` with a conditional type, the runtime on the shape of the VALUE; narrowing the value does not narrow `S`, so the arms cannot be matched up by the compiler.
+  return result as SelectionToSchema<Context, S>;
 };
 
-/** Runtime counterpart of {@link WithConditionality}. */
-const withConditionality = (schema: Fields, path: string, type: FieldType): FieldType =>
-  isConditionalPath(schema, path) ? optional(type) : type;
+/** Runtime counterpart of {@link WithConditionality}, typed as that operator applied to its inputs. */
+const withConditionality = <Context extends Fields, P extends string, T extends FieldType>(
+  schema: Context,
+  path: P,
+  type: T,
+): WithConditionality<Context, P, T> => {
+  const result = isConditionalPath(schema, path) ? optional(type) : type;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `WithConditionality` branches on the type-level `IsConditionalPath`, which the runtime decides by walking the schema value; the compiler cannot connect the boolean to the conditional type.
+  return result as WithConditionality<Context, P, T>;
+};
 
 /** Runtime counterpart of {@link IsConditionalPath}. */
 const isConditionalPath = (schema: Fields, path: string): boolean => {
@@ -609,24 +630,39 @@ const isConditionalPath = (schema: Fields, path: string): boolean => {
   return isMapType(head) ? isConditionalPath(head.fields, path.slice(dot + 1)) : false;
 };
 
-/** Runtime counterpart of {@link SelectionPath}. */
-const selectionPath = (s: SelectionNode): string =>
-  typeof s === 'string' ? s : 'alias' in s ? s.alias : s.path;
+/** Runtime counterpart of {@link SelectionPath}, typed as that operator applied to its input. */
+const selectionPath = <S extends SelectionNode>(s: S): SelectionPath<S> => {
+  // Widened to the union first: narrowing a generic `S` in place leaves it an
+  // object-or-string type parameter that `in` rejects.
+  const node: SelectionNode = s;
+  const result = typeof node === 'string' ? node : 'alias' in node ? node.alias : node.path;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: narrowing the VALUE `s` does not narrow the type parameter `S`, so the compiler cannot see that each branch produces the corresponding arm of `SelectionPath<S>`.
+  return result as SelectionPath<S>;
+};
 
 /** Runtime counterpart of {@link PathsConflict}. */
 const pathsConflict = (a: string, b: string): boolean =>
   a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
 
-/** Runtime counterpart of {@link PathToSchema}. */
-const pathToSchema = (path: string, type: FieldType): Fields => {
+/** Runtime counterpart of {@link PathToSchema}, typed as that operator applied to its inputs. */
+const pathToSchema = <Path extends string, T extends FieldType>(
+  path: Path,
+  type: T,
+): PathToSchema<Path, T> => {
   const dot = path.indexOf('.');
-  return dot < 0
-    ? { [path]: type }
-    : { [path.slice(0, dot)]: map(pathToSchema(path.slice(dot + 1), type)) };
+  const result =
+    dot < 0
+      ? { [path]: type }
+      : { [path.slice(0, dot)]: map(pathToSchema(path.slice(dot + 1), type)) };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `PathToSchema` splits `Path` with a template-literal match while the runtime splits with `indexOf`, and a computed key built from a generic `Path` is not seen to inhabit the resulting mapped type.
+  return result as PathToSchema<Path, T>;
 };
 
-/** Runtime counterpart of {@link MergeSchemas} (`a` wins on non-map conflicts). */
-const mergeSchemas = (a: Fields, b: Fields): Fields => {
+/**
+ * Runtime counterpart of {@link MergeSchemas} (`a` wins on non-map conflicts),
+ * typed as that operator applied to its inputs.
+ */
+const mergeSchemas = <A extends Fields, B extends Fields>(a: A, b: B): MergeSchemas<A, B> => {
   const result: Record<string, FieldType> = { ...b, ...a };
   for (const key of Object.keys(a)) {
     const va = a[key];
@@ -635,5 +671,6 @@ const mergeSchemas = (a: Fields, b: Fields): Fields => {
       result[key] = map(mergeSchemas(va.fields, vb.fields));
     }
   }
-  return result;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `MergeSchemas` is a mapped type over `keyof A | keyof B` whose per-key branch the compiler cannot connect to the spread-and-patch loop below it.
+  return result as MergeSchemas<A, B>;
 };

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -1,6 +1,7 @@
 import type { Collection } from '../schema.js';
 import type { AggregateWithAlias, Expression, ExpressionWithAlias, Valued } from './expression.js';
 import type { Ordering } from './ordering.js';
+import type { SelectionNode } from './selection.js';
 
 /**
  * A pipeline stage. Firestore's official taxonomy groups every stage into one of
@@ -34,7 +35,7 @@ export type TransformStage =
   | { kind: 'where'; condition: Expression<Valued<'boolean'>> }
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.select`), so an executor can translate it 1:1.
-  | { kind: 'select'; selections: readonly (string | ExpressionWithAlias)[] }
+  | { kind: 'select'; selections: readonly SelectionNode[] }
   // `selections` is already conflict-resolved (last-wins applied by
   // `Pipeline.addFields`), so an executor can translate it 1:1. Aliased
   // expressions only — see `BuildAddFieldsSchema`.
@@ -52,13 +53,13 @@ export type TransformStage =
   | {
       kind: 'aggregate';
       accumulators: readonly AggregateWithAlias[];
-      groups: readonly (string | ExpressionWithAlias)[];
+      groups: readonly SelectionNode[];
     }
   // `distinct` is a grouped aggregate with ZERO accumulators, so it shares the
   // group model: `groups` are the group keys post-conflict-resolution (last-wins
   // applied by `Pipeline.distinct`, mirroring `aggregate`), and an executor
   // translates them 1:1. Always nonempty (a distinct with no keys is meaningless).
-  | { kind: 'distinct'; groups: readonly (string | ExpressionWithAlias)[] }
+  | { kind: 'distinct'; groups: readonly SelectionNode[] }
   | { kind: 'replaceWith' }
   | { kind: 'union' }
   | { kind: 'findNearest' }

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -54,7 +54,11 @@ export type TransformStage =
       accumulators: readonly AggregateWithAlias[];
       groups: readonly (string | ExpressionWithAlias)[];
     }
-  | { kind: 'distinct' }
+  // `distinct` is a grouped aggregate with ZERO accumulators, so it shares the
+  // group model: `groups` are the group keys post-conflict-resolution (last-wins
+  // applied by `Pipeline.distinct`, mirroring `aggregate`), and an executor
+  // translates them 1:1. Always nonempty (a distinct with no keys is meaningless).
+  | { kind: 'distinct'; groups: readonly (string | ExpressionWithAlias)[] }
   | { kind: 'replaceWith' }
   | { kind: 'union' }
   | { kind: 'findNearest' }

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -121,6 +121,12 @@ const applyStage = (
       const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
       return sdk.aggregate({ accumulators, groups });
     }
+    case 'distinct': {
+      // A grouped aggregate with zero accumulators — the options-object form
+      // takes `groups`, translated exactly like the aggregate arm's groups.
+      const groups = stage.groups.map((selection) => toSdkSelectable(db, selection));
+      return sdk.distinct({ groups });
+    }
     case 'where':
       // `asBoolean()` is a type-tag wrap for the SDK's `BooleanExpression`
       // parameter — it does not change the wire proto.
@@ -130,7 +136,6 @@ const applyStage = (
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
-    case 'distinct':
     case 'replaceWith':
     case 'union':
     case 'findNearest':

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -7,7 +7,6 @@ import {
   DocRefValue,
   GeoPointValue,
   VectorValue,
-  ExpressionWithAlias,
   type AggregateFunctionName,
   type AggregatePayload,
   type FunctionName,
@@ -20,6 +19,7 @@ import type {
   PipelineResult,
   PipelineRowIdentity,
 } from 'firestore-repository/pipelines/pipeline';
+import type { SelectionNode } from 'firestore-repository/pipelines/selection';
 import type { TransformStage } from 'firestore-repository/pipelines/stage';
 import type { Collection, DocumentSchema } from 'firestore-repository/schema';
 import { assertNever } from 'firestore-repository/util';
@@ -149,13 +149,17 @@ const applyStage = (
 };
 
 /**
- * Translates a selection (bare path or aliased expression) into an SDK
- * selectable. A bare path becomes a `Field`, which implements `Selectable`
- * with its own path as the alias — the same wire proto as the SDK's string
- * handling for `select`, in the form `addFields` also accepts.
+ * Translates a selection (bare path, bare `Field`, or aliased expression) into
+ * an SDK selectable. Both bare forms become an SDK `Field`, which implements
+ * `Selectable` with its own path as the alias — the same wire proto as the
+ * SDK's string handling for `select`, in the form `addFields` also accepts.
  */
-const toSdkSelectable = (db: Firestore, s: string | ExpressionWithAlias): Pipelines.Selectable =>
-  typeof s === 'string' ? Pipelines.field(s) : toSdkExpression(db, s.expression).as(s.alias);
+const toSdkSelectable = (db: Firestore, s: SelectionNode): Pipelines.Selectable =>
+  typeof s === 'string'
+    ? Pipelines.field(s)
+    : 'alias' in s
+      ? toSdkExpression(db, s.expression).as(s.alias)
+      : Pipelines.field(s.path);
 
 /**
  * Translates the repository expression AST into an SDK expression. Threads


### PR DESCRIPTION
Implements the `distinct` pipeline stage as a grouped aggregate with ZERO accumulators, sharing the aggregate stage's group machinery entirely.

## Probed backend semantics (`.ikenox/probe-distinct.mjs`, recorded in docs/pipeline-query-aggregate-research.md)

Every aggregate group rule carries over verbatim:

- Dotted bare-path groups AND dotted aliases are `INVALID_ARGUMENT` (`TOP_LEVEL_PROPERTY_PATH_ONLY`); a nested field groups via an expression with a top-level alias (`field('a.b.c').as('c')`).
- Null and absent keys merge into ONE null row (including absent-ancestor docs under the expression form).
- A MAP-typed key is compared as a value — inner absences preserved (`{b:{}}` vs `{b:{c:'v1'}}` are distinct rows); only the wholly-absent map merges into the null row.
- Empty input → zero rows.

## Implementation

- **selection.ts** — the group half of `AggregateSchema`/`buildAggregateSchema` is factored into a shared `GroupSchema`/`groupSchema` operator; `DistinctSchema`/`buildDistinctSchema` are exactly that operator (with the lazy MapFields discharge), so both stages compute group keys identically.
- **pipeline.ts** — `distinct` takes a nonempty `AggregateGroup` tuple guarded by `UndottedGroupAliases`; identity-breaking (`Id = undefined`) — a distinct row is not a source document.
- **stage.ts** — `{ kind: 'distinct'; groups }` carrying the conflict-resolved group list; both executors translate via `sdk.distinct({ groups })`.
- **Tests** — `buildDistinctSchema` unit describe covers the distinct-specific surface plus one representative shared path (the group-projection matrix is already cell-tested through aggregate); pipeline construction/rejection tests (nonempty, dotted-alias rejection); 5 live spec cases verified against the enterprise DB.

## Verification

`pnpm check` clean; full suite incl. live: **724 passed | 83 skipped** (was 719).

🤖 Generated with [Claude Code](https://claude.com/claude-code)