### PR TITLE
Canonical union normalization

### DIFF
--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -586,25 +586,26 @@ Items agreed in discussion but previously recorded only inline in DONE notes
       `FIRESTORE_REPOSITORY_INTEGRATION_TEST_CLIENT_API_KEY`; the suite is
       skipIf-gated and has never executed against the real backend — the
       admin adapter covers the shared spec live today).
-- [ ] **Canonical union normalization — `UnionType` valid-by-construction**
-      (agreed 2026-07, NEXT UP after the aggregate stage lands). The
-      always-valid principle applied to descriptors: union normalization is
-      today re-implemented at every construction site (`EitherType` /
-      `LogicalExtreme` / `ElementUnion` / `ConcatElementUnion` /
-      `MapFieldUnion` dedups, `NullableStripped`'s strip-then-reattach,
-      and `arrayGet`'s pinned union-NESTING wrap), because nothing
-      guarantees a `UnionType` is canonical. Introduce ONE `Normalize`
-      (type + runtime twin) owned by the union constructors (`union()`,
-      `nullable()`, `RebuildUnion`, ...): 1. flatten nested unions; 2. dedup members by `DescriptorEquals` (first-occurrence order —
-      deterministic, matching the existing dedup rule); 3. drop `never` members; 4. unwrap a singleton to the bare descriptor.
-      Consequences: `NullableStripped` collapses to
-      `Normalize<[StripNull<T>, NullType]>`-composition; the per-helper
-      dedups become `Normalize` calls (N implementations → 1); `arrayGet`'s
-      nested-union pin flips to flattened (update that test as "fixed");
-      `nullable(nullable(x))` becomes idempotent. Watch TS recursion
-      cost; the runtime twin mirrors branch-for-branch as usual. Scope is
-      a cross-cutting refactor comparable to the payload-union one — its
-      own PR, with the shape-oracle tests updated alongside.
+- [x] **Canonical union normalization — `UnionType` valid-by-construction**
+      (done 2026-07). `Normalize` (type) / `normalize` (runtime twin) in
+      `schema.ts`, composed of four steps each declared as its own type-level
+      twin: `FlattenUnions` → `DedupDescriptors` → `DropNever` →
+      `UnwrapSingleton`. Owned by `union()` / `nullable()`, which therefore
+      return `Normalize<...>` and not necessarily a `UnionType` at all — so
+      every `UnionType` in the system is canonical by construction and no
+      caller re-normalizes. `descriptorEquals` / `DescriptorEquals` /
+      `DedupDescriptors` moved down from `expression.ts` alongside them.
+      The ad-hoc normalizers collapsed to `Normalize` compositions:
+      `EitherType`, `LogicalExtreme`, `ElementUnion`, `ConcatElementUnion`,
+      `ArrayConstantTypeOf`, `NullableStripped`, `StripNull`'s union arm,
+      `PropagateNull` / `PropagateAbsence` / `MapValueType` /
+      `RewriteAbsentField`; `RebuildUnion` deleted outright. Only
+      `MapFieldUnion`'s TYPE stays bespoke — a record has no ordered key
+      tuple, so it degrades to `AnyUnionType` by nature; its runtime now
+      delegates. `arrayGet`'s nested-union pin flipped to flattened, and
+      `nullable(nullable(x))` is idempotent. Recursion cost went DOWN
+      (1.07M → 684K instantiations, 6.9s → 4.2s), since N conditional chains
+      became one shared alias; no recursion bound was needed.
 - [ ] **Refine accumulator nullability by groups presence** (noted 2026-07,
       explicitly deferred as advanced). `sum`/`average`/`minimum`/`maximum`/
       `first`/`last` are currently ALWAYS nullable — sound but wider than

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -32,49 +32,53 @@ Related research / decisions:
 
 ## Current status (snapshot — read this first)
 
-**What actually runs today (verified against a real Enterprise DB):**
+**Stages that run end-to-end today** (each verified live against
+`ikenox-sunrise` / `enterprise-native-playground` through the google-cloud
+adapter, and wired identically in the firebase adapter):
 
-- `collection(def)` → `execute` returns all documents with their ids
-  (a bare collection input, no transformation stages).
-- `collection(def).sort((field) => [asc(field('rank')), desc(...)])`
-  → sorted results.
+| stage                                    | schema effect                | identity   |
+| ---------------------------------------- | ---------------------------- | ---------- |
+| `collection` / `collectionGroup` (input) | the collection's schema      | preserved  |
+| `where`                                  | unchanged                    | preserved  |
+| `sort`                                   | unchanged                    | preserved  |
+| `limit` / `offset`                       | unchanged                    | preserved  |
+| `addFields`                              | context + added fields       | preserved  |
+| `removeFields`                           | context − removed paths      | preserved  |
+| `select`                                 | only the selections          | **broken** |
+| `aggregate`                              | accumulators over group keys | **broken** |
+| `distinct`                               | the group keys               | **broken** |
 
-Both work end-to-end through **both** adapters' executors; the spec suite
-(`fetch all` + `sort` asc/desc) passes against
-`ikenox-sunrise` / `enterprise-native-playground` via the google-cloud (admin,
-ADC) adapter. The firebase (client) adapter is wired identically but has **not**
-been run live — the client SDK needs real firebase credentials (apiKey / rules)
-to reach a non-emulator DB.
+"Identity broken" means the rows are no longer source documents, so the
+pipeline's second type parameter becomes `undefined` and the results carry no
+`id` — see "Identity ratchet" below.
 
-**How the runtime AST works now** (the key shift this session):
+**Still stubs** (`unimplemented()`, and the executors throw on them): `unnest`,
+`replaceWith` (`fullReplaceWith` / `mergeWith`), `union`, `findNearest`, `let`,
+`search`, `sample`; the `database()` / `documents()` / `literals()` input
+sources; and the DML output stages (`update` / `delete`).
 
-- `Pipeline` methods used to all return `unimplemented()` (no runtime value).
-  Now `collection`/`collectionGroup` build an input stage carrying the
-  source (`{ kind: 'collection', collection }` — see `stage.ts` `InputSource`),
-  and **`sort` builds a real `{ kind: 'sort', orderings }` stage** linked to its
-  parent. **All other stages are still stubs** (`unimplemented()`), so a chain
-  like `.where(...).sort(...)` does NOT build a runtime AST yet — only
-  `input` and `sort` do.
+**How the runtime AST works:**
+
+- Every implemented method builds a stage node linked to its parent
+  (`{ kind, ...payload }` — see `stage.ts`), and an executor walks the `parent`
+  chain to replay them into `db.pipeline()...`.
 - The `parent` link is typed as `PipelineNode` (a methods-free structural view
   of `Pipeline`) so `Pipeline<Schema, Id>` — which is invariant in `Schema` —
-  is assignable without a cast. An executor walks `parent` to collect stages.
-- `Field` gained `kind: 'field'` → `Expression` is now a discriminated union
-  (`field` / `constant` / `functionCall`). New `field(type, path)` factory in
-  `expression.ts`. The `sort` field provider resolves each field's real runtime
-  `type` via the new **`fieldTypeOfPath(schema, path)`** in `schema.ts` (the
-  runtime counterpart of the `FieldTypeOfPath` type), covered by
-  `schema.field-type-of-path.test.ts`.
-- `select` / `addFields` / `distinct` use `const` type params, so callback
-  selections infer as tuples without `as const`. `select` is fully implemented
-  (bare paths, nested dotted paths, `.as(...)` aliased expressions, last-wins
-  conflicts) and verified live; every expression node now carries an SDK-style
-  `.as(alias)` producing an `ExpressionWithAlias`.
+  is assignable without a cast.
+- `Expression` is a discriminated union (`field` / `constant` / `functionCall`).
+  Field providers resolve each path's real runtime descriptor via
+  `fieldTypeOfPath(schema, path)` in `schema.ts`.
+- Stage payloads carry ALREADY conflict-resolved selections (last-wins applied
+  by the `Pipeline` method), so an executor translates them 1:1.
+- Each type-level schema operator has a runtime twin **declared as that
+  operator applied to its own arguments**, so the compiler checks that the
+  steps compose — see `selection.ts` and the guideline's §Type-level / runtime
+  mirroring.
 
 **Executors** (`packages/{firebase-js-sdk,google-cloud-firestore}/src/pipeline.ts`):
-`executor(db)` walks the stage chain into `db.pipeline()...`, translates `sort`
-to `field(path).ascending()/.descending()`, runs it, and converts each result
-via the existing per-adapter `fromFirestore.docRef` / `decode` (both now
-exported through `buildFirestoreUtilities`, with an added `decode` method).
+`executor(db)` walks the stage chain, translates each stage to its SDK call,
+runs it, and converts each result via the per-adapter `fromFirestore.docRef` /
+`decode` (exported through `buildFirestoreUtilities`).
 
 **Running the pipeline spec tests** (Enterprise-only; the emulator can't run
 pipelines):
@@ -98,15 +102,15 @@ Without those two env vars the pipeline `describe` is `skipIf`-skipped. See the
 test-infra note under "Per-SDK adapters" for why the admin SDK can target the
 real backend while the repository tests still use the emulator in the same run.
 
-**Type assertions used** (all the `decode` class — runtime value → schema-derived
-type; policy in `docs/coding-guideline.md`): `fieldTypeOfPath` (2: `MapType`
-narrowing + the `FieldTypeOfPath` bridge) and each executor's result map
-(1 each: `... as PipelineResult<Schema, Id>`). The parent-invariance and the
-field-provider casts were **eliminated** (via `PipelineNode` and the resolver).
+**Type assertions** (policy in `docs/coding-guideline.md`): the `decode` class
+(runtime value → schema-derived type) — `fieldTypeOfPath` and each executor's
+result map — plus the step-local bridges in `selection.ts`, where each runtime
+twin asserts exactly ONE step of its type-level operator and the composition is
+compiler-checked.
 
-**Repo state:** core `firestore-repository` is green (lint 0, fmt clean, 210
-tests pass). Adapter repository tests still need the emulator (not run in this
-snapshot). Ad-hoc probe scripts live in `./.ikenox/` (gitignored).
+**Repo state:** `pnpm check` clean (lint 0, fmt clean); the full suite including
+the live Enterprise DB passes. Adapter repository (non-pipeline) tests need the
+emulator. Ad-hoc probe scripts live in `./.ikenox/` (gitignored).
 
 ## Conventions
 

--- a/packages/firestore-repository/src/pipelines/expression.test.ts
+++ b/packages/firestore-repository/src/pipelines/expression.test.ts
@@ -951,7 +951,9 @@ describe('existence / error / conditional operators (slice 5)', () => {
     expectTypedStrictEqual(t.type, string());
     const nullableThrough = ifAbsent(nullableName, constant('dflt'));
     // null is a VALUE for ifAbsent — it survives in the pass-through side.
-    expectTypedStrictEqual(nullableThrough.type, union(nullable(string()), string()));
+    // The fallback's `string` is already a member of that side, so the
+    // canonical union of the two sides is just the pass-through side.
+    expectTypedStrictEqual(nullableThrough.type, union(string(), nullType()));
   });
 
   it('ifNull strips null from the pass-through side', () => {
@@ -1196,10 +1198,11 @@ describe('array / map operators (slice 6)', () => {
     // wrapped as always-nullable (out-of-range is absent).
     const na = arrayGet(field(nullable(array(string())), 'na'), constant(0));
     expectTypedStrictEqual(na.type, nullable(string()));
-    // A union element: the always-nullable wrap composes WITHOUT flattening —
-    // nullable(union(string, int64)) = union(union(string, int64), null).
+    // A union element: the always-nullable wrap merges into the element's own
+    // union rather than wrapping it, so the result is the flat
+    // union(string, int64, null) — unions are canonical (see `Normalize`).
     const au = arrayGet(field(array(union(string(), int64())), 'au'), constant(0));
-    expectTypedStrictEqual(au.type, nullable(union(string(), int64())));
+    expectTypedStrictEqual(au.type, union(string(), int64(), nullType()));
     // ElementsOf's wide fallback arm (cell 22) is NOT exercisable: `arrayGet`
     // constrains its operand to `ArrayOperandInput`, and a truly-wide array
     // descriptor carries `firestoreType: unknown` (the `Any*` members), which

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -24,6 +24,8 @@ import {
   type LiteralType,
   map,
   type MapType,
+  normalize,
+  type Normalize,
   nullable,
   nullType,
   type NullType,
@@ -285,39 +287,17 @@ export type ConstantTypeOf<V extends ConstantValue> = ConstantValue extends V
 /**
  * The element descriptor is derived by walking the TUPLE (not the union of
  * the element types): tuple order is stable, so the runtime can mirror the
- * exact same first-occurrence dedup. A single distinct element type stays
- * bare; several become a `UnionType` in tuple order — matching the runtime's
- * `union(...deduped)`.
+ * exact same canonicalization. `Normalize` then decides the shape — a single
+ * distinct element type stays bare, several become a `UnionType` in
+ * first-occurrence order — matching the runtime's `union(...elements)`.
  */
-type ArrayConstantTypeOf<V extends ConstantArray> =
-  DedupDescriptors<{ readonly [K in keyof V]: ConstantTypeOf<V[K]> }> extends infer D
-    ? D extends readonly [infer Only extends FieldType]
-      ? ArrayType<Only>
-      : D extends readonly FieldType[]
-        ? ArrayType<UnionType<[...D]>>
-        : never
-    : never;
-
-/** First-occurrence dedup over a tuple of descriptors (mutual-`extends` equality). */
-type DedupDescriptors<
-  T extends readonly FieldType[],
-  Acc extends readonly FieldType[] = [],
-> = T extends readonly [infer H extends FieldType, ...infer R extends readonly FieldType[]]
-  ? IncludesDescriptor<Acc, H> extends true
-    ? DedupDescriptors<R, Acc>
-    : DedupDescriptors<R, [...Acc, H]>
-  : Acc;
-
-type IncludesDescriptor<T extends readonly FieldType[], X extends FieldType> = T extends readonly [
-  infer H extends FieldType,
-  ...infer R extends readonly FieldType[],
-]
-  ? DescriptorEquals<H, X> extends true
-    ? true
-    : IncludesDescriptor<R, X>
-  : false;
-
-type DescriptorEquals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type ArrayConstantTypeOf<V extends ConstantArray> = {
+  readonly [K in keyof V]: ConstantTypeOf<V[K]>;
+} extends infer D extends readonly FieldType[]
+  ? Normalize<D> extends infer N extends FieldType
+    ? ArrayType<N>
+    : never
+  : never;
 
 /**
  * Runtime counterpart of {@link ConstantTypeOf} (same branch order). The
@@ -349,14 +329,9 @@ function constantTypeOf(value: ConstantValue): FieldType {
       // Runtime twin of ConstantArray's non-empty tuple constraint.
       throw new Error('constant arrays must not be empty (no element to infer a type from)');
     }
-    // Mirrors ArrayConstantTypeOf: first-occurrence dedup in tuple order, a
-    // single distinct descriptor stays bare, several become a union.
-    const elements = value.map((element) => constantTypeOf(element));
-    const deduped = elements.filter(
-      (d, i) => elements.findIndex((e) => descriptorEquals(e, d)) === i,
-    );
-    const [only] = deduped;
-    return only !== undefined && deduped.length === 1 ? array(only) : array(union(...deduped));
+    // Mirrors ArrayConstantTypeOf: the element descriptors in tuple order,
+    // canonicalized by the union constructor.
+    return array(union(...value.map((element) => constantTypeOf(element))));
   }
   switch (typeof value) {
     case 'string':
@@ -381,22 +356,6 @@ function constantTypeOf(value: ConstantValue): FieldType {
 
 /** `Array.isArray` does not narrow `readonly` array unions — a dedicated guard does. */
 const isConstantArray = (value: ConstantValue): value is ConstantArray => Array.isArray(value);
-
-/** Structural descriptor equality (key-order insensitive; descriptors are plain data). */
-const descriptorEquals = (a: unknown, b: unknown): boolean => {
-  if (a === b) {
-    return true;
-  }
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
-    return false;
-  }
-  const entriesA = Object.entries(a);
-  const bRecord = new Map(Object.entries(b));
-  return (
-    entriesA.length === bRecord.size &&
-    entriesA.every(([k, v]) => bRecord.has(k) && descriptorEquals(v, bRecord.get(k)))
-  );
-};
 
 export const constant = <const V extends ConstantValue>(value: V): Constant<ConstantTypeOf<V>> =>
   Constant.of(value);
@@ -865,7 +824,7 @@ type PropagateNull<Operands extends FieldType, T extends FieldType> = [
   Extract<Operands['firestoreType'], 'null'> | Extract<Operands, Optional>,
 ] extends [never]
   ? T
-  : UnionType<[T, NullType]>;
+  : Normalize<[T, NullType]>;
 
 /**
  * Runtime counterpart of {@link PropagateNull} (the overload signature
@@ -930,7 +889,7 @@ type PropagateAbsence<Operands extends FieldType, T extends FieldType> = [
   Extract<Operands, Optional>,
 ] extends [never]
   ? T
-  : UnionType<[T, NullType]>;
+  : Normalize<[T, NullType]>;
 
 /** Runtime counterpart of {@link PropagateAbsence} (same bridge shape as `propagateNull`). */
 function propagateAbsence<Ops extends readonly Expression[], T extends FieldType>(
@@ -964,16 +923,16 @@ export const withoutOptional = (t: FieldType & { optional?: boolean }): FieldTyp
 
 /**
  * The type of "one of these two expressions' values" — the return descriptor
- * of the branching functions (`conditional`, the `if*` fallbacks): the single
- * descriptor when both sides agree, their union otherwise. A `never` side
- * (e.g. a fully null-stripped `StripNull`) collapses to the other. Operands'
- * `Optional` markers are dropped (see {@link WithoutOptional}).
+ * of the branching functions (`conditional`, the `if*` fallbacks): the
+ * canonical union of the two sides, so agreeing sides collapse to the single
+ * descriptor, a union side merges its own members in, and a `never` side
+ * (e.g. a fully null-stripped `StripNull`) drops out — all of it from
+ * {@link Normalize}. Operands' `Optional` markers are dropped first (see
+ * {@link WithoutOptional}).
  */
-type EitherType<A extends FieldType, B extends FieldType> = [A] extends [never]
-  ? WithoutOptional<B>
-  : DescriptorEquals<WithoutOptional<A>, WithoutOptional<B>> extends true
-    ? WithoutOptional<A>
-    : UnionType<[WithoutOptional<A>, WithoutOptional<B>]>;
+type EitherType<A extends FieldType, B extends FieldType> = Normalize<
+  [WithoutOptional<A>, WithoutOptional<B>]
+>;
 
 /** Runtime counterpart of {@link EitherType} (same bridge shape as `propagateNull`). */
 function eitherType<A extends Expression, B extends Expression>(
@@ -985,13 +944,8 @@ function eitherType(a: Expression, b: Expression): FieldType {
 }
 
 /** `EitherType` over already-resolved descriptors, with the `never` side as `undefined`. */
-const fallbackType = (a: FieldType | undefined, b: FieldType): FieldType => {
-  const bare = withoutOptional(b);
-  if (a === undefined) {
-    return bare;
-  }
-  return descriptorEquals(a, bare) ? a : union(a, bare);
-};
+const fallbackType = (a: FieldType | undefined, b: FieldType): FieldType =>
+  normalize([a, withoutOptional(b)]);
 
 /**
  * The descriptor with its null-ness removed — what remains of a value that
@@ -1012,7 +966,7 @@ type StripNullBare<T extends FieldType> = T extends NullType
   : T extends { type: 'union'; elements: infer E extends readonly FieldType[] }
     ? FieldType[] extends E
       ? T
-      : RebuildUnion<NonNullElements<E>>
+      : Normalize<NonNullElements<E>>
     : T extends {
           type: 'const';
           values: infer V extends readonly (string | number | boolean | null)[];
@@ -1043,14 +997,6 @@ type NonNullLiteralValues<V extends readonly (string | number | boolean | null)[
       : [H, ...NonNullLiteralValues<R>]
     : [];
 
-type RebuildUnion<E extends readonly FieldType[]> = E extends readonly [infer One extends FieldType]
-  ? One
-  : E extends readonly []
-    ? never
-    : E extends [FieldType, FieldType, ...FieldType[]]
-      ? UnionType<E>
-      : never;
-
 /** Runtime counterpart of {@link StripNull} (`never` is `undefined`). */
 const stripNull = (raw: FieldType): FieldType | undefined => {
   const t = withoutOptional(raw);
@@ -1058,11 +1004,8 @@ const stripNull = (raw: FieldType): FieldType | undefined => {
     case 'null':
       return undefined;
     case 'union': {
-      const [first, ...rest] = t.elements.filter((e) => e.type !== 'null');
-      if (first === undefined) {
-        return undefined;
-      }
-      return rest.length === 0 ? first : union(first, ...rest);
+      const nonNull = t.elements.filter((e) => e.type !== 'null');
+      return nonNull.length === 0 ? undefined : union(...nonNull);
     }
     case 'const': {
       const [first, ...rest] = t.values.filter((v) => v !== null);
@@ -1092,17 +1035,19 @@ const stripNull = (raw: FieldType): FieldType | undefined => {
  * only when EVERY operand may be null or absent (the all-ignored case
  * returns null — probed).
  */
-type LogicalExtreme<Ops extends readonly Expression[]> = RebuildUnion<
-  DedupDescriptors<[...StrippedTypes<Ops>, ...(AllMayBeNull<Ops> extends true ? [NullType] : [])]>
+type LogicalExtreme<Ops extends readonly Expression[]> = Normalize<
+  [...StrippedTypes<Ops>, ...(AllMayBeNull<Ops> extends true ? [NullType] : [])]
 >;
 
+/**
+ * The operands' null-stripped types in operand order. A pure-null operand
+ * contributes `never`, which {@link Normalize} drops.
+ */
 type StrippedTypes<Ops extends readonly Expression[]> = Ops extends readonly [
   infer H extends Expression,
   ...infer R extends readonly Expression[],
 ]
-  ? [StripNull<H['type']>] extends [never]
-    ? StrippedTypes<R>
-    : [StripNull<H['type']>, ...StrippedTypes<R>]
+  ? [StripNull<H['type']>, ...StrippedTypes<R>]
   : [];
 
 type AllMayBeNull<Ops extends readonly Expression[]> = Ops extends readonly [
@@ -1123,18 +1068,11 @@ type MayBeNullOrAbsent<T extends FieldType> = [
 /** Runtime counterpart of {@link LogicalExtreme} (same bridge shape as `propagateNull`). */
 function logicalExtremeType<Ops extends readonly Expression[]>(operands: Ops): LogicalExtreme<Ops>;
 function logicalExtremeType(operands: readonly Expression[]): FieldType {
-  const stripped = operands
-    .map((operand) => stripNull(operand.type))
-    .filter((t): t is FieldType => t !== undefined)
-    .filter((t, i, all) => all.findIndex((o) => descriptorEquals(o, t)) === i);
+  const stripped: (FieldType | undefined)[] = operands.map((operand) => stripNull(operand.type));
   if (operands.every((operand) => mayBeNull(operand.type) || mayBeAbsent(operand.type))) {
     stripped.push(nullType());
   }
-  const [first, ...rest] = stripped;
-  if (first === undefined) {
-    return nullType();
-  }
-  return rest.length === 0 ? first : union(first, ...rest);
+  return normalize(stripped);
 }
 
 /** Logical conjunction of two or more boolean expressions (Kleene: null operands propagate). */
@@ -1954,10 +1892,8 @@ const typeNameLiteral = (): LiteralType<FirestoreTypeName[]> =>
 /** An array-domain operand. */
 type ArrayOperand = Expression<Valued<readonly FirestoreType[]>>;
 
-/** The deduped element-type union of a tuple of element expressions. */
-type ElementUnion<Els extends readonly Expression[]> = RebuildUnion<
-  DedupDescriptors<ElementTypes<Els>>
->;
+/** The canonical element-type union of a tuple of element expressions. */
+type ElementUnion<Els extends readonly Expression[]> = Normalize<ElementTypes<Els>>;
 type ElementTypes<Els extends readonly Expression[]> = Els extends readonly [
   infer H extends Expression,
   ...infer R extends readonly Expression[],
@@ -1968,13 +1904,7 @@ type ElementTypes<Els extends readonly Expression[]> = Els extends readonly [
 /** Runtime counterpart of {@link ElementUnion} (same bridge shape as `propagateNull`). */
 function elementUnionType<Els extends readonly Expression[]>(elements: Els): ElementUnion<Els>;
 function elementUnionType(elements: readonly Expression[]): FieldType {
-  const [first, ...rest] = elements
-    .map((e) => withoutOptional(e.type))
-    .filter((t, i, all) => all.findIndex((o) => descriptorEquals(o, t)) === i);
-  if (first === undefined) {
-    throw new Error('an element list must not be empty');
-  }
-  return rest.length === 0 ? first : union(first, ...rest);
+  return union(...elements.map((e) => withoutOptional(e.type)));
 }
 
 /**
@@ -2028,7 +1958,7 @@ export const arrayGet = <
 >(
   value: Arr,
   index: Idx,
-): FunctionCall<UnionType<[ElementsOf<StripNull<TypeOfOperand<Arr>>>, NullType]>> => {
+): FunctionCall<Normalize<[ElementsOf<StripNull<TypeOfOperand<Arr>>>, NullType]>> => {
   const v = toOperand(value);
   const i = toOperand(index);
   return new FunctionCall(nullable(elementTypeOf(v)), { name: 'arrayGet', value: v, index: i });
@@ -2120,9 +2050,7 @@ export const arrayConcat = <
   });
 };
 
-type ConcatElementUnion<Ops extends readonly Expression[]> = RebuildUnion<
-  DedupDescriptors<ConcatElementTypes<Ops>>
->;
+type ConcatElementUnion<Ops extends readonly Expression[]> = Normalize<ConcatElementTypes<Ops>>;
 type ConcatElementTypes<Ops extends readonly Expression[]> = Ops extends readonly [
   infer H extends Expression,
   ...infer R extends readonly Expression[],
@@ -2135,13 +2063,7 @@ function concatElementUnionType<Ops extends readonly Expression[]>(
   operands: Ops,
 ): ConcatElementUnion<Ops>;
 function concatElementUnionType(operands: readonly Expression[]): FieldType {
-  const [first, ...rest] = operands
-    .map((operand) => elementTypeOf(operand))
-    .filter((t, i, all) => all.findIndex((o) => descriptorEquals(o, t)) === i);
-  if (first === undefined) {
-    throw new Error('arrayConcat needs at least one operand');
-  }
-  return rest.length === 0 ? first : union(first, ...rest);
+  return union(...operands.map((operand) => elementTypeOf(operand)));
 }
 
 // ---- map ----
@@ -2186,7 +2108,7 @@ export const mapGet = <const M extends MapOperandInput, K extends MapKeysOf<Type
 
 type MapValueType<V extends FieldType> = [Extract<V, Optional>] extends [never]
   ? V
-  : UnionType<[WithoutOptional<V>, NullType]>;
+  : Normalize<[WithoutOptional<V>, NullType]>;
 
 /** Runtime counterpart of `MapValueType<FieldsOf<...>[K]>` (same bridge shape as `propagateNull`). */
 function mapValueTypeOf<M extends Expression, K extends string>(
@@ -2312,13 +2234,9 @@ function mapFieldUnionType(value: Expression): FieldType {
   if (t === undefined || t.type !== 'map') {
     throw new Error('operand is not a map');
   }
-  const [first, ...rest] = Object.values(t.fields)
-    .map((v) => withoutOptional(v))
-    .filter((v, i, all) => all.findIndex((o) => descriptorEquals(o, v)) === i);
-  if (first === undefined) {
-    return nullType();
-  }
-  return rest.length === 0 ? first : union(first, ...rest);
+  const values = Object.values(t.fields).map((v) => withoutOptional(v));
+  // An empty map has no values at all, so there is no union to build.
+  return values.length === 0 ? nullType() : union(...values);
 }
 
 /**
@@ -2873,24 +2791,22 @@ export type AggregateWithAlias<
  *
  * - `minimum` / `maximum` ignore null and absent inputs, `first` / `last`
  *   keep them, and every one of them is `null` over an empty group (probed) —
- *   all three shapes collapse to "the value's kind, or null", so stripping the
- *   operand's own null before re-adding one avoids double-nesting
- *   (`minimum(nullable(string))` is `nullable(string)`, not
- *   `nullable(nullable(string))`).
+ *   all three shapes collapse to "the value's kind, or null". Stripping the
+ *   operand's own null first is what makes that precise even where the null
+ *   lives INSIDE the descriptor rather than beside it — a literal set's
+ *   `null` value moves out to the union member
+ *   (`minimum(literal('a', null))` is `union(literal('a'), null)`).
  * - `sum` / `average` reuse it too: their payload
  *   (`NumericResult` / `DoubleType`) is never itself nullable, so
  *   null-stripping is a no-op and this yields exactly `nullable(payload)` —
  *   the one empty-group null the no-groups row can carry (probed).
  */
-type NullableStripped<T extends FieldType> = [StripNull<T>] extends [never]
-  ? NullType
-  : UnionType<[StripNull<T>, NullType]>;
+type NullableStripped<T extends FieldType> = Normalize<[StripNull<T>, NullType]>;
 
 /** Runtime counterpart of {@link NullableStripped} (same bridge shape as `propagateNull`; `never` is `undefined`). */
 function nullableStripped<T extends FieldType>(t: T): NullableStripped<T>;
 function nullableStripped(t: FieldType): FieldType {
-  const stripped = stripNull(t);
-  return stripped === undefined ? nullType() : nullable(stripped);
+  return normalize([stripNull(t), nullType()]);
 }
 
 /**

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -11,7 +11,7 @@ import {
   type NullType,
   type Optional,
   optional,
-  type UnionType,
+  type Normalize,
 } from '../schema.js';
 import { assertNever } from '../util.js';
 import {
@@ -276,7 +276,7 @@ type OverwriteMerge<A, B> = {
 
 /**
  * Rewrites every `X & Optional` field — at ANY map depth — to
- * `UnionType<[WithoutOptional<X>, NullType]>`: null and absent group keys
+ * `Normalize<[WithoutOptional<X>, NullType]>`: null and absent group keys
  * merge into one `null` group (probed), so a group key is never absent in the
  * result schema. SHALLOW by design: group outputs are always TOP-LEVEL keys
  * (the backend rejects dotted assignment targets in `aggregate` —
@@ -298,7 +298,7 @@ export type AbsentMergesIntoNull<S extends Fields> = {
   : never;
 
 type RewriteAbsentField<T extends FieldType> = T extends Optional
-  ? UnionType<[WithoutOptional<T>, NullType]>
+  ? Normalize<[WithoutOptional<T>, NullType]>
   : T;
 
 /**

--- a/packages/firestore-repository/src/schema.test.ts
+++ b/packages/firestore-repository/src/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import { expectTypedStrictEqual } from './__test__/assertion.js';
 import {
   type AnyMapType,
   array,
@@ -49,6 +50,10 @@ import {
   ArrayUnion,
   nullType,
   nullable,
+  normalize,
+  type Normalize,
+  type NullType,
+  type UnionType,
 } from './schema.js';
 
 describe('schema', () => {
@@ -743,6 +748,154 @@ describe('document', () => {
         expect(actual).toStrictEqual(oracle);
         expectTypeOf(actual).toEqualTypeOf(oracle);
       });
+    });
+  });
+});
+
+/**
+ * Cases enumerated from the four steps of `Normalize` (flatten / dedup /
+ * drop-`never` / unwrap-singleton) and their interactions, not from any
+ * particular caller. Every case but the shape anchor is stated as "this
+ * spelling IS that canonical spelling": `expectTypedStrictEqual` pins the
+ * runtime value and the static type of both sides together, and the anchor
+ * below fixes what the canonical spelling itself denotes.
+ */
+describe('union normalization', () => {
+  it('a multi-member list is a UnionType holding the members in order', () => {
+    const t = union(string(), int64());
+    expect(t).toStrictEqual({ type: 'union', elements: [{ type: 'string' }, { type: 'int64' }] });
+    expectTypeOf(t).toEqualTypeOf<UnionType<[StringType, Int64Type]>>();
+  });
+
+  describe('1. flatten nested unions', () => {
+    it('flattens a nested union in the first position', () => {
+      expectTypedStrictEqual(
+        union(union(string(), int64()), bool()),
+        union(string(), int64(), bool()),
+      );
+    });
+
+    it('flattens a nested union in a later position', () => {
+      expectTypedStrictEqual(
+        union(bool(), union(string(), int64())),
+        union(bool(), string(), int64()),
+      );
+    });
+
+    it('flattens every nested union of a list', () => {
+      expectTypedStrictEqual(
+        union(union(bool(), string()), union(int64(), timestamp())),
+        union(bool(), string(), int64(), timestamp()),
+      );
+    });
+
+    it('flattens through multiple levels of nesting', () => {
+      expectTypedStrictEqual(
+        union(union(union(string(), int64()), bool()), timestamp()),
+        union(string(), int64(), bool(), timestamp()),
+      );
+    });
+
+    it('keeps a union whose members are not statically known whole', () => {
+      // The recursion breaker: the wide `UnionType` has no known member
+      // tuple to spread, so it stays a member of the outer union.
+      expectTypeOf<Normalize<[UnionType, NullType]>>().toEqualTypeOf<
+        UnionType<[UnionType, NullType]>
+      >();
+    });
+  });
+
+  describe('2. dedup members, keeping the first occurrence', () => {
+    it('collapses adjacent duplicates', () => {
+      expectTypedStrictEqual(union(string(), string(), int64()), union(string(), int64()));
+    });
+
+    it('collapses separated duplicates at the FIRST occurrence, preserving order', () => {
+      expectTypedStrictEqual(union(string(), int64(), string()), union(string(), int64()));
+    });
+
+    it('compares members structurally, not by identity', () => {
+      expectTypedStrictEqual(
+        union(map({ a: string() }), map({ a: string() }), int64()),
+        union(map({ a: string() }), int64()),
+      );
+    });
+
+    it('distinguishes members differing only in a nested descriptor', () => {
+      expectTypedStrictEqual(
+        union(map({ a: string() }), map({ a: int64() })),
+        union(map({ a: string() }), map({ a: int64() })),
+      );
+    });
+  });
+
+  describe('3. drop `never` members', () => {
+    // A `never` member has no runtime value; `undefined` is its runtime
+    // encoding (see `stripNull`), which the typed overload cannot express —
+    // so the two claims are made side by side here.
+    it('drops some-but-not-all `never` members', () => {
+      expect(normalize([undefined, string(), undefined, nullType()])).toStrictEqual(
+        union(string(), nullType()),
+      );
+      expectTypeOf<Normalize<[never, StringType, never, NullType]>>().toEqualTypeOf<
+        UnionType<[StringType, NullType]>
+      >();
+    });
+
+    it('leaves a single member bare once the `never`s are dropped', () => {
+      expect(normalize([undefined, string()])).toStrictEqual(string());
+      expectTypeOf<Normalize<[never, StringType]>>().toEqualTypeOf<StringType>();
+    });
+
+    it('has nothing left when every member is `never`', () => {
+      expect(() => normalize([undefined, undefined])).toThrow();
+      expectTypeOf<Normalize<[never, never]>>().toEqualTypeOf<never>();
+    });
+  });
+
+  describe('4. unwrap a singleton', () => {
+    it('a one-member list IS that member, not a union of one', () => {
+      expectTypedStrictEqual(union(string()), string());
+    });
+
+    it('an empty list has no descriptor', () => {
+      expect(() => union()).toThrow();
+      expectTypeOf<Normalize<[]>>().toEqualTypeOf<never>();
+    });
+  });
+
+  describe('the steps compose', () => {
+    it('dedups a duplicate that only flattening brings together', () => {
+      expectTypedStrictEqual(union(union(string(), int64()), string()), union(string(), int64()));
+    });
+
+    it('unwraps when dedup leaves exactly one member', () => {
+      expectTypedStrictEqual(union(string(), string()), string());
+    });
+
+    it('unwraps when flattening and dedup together leave one member', () => {
+      expectTypedStrictEqual(union(union(string(), string()), string()), string());
+    });
+  });
+
+  describe('nullable', () => {
+    it('adds NullType as the last member', () => {
+      expectTypedStrictEqual(nullable(string()), union(string(), nullType()));
+    });
+
+    it('is idempotent', () => {
+      expectTypedStrictEqual(nullable(nullable(string())), nullable(string()));
+    });
+
+    it('collapses to NullType alone when the payload is already null', () => {
+      expectTypedStrictEqual(nullable(nullType()), nullType());
+    });
+
+    it('flattens the payload union rather than nesting it', () => {
+      expectTypedStrictEqual(
+        nullable(union(string(), int64())),
+        union(string(), int64(), nullType()),
+      );
     });
   });
 });

--- a/packages/firestore-repository/src/schema.ts
+++ b/packages/firestore-repository/src/schema.ts
@@ -421,19 +421,193 @@ export const map = <T extends MapFields & WithoutDottedFieldNames<T>>(fields: T)
 };
 export const array = <T extends FieldType>(elementType: T): ArrayType<T> =>
   buildType({ type: 'array', dynamicPart: elementType });
-export const union = <T extends FieldType[]>(...elements: T): UnionType<T> =>
-  buildType({ type: 'union', elements });
+/**
+ * A union of the given member descriptors, in {@link Normalize}d (canonical)
+ * form — so the result is NOT always a `UnionType`: members that are
+ * themselves unions are flattened in, duplicates collapse, and a list that
+ * reduces to a single member yields that member BARE. Every `UnionType` in
+ * the system is produced here (or by {@link nullable}), which is what makes
+ * "a `UnionType` is canonical" true by construction: no caller has to
+ * re-normalize, and no two spellings of the same union coexist.
+ *
+ * A member list that reduces to nothing has no descriptor to return (its
+ * type is `never`), so it throws.
+ */
+export function union<T extends FieldType[]>(...elements: T): Normalize<T>;
+export function union(...elements: FieldType[]): FieldType {
+  return normalize(elements);
+}
 export const nullType = (): NullType => buildType({ type: 'null' });
 
 export const literal = <const T extends (string | number | boolean | null)[]>(
   ...values: T
 ): LiteralType<T> => buildType({ type: 'const', values });
 
-export const nullable = <T extends FieldType>(t: T): UnionType<[T, NullType]> =>
-  union(t, nullType());
+/**
+ * The descriptor widened to also admit `null`, in canonical form (see
+ * {@link union}) — hence idempotent: `nullable(nullable(t))` is
+ * `nullable(t)`, and `nullable(nullType())` is just `nullType()`.
+ */
+export function nullable<T extends FieldType>(t: T): Normalize<[T, NullType]>;
+export function nullable(t: FieldType): FieldType {
+  return normalize([t, nullType()]);
+}
 
 export const optional = <T extends FieldType>(type: T): T & Optional =>
   buildType({ ...type, optional: true });
+
+/**
+ * The canonical form of a union's member list — the ONE normalization the
+ * union constructors ({@link union} / {@link nullable}) own, so that a
+ * `UnionType` is valid by construction and never has to be re-normalized
+ * downstream. Four steps, in order:
+ *
+ * 1. {@link FlattenUnions} — a member that is itself a union contributes its
+ *    own members, so unions never nest.
+ * 2. {@link DedupDescriptors} — structurally equal members collapse, keeping
+ *    the FIRST occurrence, so the result is deterministic and order-stable.
+ * 3. {@link DropNever} — a `never` member (an empty possibility, e.g. a fully
+ *    null-stripped descriptor) contributes nothing.
+ * 4. {@link UnwrapSingleton} — a one-member list IS that member, so a union
+ *    of one is never spelled as a `UnionType`; an empty list is `never`.
+ */
+export type Normalize<T extends readonly FieldType[]> = UnwrapSingleton<
+  DropNever<DedupDescriptors<FlattenUnions<T>>>
+>;
+
+/**
+ * Runtime counterpart of {@link Normalize}, composed of the same four steps
+ * applied in the same order, each typed as its own type-level twin so the
+ * compiler checks that the steps compose.
+ *
+ * The second overload accepts `undefined` members: that is this codebase's
+ * standing runtime encoding of a type-level `never` descriptor (see
+ * `stripNull` in `pipelines/expression.ts`), which step 3 drops.
+ */
+export function normalize<T extends readonly FieldType[]>(elements: T): Normalize<T>;
+export function normalize(elements: readonly (FieldType | undefined)[]): FieldType;
+export function normalize(elements: readonly (FieldType | undefined)[]): FieldType {
+  return unwrapSingleton(dropNever(dedupDescriptors(flattenUnions(elements))));
+}
+
+/** Step 1: a member that is itself a union contributes its own members instead. */
+type FlattenUnions<T extends readonly FieldType[]> = T extends readonly [
+  infer H extends FieldType,
+  ...infer R extends readonly FieldType[],
+]
+  ? [...MembersOf<H>, ...FlattenUnions<R>]
+  : [];
+
+/**
+ * The members a single descriptor contributes to a flattened list: its own
+ * elements when it is a union (recursively — nesting can be arbitrarily
+ * deep), otherwise just itself. The wide `UnionType` (unresolved element
+ * tuple) has no member list to spread, so it stays whole — a recursion
+ * breaker in the same spirit as `StripNull`'s.
+ */
+type MembersOf<T extends FieldType> = [T] extends [never]
+  ? [never]
+  : [T] extends [{ type: 'union'; elements: infer E extends readonly FieldType[] }]
+    ? FieldType[] extends E
+      ? [T]
+      : FlattenUnions<E>
+    : [T];
+
+/** Runtime counterpart of {@link FlattenUnions}. */
+function flattenUnions<T extends readonly FieldType[]>(elements: T): FlattenUnions<T>;
+function flattenUnions(elements: readonly (FieldType | undefined)[]): (FieldType | undefined)[];
+function flattenUnions(elements: readonly (FieldType | undefined)[]): (FieldType | undefined)[] {
+  return elements.flatMap((element) =>
+    element !== undefined && element.type === 'union' ? flattenUnions(element.elements) : [element],
+  );
+}
+
+/** Step 2: first-occurrence dedup over a tuple of descriptors (mutual-`extends` equality). */
+type DedupDescriptors<
+  T extends readonly FieldType[],
+  Acc extends readonly FieldType[] = [],
+> = T extends readonly [infer H extends FieldType, ...infer R extends readonly FieldType[]]
+  ? IncludesDescriptor<Acc, H> extends true
+    ? DedupDescriptors<R, Acc>
+    : DedupDescriptors<R, [...Acc, H]>
+  : Acc;
+
+type IncludesDescriptor<T extends readonly FieldType[], X extends FieldType> = T extends readonly [
+  infer H extends FieldType,
+  ...infer R extends readonly FieldType[],
+]
+  ? DescriptorEquals<H, X> extends true
+    ? true
+    : IncludesDescriptor<R, X>
+  : false;
+
+/** Type-level descriptor equality: mutual assignability. */
+type DescriptorEquals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/** Runtime counterpart of {@link DedupDescriptors}. */
+function dedupDescriptors<T extends readonly FieldType[]>(elements: T): DedupDescriptors<T>;
+function dedupDescriptors(elements: readonly (FieldType | undefined)[]): (FieldType | undefined)[];
+function dedupDescriptors(elements: readonly (FieldType | undefined)[]): (FieldType | undefined)[] {
+  return elements.filter((e, i) => elements.findIndex((o) => descriptorEquals(o, e)) === i);
+}
+
+/**
+ * Structural descriptor equality (key-order insensitive; descriptors are
+ * plain data) — the runtime counterpart of {@link DescriptorEquals}.
+ */
+const descriptorEquals = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false;
+  }
+  const entriesA = Object.entries(a);
+  const bRecord = new Map(Object.entries(b));
+  return (
+    entriesA.length === bRecord.size &&
+    entriesA.every(([k, v]) => bRecord.has(k) && descriptorEquals(v, bRecord.get(k)))
+  );
+};
+
+/** Step 3: a `never` member is an empty possibility and contributes nothing. */
+type DropNever<T extends readonly FieldType[]> = T extends readonly [
+  infer H extends FieldType,
+  ...infer R extends readonly FieldType[],
+]
+  ? [H] extends [never]
+    ? DropNever<R>
+    : [H, ...DropNever<R>]
+  : [];
+
+/** Runtime counterpart of {@link DropNever} (`undefined` is the runtime `never`). */
+function dropNever<T extends readonly FieldType[]>(elements: T): DropNever<T>;
+function dropNever(elements: readonly (FieldType | undefined)[]): FieldType[];
+function dropNever(elements: readonly (FieldType | undefined)[]): FieldType[] {
+  return elements.filter((e) => e !== undefined);
+}
+
+/** Step 4: a one-member list IS that member; an empty list is `never`. */
+type UnwrapSingleton<T extends readonly FieldType[]> = T extends readonly [
+  infer One extends FieldType,
+]
+  ? One
+  : T extends readonly []
+    ? never
+    : UnionType<[...T]>;
+
+/** Runtime counterpart of {@link UnwrapSingleton} (`never` has no value, so it throws). */
+function unwrapSingleton<T extends readonly FieldType[]>(elements: T): UnwrapSingleton<T>;
+function unwrapSingleton(elements: readonly FieldType[]): FieldType;
+function unwrapSingleton(elements: readonly FieldType[]): FieldType {
+  const [first, ...rest] = elements;
+  if (first === undefined) {
+    throw new Error('a union must have at least one member');
+  }
+  return rest.length === 0
+    ? first
+    : buildType<UnionType>({ type: 'union', elements: [...elements] });
+}
 
 /**
  * A type-safe path to anything addressable on a **document**: either one of its


### PR DESCRIPTION
Makes `UnionType` valid-by-construction: one normalization, owned by the union constructors, replacing the ad-hoc normalization that was re-implemented at every construction site.

## The normalization

`Normalize` (type) / `normalize` (runtime twin) in `schema.ts`, four steps each declared as its own type-level twin so the compiler checks the composition:

```
Normalize<T> = UnwrapSingleton<DropNever<DedupDescriptors<FlattenUnions<T>>>>
```

1. **FlattenUnions** — a union member contributes its own members, recursively (the wide `UnionType` has no member list to spread, so it stays whole).
2. **DedupDescriptors** — first-occurrence, by `DescriptorEquals` (moved down from `expression.ts` with its runtime twin).
3. **DropNever** — `undefined` is this codebase's runtime encoding of a type-level `never`.
4. **UnwrapSingleton** — a one-member list IS that member, bare.

`union()` and `nullable()` own it, so they return `Normalize<...>` rather than necessarily a `UnionType`. Every `UnionType` in the system is therefore canonical by construction, no caller re-normalizes, and `nullable(nullable(x))` is idempotent.

## What collapsed

`EitherType`, `LogicalExtreme`, `ElementUnion`, `ConcatElementUnion`, `ArrayConstantTypeOf`, `NullableStripped`, `StripNull`'s union arm, and the hand-written `UnionType<[T, NullType]>` returns on `PropagateNull` / `PropagateAbsence` / `MapValueType` / `RewriteAbsentField`. `RebuildUnion` is deleted.

**One helper stays bespoke:** `MapFieldUnion`'s type. A record has no ordered key tuple, so it degrades to `AnyUnionType` by nature — there is no member tuple to normalize. Its runtime delegates to `union()`.

**`StripNull` survives** the refactor: it strips `null` from inside a literal value set (`literal('a', null)` → `literal('a')`), which flattening cannot reach. Its JSDoc rationale is rewritten accordingly — it previously argued from double-nesting, which canonical unions now prevent on their own.

## Changed oracles (2), both recording the new canonical form

- `arrayGet` over a union element: `nullable(union(string, int64))` → the flat `union(string, int64, null)`. This is the predicted flip — the always-nullable wrap merges into the element's own union.
- `ifAbsent` pass-through: spelled explicitly as `union(string(), nullType())` instead of `union(nullable(string()), string())`. Same value; it no longer relies on the oracle itself normalizing.

## Verification

`pnpm check` clean; full suite incl. live Enterprise DB: **760 passed | 85 skipped** (was 738). The 22 new tests are the `union normalization` describe, derived from the four steps and their interactions.

Compile cost went **down**: 1,071,468 → 684,189 instantiations, 6.95s → 4.15s — N separate conditional chains became one shared alias. No recursion bound was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)