### PR TITLE
Pipeline unnest stage

### DIFF
--- a/docs/pipeline-query-unnest-research.md
+++ b/docs/pipeline-query-unnest-research.md
@@ -1,0 +1,77 @@
+# Pipeline Query — `unnest` semantics
+
+> Empirical study of the `unnest` stage, probed against a real Firestore
+> Enterprise database (2026-07, `.ikenox/probe-unnest.mjs`).
+
+`unnest(selectable, indexField?)` emits one row per element of the array the
+selectable evaluates to, augmenting the input row with the element under the
+selectable's ALIAS (and the element's offset under `indexField`).
+
+## Identity
+
+- **Read-identity is PRESERVED**: every emitted row carries its source
+  document's `ref`. Unlike `select` / `aggregate` / `distinct`, `unnest` does
+  not break identity.
+- **But ids are no longer unique across rows**: a document with an n-element
+  array yields n rows that all carry the SAME id. Identity here means "this row
+  came from that document", not "one row per document".
+
+## Row shaping
+
+- **The source field survives**: unnesting `t` under the alias `e` leaves `t`
+  (the whole array) in the row alongside `e`.
+- **Aliasing onto the source's own name replaces it**: `field('t').as('t')`
+  yields rows whose `t` is the ELEMENT, with no trace of the array. Same for
+  the un-aliased form.
+- **An un-aliased bare `Field` works**, keyed by its own path — the `Field`-is-
+  a-selectable model, consistent with `select` / groups.
+- **The index field overwrites a colliding existing field** (`indexField: 'n'`
+  replaces the document's `n`).
+- Net effect on the schema: the alias (and the index field) are overlaid on the
+  input context, added-field-wins — i.e. exactly `addFields` semantics.
+
+## Output shape restrictions (`TOP_LEVEL_PROPERTY_PATH_ONLY`)
+
+- A **dotted alias** and a **dotted `indexField`** are both INVALID_ARGUMENT —
+  the same restriction `aggregate` / `distinct` have.
+- The **SOURCE path may be dotted**: `field('m.k').as('e')` unnests a nested
+  array fine. Only the OUTPUT name is restricted to top level.
+
+## Non-array / empty / null / absent
+
+The SDK's own doc comment says a non-array value makes the stage "a no-op ...
+returning it as is with the `alias` field absent". **The probe contradicts
+that** — the alias is set to the value:
+
+| source value    | rows emitted | alias                                   | index field |
+| --------------- | ------------ | --------------------------------------- | ----------- |
+| `['a','b']`     | 2            | `'a'` / `'b'`                           | `0` / `1`   |
+| `['p', null]`   | 2            | `'p'` / `null` (null ELEMENTS are kept) | `0` / `1`   |
+| `[]` (empty)    | **0**        | —                                       | —           |
+| `null`          | 1            | **`null`**                              | **`null`**  |
+| `7` (non-array) | 1            | **`7`**                                 | **`null`**  |
+| absent          | 1            | **absent**                              | **`null`**  |
+
+- So the no-op row passes the VALUE through to the alias; only a genuinely
+  absent source leaves the alias absent.
+- **The index field is always present on emitted rows**, `null` on every no-op
+  row — including the absent-source row, where the alias itself is absent. The
+  two do not travel together.
+- An empty array emits nothing at all, so a row whose source was a real array
+  always has a real (int64) index.
+
+## Library consequences (design)
+
+Schema: the input context with the alias overlaid (added-field-wins,
+`addFields`-shaped), plus the index field when requested.
+
+| source descriptor    | alias descriptor | index descriptor    |
+| -------------------- | ---------------- | ------------------- |
+| `array(E)`           | `E`              | `int64()`           |
+| `nullable(array(E))` | `nullable(E)`    | `nullable(int64())` |
+| `optional(array(E))` | `E & Optional`   | `nullable(int64())` |
+
+(The non-array-scalar column has no row: a typed selectable is array-valued by
+construction, so that cell is unreachable through the library.)
+
+Identity: preserved (`Id` threads through), with the duplicate-id caveat above.

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -676,6 +676,34 @@ nullable(T)`); count family unaffected. Also probe the un-probed
       `BuildAddFieldsSchema`). Note one arm is irreducible: `UndottedGroupAliases`
       is a parameter intersection over the user's un-normalized tuple, so it
       must keep matching the input forms directly.
+
+      **The invariant that makes this a concept and not a coincidence** (noted
+      2026-07 while reviewing `unnest`): a bare `Field` and an
+      `ExpressionWithAlias` are accepted TOGETHER at every site — `Selection`,
+      `AggregateGroup`, `UnnestSelectable` — with `addFields` the lone
+      exception, and it is not a counterexample: it excludes BARENESS as a
+      category (the bare string form too), because a bare form names an
+      EXISTING field, so re-adding it under its own name is a no-op at best and,
+      through an optional map, silently materializes empty maps. So the real
+      axis is not "`Field` vs aliased" but "bare (names an existing field) vs
+      aliased (names a new output)". Under that framing the target shape falls
+      out — one parameterized concept plus each site's own bare-string form and
+      value constraint:
+
+      ```ts
+      type Selectable<Context, V extends FieldType = FieldType> =
+        | Field<V, MapFieldPath<Context>>
+        | ExpressionWithAlias<V>;
+
+      type Selection<Context> = MapFieldPath<Context> | Selectable<Context>;
+      type AggregateGroup<Context> = (keyof Context & string) | Selectable<Context>;
+      type UnnestSelectable<Context> = Selectable<Context, ArrayValued>;
+      // addFields stays ExpressionWithAlias[] — the documented bareness exclusion
+      ```
+
+      `unnest` made this a THIRD site spelling the same union by hand, so the
+      duplication now costs more than when it was first noted.
+
 - [ ] **Align AST node names with the SDK's vocabulary** (decided 2026-07):
       the aggregate node ships as `AggregateFunction` (the SDK's name), which
       makes the pair with the expression node asymmetric — rename

--- a/docs/plan/pipeline-query.md
+++ b/docs/plan/pipeline-query.md
@@ -38,6 +38,13 @@ Related research / decisions:
   (a bare collection input, no transformation stages).
 - `collection(def).sort((field) => [asc(field('rank')), desc(...)])`
   → sorted results.
+- `collection(def).unnest((field) => ({ selectable: field('t').as('e'), indexField? }))`
+  → one row per array element. **Schema effect:** `addFields`-shaped
+  augmentation (the alias — and the index field — overlaid on the input
+  context, added-field-wins; the source array survives unless the alias reuses
+  its name). **Identity:** PRESERVED (`Id` threads through), with the caveat
+  that ids are no longer unique across rows — an n-element array yields n rows
+  carrying the SAME source id.
 
 Both work end-to-end through **both** adapters' executors; the spec suite
 (`fetch all` + `sort` asc/desc) passes against
@@ -292,7 +299,34 @@ Transformation stages already stubbed:
 - [x] `limit(N)` / `offset(N)` — stages carry the count, executors translate
       to `sdk.limit/offset`, schema unchanged, identity preserved. Verified live
       incl. offset+limit paging and an over-sized limit.
-- [ ] `unnest(...)` — Context augmentation + identity preserve.
+- [x] `unnest(...)` — done (2026-07; semantics in
+      `../pipeline-query-unnest-research.md`). The
+      `unnest((field) => ({ selectable, indexField? }))` stage emits one row per
+      array element, augmenting the row with
+      the element under the selectable's output name (and its int64 offset under
+      `indexField`). Identity is PRESERVED (`Id` threads through) — but ids are
+      no longer unique across rows: an n-element array yields n rows carrying the
+      SAME source id (probed, and pinned by a live same-id test). `selectable`
+      takes the two selection forms (a bare array-valued `Field`, or an aliased
+      array-valued expression) — array-valued by construction (`ArrayValued` /
+      `ArrayElementType`), which makes the non-array no-op cell unreachable
+      through the library. Output names are TOP-LEVEL only: a dotted alias AND a
+      dotted `indexField` are both rejected (`UndottedSelectionAlias` /
+      `UndottedIndexField` at the `Pipeline.unnest` parameter — probed
+      INVALID_ARGUMENT), while the SOURCE path may be dotted. Schema effect is
+      `addFields`-shaped (`UnnestSchema` = `MergeSchemas<overlay, Context>`,
+      added-field-wins — so aliasing onto the source's own name replaces the
+      array with the element; the source field otherwise survives). The alias
+      and index descriptors are derived from the source array by DIFFERENT rules
+      (they do not travel together — probed): `array(E)` → alias `E`, index
+      `int64()`; `nullable(array(E))` → `nullable(E)` / `nullable(int64())`;
+      `optional(array(E))` → `E & Optional` / `nullable(int64())`. Absence
+      reaches the ALIAS only (an absent source emits a no-op row whose alias is
+      itself absent — `PreserveOptional`), while the index picks up null from
+      BOTH the null and absent cases (`PropagateNull`). Both executors via
+      `sdk.unnest({ selectable, indexField })`. Verified live (google-cloud) —
+      the spec reproduces every probed cell incl. empty-array (0 rows),
+      null-element, and the index-null-on-absent-alias asymmetry.
 - [ ] `replaceWith(...)` — Context replacement + identity break.
 - [ ] `union(other)` — combine sources; identity break (conservative).
 - [ ] `findNearest(...)` — vector search; behavior TBD.

--- a/packages/firebase-js-sdk/src/pipeline.ts
+++ b/packages/firebase-js-sdk/src/pipeline.ts
@@ -247,6 +247,13 @@ const applyStage = (db: Firestore, sdk: SdkPipeline, stage: TransformStage): Sdk
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
+      // The options-object form: `selectable` translates exactly like a `select`
+      // selection (a bare `Field` or an aliased expression), and `indexField` is
+      // passed through only when set (spread, for `exactOptionalPropertyTypes`).
+      return sdk.unnest({
+        selectable: toSdkSelectable(db, stage.selectable),
+        ...(stage.indexField !== undefined ? { indexField: stage.indexField } : {}),
+      });
     case 'replaceWith':
     case 'union':
     case 'findNearest':

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -1941,6 +1941,24 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
         );
       });
 
+      it('a bare Field selectable needs no alias: its path is its output name', async () => {
+        // A `Field` is inherently aliased, so `field('t')` is the `.as('t')` form
+        // above — same rows, and the executor translates it through the bare-Field
+        // arm of the selectable conversion.
+        await expectPipeline(
+          src().unnest((field) => ({ selectable: field('t') })),
+          [
+            { id: ['u1'], data: { t: 'a' } },
+            { id: ['u1'], data: { t: 'b' } },
+            { id: ['u3'], data: { t: null } },
+            { id: ['u4'], data: {} },
+            { id: ['u6'], data: { t: 'p' } },
+            { id: ['u6'], data: { t: null } },
+          ],
+          { ordered: false },
+        );
+      });
+
       it('rows from the SAME document carry the SAME id (identity preserved, not unique)', async () => {
         // The decided semantics: unnest does not break identity, but a 2-element
         // array yields two rows that BOTH carry the source document's id.

--- a/packages/firestore-repository/src/__test__/pipeline-spec.ts
+++ b/packages/firestore-repository/src/__test__/pipeline-spec.ts
@@ -128,6 +128,7 @@ import {
 } from '../pipelines/source.js';
 import type { Doc, DocRef, FirestoreEnvironment, PlainRepository } from '../repository.js';
 import {
+  array,
   double,
   int64,
   map,
@@ -1848,6 +1849,135 @@ export const definePipelineSpecificationTests = <Env extends FirestoreEnvironmen
             { data: { cat: 'y', q: 'b' } },
             { data: { cat: 'y', q: null } },
             { data: { cat: 'z', q: 'a' } },
+          ],
+          { ordered: false },
+        );
+      });
+    });
+
+    // The `unnest` stage, seeded to reproduce EVERY cell of the probe matrix in
+    // docs/pipeline-query-unnest-research.md. Unlike select/distinct/aggregate,
+    // `unnest` PRESERVES read-identity: rows still carry `id` — but ids are no
+    // longer unique across rows (an n-element array yields n rows with the SAME
+    // id). The source field survives alongside the alias (addFields-shaped
+    // overlay). Multi-row outputs are order-independent (`{ ordered: false }`).
+    describe('unnest', () => {
+      // `t` is optional + nullable + array-of-nullable-string, so ONE field
+      // exercises every non-happy cell: a real array (u1), an empty array (u2 —
+      // emits nothing), a null source (u3), an absent source (u4), and a null
+      // ELEMENT (u6). The element type stays nullable so the null element is
+      // representable.
+      const unnestCollection = rootCollection({
+        name: 'Unnest',
+        schema: { t: optional(nullable(array(nullable(string())))) },
+      });
+      type UnnestDoc = Doc<typeof unnestCollection>;
+      const unnestItems: UnnestDoc[] = [
+        { id: ['u1'], data: { t: ['a', 'b'] } }, //   2-element array
+        { id: ['u2'], data: { t: [] } }, //           empty array → 0 rows
+        { id: ['u3'], data: { t: null } }, //         null source → 1 no-op row
+        { id: ['u4'], data: {} }, //                  absent source → 1 no-op row
+        { id: ['u6'], data: { t: ['p', null] } }, //  a null ELEMENT is kept
+      ];
+
+      let coll: typeof unnestCollection;
+      beforeEach(async () => {
+        coll = uniqueCollection(unnestCollection);
+        await createRepository(coll).batchSet(unnestItems);
+      });
+      const src = () => collectionInput(coll);
+
+      it('emits one row per element, passing null/empty/absent through per the probed matrix', async () => {
+        // u1 ['a','b'] → 2 rows; u2 [] → 0 rows; u3 null → one row alias null;
+        // u4 absent → one row alias ABSENT (omitted); u6 ['p',null] → 2 rows,
+        // the null element kept. The source field `t` survives alongside `e`.
+        // Every row keeps its source `id` (identity preserved).
+        await expectPipeline(
+          src().unnest((field) => ({ selectable: field('t').as('e') })),
+          [
+            { id: ['u1'], data: { t: ['a', 'b'], e: 'a' } },
+            { id: ['u1'], data: { t: ['a', 'b'], e: 'b' } },
+            { id: ['u3'], data: { t: null, e: null } },
+            { id: ['u4'], data: {} },
+            { id: ['u6'], data: { t: ['p', null], e: 'p' } },
+            { id: ['u6'], data: { t: ['p', null], e: null } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('the index field is always present, null on every no-op row (even the absent-alias one)', async () => {
+        // The alias/index asymmetry: on the ABSENT-source row (u4) the alias `e`
+        // is ABSENT (omitted) but the index `i` is null (present). null source
+        // (u3) nulls both; a real array carries a real int64 offset.
+        await expectPipeline(
+          src().unnest((field) => ({ selectable: field('t').as('e'), indexField: 'i' })),
+          [
+            { id: ['u1'], data: { t: ['a', 'b'], e: 'a', i: 0 } },
+            { id: ['u1'], data: { t: ['a', 'b'], e: 'b', i: 1 } },
+            { id: ['u3'], data: { t: null, e: null, i: null } },
+            { id: ['u4'], data: { i: null } },
+            { id: ['u6'], data: { t: ['p', null], e: 'p', i: 0 } },
+            { id: ['u6'], data: { t: ['p', null], e: null, i: 1 } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('an alias onto the source own name replaces the array with the element', async () => {
+        // `field('t').as('t')`: rows whose `t` is the ELEMENT, no trace of the
+        // array (probed). The no-op rows keep the pass-through value under `t`.
+        await expectPipeline(
+          src().unnest((field) => ({ selectable: field('t').as('t') })),
+          [
+            { id: ['u1'], data: { t: 'a' } },
+            { id: ['u1'], data: { t: 'b' } },
+            { id: ['u3'], data: { t: null } },
+            { id: ['u4'], data: {} },
+            { id: ['u6'], data: { t: 'p' } },
+            { id: ['u6'], data: { t: null } },
+          ],
+          { ordered: false },
+        );
+      });
+
+      it('rows from the SAME document carry the SAME id (identity preserved, not unique)', async () => {
+        // The decided semantics: unnest does not break identity, but a 2-element
+        // array yields two rows that BOTH carry the source document's id.
+        const results = await executor.execute(
+          src().unnest((field) => ({ selectable: field('t').as('e') })),
+        );
+        const u1Rows = results.filter((r) => r.id[0] === 'u1');
+        expect(u1Rows).toHaveLength(2);
+        // Both rows are the SAME document ref, differing only in the element.
+        expect(u1Rows.map((r) => r.id)).toStrictEqual([['u1'], ['u1']]);
+        assert.sameDeepMembers(
+          u1Rows.map((r) => r.data.e),
+          ['a', 'b'],
+        );
+      });
+    });
+
+    // `unnest` of a NESTED array via a dotted SOURCE path — the source path may
+    // be dotted (only the OUTPUT name is top-level-restricted, probed). Its own
+    // collection keeps the surviving-fields noise out of the matrix above.
+    describe('unnest (nested source path)', () => {
+      const nestedCollection = rootCollection({
+        name: 'UnnestNested',
+        schema: { m: map({ k: array(string()) }) },
+      });
+      let coll: typeof nestedCollection;
+      beforeEach(async () => {
+        coll = uniqueCollection(nestedCollection);
+        await createRepository(coll).batchSet([{ id: ['mk1'], data: { m: { k: ['x', 'y'] } } }]);
+      });
+
+      it('unnests a non-empty nested array addressed by a dotted source path', async () => {
+        await expectPipeline(
+          collectionInput(coll).unnest((field) => ({ selectable: field('m.k').as('e') })),
+          [
+            { id: ['mk1'], data: { m: { k: ['x', 'y'] }, e: 'x' } },
+            { id: ['mk1'], data: { m: { k: ['x', 'y'] }, e: 'y' } },
           ],
           { ordered: false },
         );

--- a/packages/firestore-repository/src/pipelines/expression.ts
+++ b/packages/firestore-repository/src/pipelines/expression.ts
@@ -28,6 +28,7 @@ import {
   nullType,
   type NullType,
   type Optional,
+  optional,
   string,
   type StringType,
   timestamp,
@@ -818,6 +819,35 @@ type ElementsOf<T extends FieldType> = T extends {
   : FieldType;
 
 /**
+ * The ELEMENT descriptor of an array-valued descriptor, read THROUGH the
+ * value's null-ness and absence: `array(E)`, `nullable(array(E))` and
+ * `optional(array(E))` all yield `E`. Null-ness/absence of the array itself is
+ * a property of the CONTAINER, so it never belongs to the element domain —
+ * whether it re-surfaces on a derived descriptor is each caller's rule (see
+ * `UnnestAliasType`, which re-applies it, and `arrayGet`, which does not).
+ */
+export type ArrayElementType<T extends FieldType> = ElementsOf<StripNull<T>>;
+
+/**
+ * Runtime counterpart of {@link ArrayElementType}, typed as that operator
+ * applied to its input (the overload signature carries the type-level result;
+ * the loose implementation check is the runtime-to-type bridge, mirroring the
+ * type's `StripNull` then `ElementsOf` composition step for step).
+ *
+ * Throws for a non-array descriptor: the type-level `FieldType` fallback of
+ * `ElementsOf` is unreachable through the typed API (every caller constrains
+ * its operand to {@link ArrayValued}), so a throw is the defensive equivalent.
+ */
+export function arrayElementType<T extends FieldType>(t: T): ArrayElementType<T>;
+export function arrayElementType(t: FieldType): FieldType {
+  const stripped = stripNull(t);
+  if (stripped === undefined || stripped.type !== 'array') {
+    throw new Error('descriptor is not an array');
+  }
+  return stripped.dynamicPart;
+}
+
+/**
  * Whether `value` equals ANY element of the `options` array. Total like the
  * comparisons (probed): an absent value or a no-match is `false` — a null
  * ELEMENT is matched as a value (`equalAny(null-field, constant([null]))` is
@@ -861,7 +891,7 @@ export const notEqualAny = <const L extends OperandInput, const R extends ArrayO
  * `not` mirror it), and so do most value functions. The comparison
  * operators do NOT: they are total (never null).
  */
-type PropagateNull<Operands extends FieldType, T extends FieldType> = [
+export type PropagateNull<Operands extends FieldType, T extends FieldType> = [
   Extract<Operands['firestoreType'], 'null'> | Extract<Operands, Optional>,
 ] extends [never]
   ? T
@@ -884,6 +914,24 @@ function propagateNull<Ops extends readonly Expression[], T extends FieldType>(
 ): PropagateNull<Ops[number]['type'], T>;
 function propagateNull(operands: readonly Expression[], type: FieldType): FieldType {
   return operands.some((operand) => mayBeNull(operand.type)) ? nullable(type) : type;
+}
+
+/**
+ * DESCRIPTOR-level counterpart of {@link PropagateNull}: the same operator for
+ * callers that hold a descriptor rather than the operand expressions.
+ *
+ * A separate entry point rather than a widened `propagateNull`, because the
+ * two calling conventions are not interchangeable: a stage may propagate from a
+ * descriptor that no expression carries — `unnest` propagates from the source
+ * field's descriptor AFTER `WithConditionality` has moved ancestor optionality
+ * onto it, which the `Field` node's own `type` does not record.
+ */
+export function propagateNullType<T extends FieldType, X extends FieldType>(
+  source: T,
+  type: X,
+): PropagateNull<T, X>;
+export function propagateNullType(source: FieldType, type: FieldType): FieldType {
+  return mayBeNull(source) ? nullable(type) : type;
 }
 
 /**
@@ -953,14 +1001,49 @@ const mayBeAbsent = (t: FieldType & { optional?: boolean }): boolean => t.option
  */
 export type WithoutOptional<T extends FieldType> = T extends Optional ? Omit<T, 'optional'> : T;
 
-/** Runtime counterpart of {@link WithoutOptional}. */
-export const withoutOptional = (t: FieldType & { optional?: boolean }): FieldType => {
+/**
+ * Runtime counterpart of {@link WithoutOptional}, typed as that operator
+ * applied to its input (same overload bridge shape as `propagateNull`).
+ */
+export function withoutOptional<T extends FieldType>(t: T): WithoutOptional<T>;
+export function withoutOptional(t: FieldType & { optional?: boolean }): FieldType {
   if (t.optional !== true) {
     return t;
   }
   const { optional: _optional, ...rest } = t;
   return rest;
-};
+}
+
+/**
+ * The inverse of {@link WithoutOptional}: re-applies `source`'s absence marker
+ * to a descriptor `derived` computed from it. For the stages whose output slot
+ * is absent exactly when the input slot was — `unnest`'s alias, which is absent
+ * only for an absent source (probed) — so absence CARRIES OVER rather than
+ * being observed as null.
+ *
+ * The `infer R extends FieldType` re-binding discharges the descriptor
+ * constraint lazily (the `AbsentMergesIntoNull` idiom): over an unresolved
+ * `Derived` the `Derived & Optional` arm is not PROVABLY a `FieldType`, so
+ * without it the result is rejected wherever a descriptor is required. Identity
+ * on every instantiation, so callers need no re-binding of their own.
+ */
+export type PreserveOptional<Source extends FieldType, Derived extends FieldType> = (
+  Source extends Optional ? Derived & Optional : Derived
+) extends infer R extends FieldType
+  ? R
+  : never;
+
+/** Runtime counterpart of {@link PreserveOptional} (same overload bridge shape as `propagateNull`). */
+export function preserveOptional<Source extends FieldType, Derived extends FieldType>(
+  source: Source,
+  derived: Derived,
+): PreserveOptional<Source, Derived>;
+export function preserveOptional(
+  source: FieldType & { optional?: boolean },
+  derived: FieldType,
+): FieldType {
+  return source.optional === true ? optional(derived) : derived;
+}
 
 /**
  * The type of "one of these two expressions' values" — the return descriptor
@@ -1951,8 +2034,16 @@ const typeNameLiteral = (): LiteralType<FirestoreTypeName[]> =>
 // false). `arrayContainsAll`/`arrayContainsAny` take one array-typed
 // options expression, like `equalAny`.
 
+/**
+ * The descriptor domain of an ARRAY-valued expression — null-tolerated like
+ * every {@link Valued} domain, so `array(E)`, `nullable(array(E))` and
+ * `optional(array(E))` all qualify. Exported because it is also the constraint
+ * on the `unnest` stage's selectable, which is array-valued by construction.
+ */
+export type ArrayValued = Valued<readonly FirestoreType[]>;
+
 /** An array-domain operand. */
-type ArrayOperand = Expression<Valued<readonly FirestoreType[]>>;
+type ArrayOperand = Expression<ArrayValued>;
 
 /** The deduped element-type union of a tuple of element expressions. */
 type ElementUnion<Els extends readonly Expression[]> = RebuildUnion<
@@ -2034,14 +2125,10 @@ export const arrayGet = <
   return new FunctionCall(nullable(elementTypeOf(v)), { name: 'arrayGet', value: v, index: i });
 };
 
-/** Runtime counterpart of `ElementsOf<StripNull<...>>` (same bridge shape as `propagateNull`). */
-function elementTypeOf<Arr extends Expression>(value: Arr): ElementsOf<StripNull<Arr['type']>>;
+/** {@link arrayElementType} over an EXPRESSION (same bridge shape as `propagateNull`). */
+function elementTypeOf<Arr extends Expression>(value: Arr): ArrayElementType<Arr['type']>;
 function elementTypeOf(value: Expression): FieldType {
-  const t = stripNull(value.type);
-  if (t === undefined || t.type !== 'array') {
-    throw new Error('operand is not an array');
-  }
-  return t.dynamicPart;
+  return arrayElementType(value.type);
 }
 
 /** Whether the array contains the element (a null element is compared as a value). */
@@ -2222,7 +2309,7 @@ type WithoutDottedKeys<F> = {
   [K in keyof F]: K extends `${string}.${string}` ? never : F[K];
 };
 /** A key literal that must not contain the path separator. */
-type UndottedKey<K extends string> = K extends `${string}.${string}` ? never : K;
+export type UndottedKey<K extends string> = K extends `${string}.${string}` ? never : K;
 
 /** Builds a map EXPRESSION from field-value expressions — `mapValue({ x: field('num') })`. See {@link arrayValue}. */
 export const mapValue = <const F extends Readonly<Record<string, OperandInput>>>(

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -6,7 +6,17 @@ import {
   postsCollection,
 } from '../__test__/specification.js';
 import type { DocRef } from '../repository.js';
-import type { StringType } from '../schema.js';
+import {
+  array,
+  type DoubleType,
+  type LiteralType,
+  map,
+  type MapType,
+  type Optional,
+  rootCollection,
+  string,
+  type StringType,
+} from '../schema.js';
 import { countAll, documentId, equal, field, sum } from './expression.js';
 import { collection, type Pipeline, type PipelineResult } from './index.js';
 import { asc } from './ordering.js';
@@ -170,6 +180,34 @@ describe('pipeline', () => {
     void _rejections;
   });
 
+  // A nested array — the shape that distinguishes `unnest`'s output-name rule
+  // from `select`'s: the SOURCE path may be dotted, the OUTPUT name may not.
+  const nestedArrayCollection = rootCollection({
+    name: 'NestedArray',
+    schema: { m: map({ k: array(string()) }) },
+  });
+
+  it('unnest takes a bare Field: its path IS its output name, so it replaces the source', () => {
+    type SchemaOf<P> = P extends Pipeline<infer S, infer _I> ? S : never;
+
+    // No `.as(...)` needed — a `Field` is inherently aliased (the SDK's
+    // `Selectable` model), so `field('tag')` names its own output. Because that
+    // output name IS the source's name, the array is replaced by the element.
+    const bare = base.unnest((field) => ({ selectable: field('tag') }));
+    expectTypeOf<SchemaOf<typeof bare>>().toEqualTypeOf<{
+      name: StringType;
+      profile: MapType<{ age: DoubleType; gender: LiteralType<['male', 'female']> & Optional }>;
+      rank: DoubleType;
+      tag: StringType;
+    }>();
+    // Identical to spelling the alias out, exactly as in `select`.
+    const aliased = base.unnest((field) => ({ selectable: field('tag').as('tag') }));
+    expectTypeOf<SchemaOf<typeof bare>>().toEqualTypeOf<SchemaOf<typeof aliased>>();
+    expect(bare.stages().transforms).toEqual([
+      { kind: 'unnest', selectable: field(base.node.schema.tag, 'tag') },
+    ]);
+  });
+
   it('unnest PRESERVES identity: rows keep `id`, and the pipeline stays identity-preserving', () => {
     type RowOf<P> = P extends Pipeline<infer S, infer I> ? PipelineResult<S, I> : never;
 
@@ -214,6 +252,13 @@ describe('pipeline', () => {
       // The selectable must be ARRAY-valued — a scalar field is not unnestable.
       // @ts-expect-error -- a non-array selectable is rejected
       base.unnest((field) => ({ selectable: field('name').as('n') }));
+      // A BARE `Field` at a dotted path is rejected too: its path IS its output
+      // name, so it would be a dotted output. This is where `unnest` parts ways
+      // with `select`, which accepts the same selectable and nests it instead —
+      // reach a nested array with an explicit top-level alias.
+      // @ts-expect-error -- a dotted bare Field is not a top-level output
+      collection(nestedArrayCollection).unnest((field) => ({ selectable: field('m.k') }));
+      collection(nestedArrayCollection).unnest((field) => ({ selectable: field('m.k').as('e') }));
     };
     void _rejections;
   });

--- a/packages/firestore-repository/src/pipelines/pipeline.test.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../__test__/specification.js';
 import type { DocRef } from '../repository.js';
 import type { StringType } from '../schema.js';
-import { countAll, documentId, equal, sum } from './expression.js';
+import { countAll, documentId, equal, field, sum } from './expression.js';
 import { collection, type Pipeline, type PipelineResult } from './index.js';
 import { asc } from './ordering.js';
 
@@ -166,6 +166,54 @@ describe('pipeline', () => {
       // existing field under its own name is meaningless. See BuildAddFieldsSchema.
       // @ts-expect-error -- addFields takes aliased expressions only
       base.addFields((field) => [field('rank')]);
+    };
+    void _rejections;
+  });
+
+  it('unnest PRESERVES identity: rows keep `id`, and the pipeline stays identity-preserving', () => {
+    type RowOf<P> = P extends Pipeline<infer S, infer I> ? PipelineResult<S, I> : never;
+
+    // `tag` is an array field; unnesting it keeps read-identity — an emitted row
+    // still came from its source document (though ids are no longer unique
+    // across rows). Contrast the identity-BREAKING stages above.
+    const unnested = base.unnest((field) => ({ selectable: field('tag').as('t') }));
+    expectTypeOf<RowOf<typeof unnested>>().toHaveProperty('id');
+
+    // Assignable where an identity-preserving pipeline is expected (the schema is
+    // the input context with the alias `t` overlaid). Threads the SAME `Id`.
+    const _preserving: Pipeline<
+      AuthorsCollection['schema'] & { t: StringType },
+      DocRef<AuthorsCollection>
+    > = unnested;
+    void _preserving;
+
+    // A downstream preserving stage keeps it, and the stage node carries the
+    // selectable (plus the index field when requested).
+    const withIndex = base.unnest((field) => ({
+      selectable: field('tag').as('t'),
+      indexField: 'i',
+    }));
+    expectTypeOf<RowOf<typeof withIndex>>().toHaveProperty('id');
+    expect(withIndex.stages().transforms).toEqual([
+      {
+        kind: 'unnest',
+        selectable: { expression: field(base.node.schema.tag, 'tag'), alias: 't' },
+        indexField: 'i',
+      },
+    ]);
+  });
+
+  it('unnest rejects dotted output names and a non-array selectable at the type level', () => {
+    const _rejections = () => {
+      // A dotted ALIAS is not a top-level output (TOP_LEVEL_PROPERTY_PATH_ONLY).
+      // @ts-expect-error -- a dotted unnest alias is rejected
+      base.unnest((field) => ({ selectable: field('tag').as('out.t') }));
+      // A dotted INDEX field is likewise top-level only.
+      // @ts-expect-error -- a dotted unnest indexField is rejected
+      base.unnest((field) => ({ selectable: field('tag').as('t'), indexField: 'ix.j' }));
+      // The selectable must be ARRAY-valued — a scalar field is not unnestable.
+      // @ts-expect-error -- a non-array selectable is rejected
+      base.unnest((field) => ({ selectable: field('name').as('n') }));
     };
     void _rejections;
   });

--- a/packages/firestore-repository/src/pipelines/pipeline.ts
+++ b/packages/firestore-repository/src/pipelines/pipeline.ts
@@ -24,11 +24,16 @@ import {
   buildDistinctSchema,
   buildSelectionSchema,
   type BuildSelectionSchema,
+  buildUnnestSchema,
   type DistinctSchema,
   dropOverriddenSelections,
   type ExpressionWithAlias,
   type Selection,
   type UndottedGroupAliases,
+  type UndottedIndexField,
+  type UndottedSelectionAlias,
+  type UnnestSchema,
+  type UnnestSelectable,
 } from './selection.js';
 import type { InputStage, TransformStage } from './stage.js';
 
@@ -205,9 +210,51 @@ export class Pipeline<
       parent: this.node,
     });
   }
-  // TODO
-  unnest(..._args: unknown[]): Pipeline<Fields, Id> {
-    return unimplemented();
+  /**
+   * Emits one row per element of the array `selectable` evaluates to, adding the
+   * element under the selectable's output name — and the element's zero-based
+   * offset under `indexField` when one is requested. Identity-PRESERVING (`Id`
+   * threads through unchanged): an emitted row still came from its source
+   * document, so it keeps that document's ref.
+   *
+   * **⚠️ ids are no longer unique across rows.** A document with an n-element
+   * array yields n rows that ALL carry the SAME id — identity here means "this
+   * row came from that document", not "one row per document". (An empty array
+   * emits NO row, so a row from a real array always carries a real element and a
+   * real int64 index; probed.)
+   *
+   * The schema effect is `addFields`-shaped: the input context with the alias
+   * (and the index field) overlaid, added-field-wins — so aliasing onto the
+   * SOURCE's own name (`field('t').as('t')`) replaces the array with the
+   * element, and the source field otherwise survives alongside the alias.
+   *
+   * `selectable` accepts a bare {@link Field} (its path is its output name) or
+   * an aliased expression, and must be ARRAY-valued. Its output name — and
+   * `indexField` — are TOP-LEVEL only (a dotted alias and a dotted index field
+   * are both rejected: the backend's `TOP_LEVEL_PROPERTY_PATH_ONLY`, probed).
+   * The SOURCE path MAY be dotted: `field('m.k').as('e')` unnests a nested array.
+   *
+   * The alias and the index do not travel together over a non-array source
+   * (probed): a null source emits one row whose alias is `null` and whose index
+   * is `null`; an ABSENT source emits one row whose alias is ABSENT but whose
+   * index is still `null`. So absence reaches the alias only, while the index
+   * picks up null from both the null and absent cases — see {@link UnnestSchema}.
+   */
+  unnest<
+    const Sel extends UnnestSelectable<Schema>,
+    const Index extends string | undefined = undefined,
+  >(
+    spec: (field: FieldProvider<Schema>) => {
+      selectable: Sel & UndottedSelectionAlias<Sel>;
+      indexField?: Index & UndottedIndexField<Index>;
+    },
+  ): Pipeline<UnnestSchema<Schema, Sel, Index>, Id> {
+    const { selectable, indexField } = spec(fieldProvider(this.node.schema));
+    return new Pipeline<UnnestSchema<Schema, Sel, Index>, Id>({
+      schema: buildUnnestSchema<Schema, Sel, Index>(this.node.schema, selectable, indexField),
+      stage: { kind: 'unnest', selectable, ...(indexField !== undefined ? { indexField } : {}) },
+      parent: this.node,
+    });
   }
   /**
    * Groups the rows by the `groups` keys (the whole input when omitted) and

--- a/packages/firestore-repository/src/pipelines/selection.test.ts
+++ b/packages/firestore-repository/src/pipelines/selection.test.ts
@@ -19,7 +19,16 @@ import {
   string,
   type StringType,
 } from '../schema.js';
-import { constant, countAll, equal, field, type Field, greaterThan, sum } from './expression.js';
+import {
+  arrayReverse,
+  constant,
+  countAll,
+  equal,
+  field,
+  type Field,
+  greaterThan,
+  sum,
+} from './expression.js';
 import {
   type BuildAddFieldsSchema,
   buildAddFieldsSchema,
@@ -27,6 +36,7 @@ import {
   buildDistinctSchema,
   type BuildSelectionSchema,
   buildSelectionSchema,
+  buildUnnestSchema,
   type ExpressionWithAlias,
 } from './selection.js';
 
@@ -787,5 +797,166 @@ describe('buildDistinctSchema (runtime)', () => {
       // @ts-expect-error -- a dotted BARE path is not a top-level group key
       void buildDistinctSchema(schema, ['profile.gender']);
     });
+  });
+});
+
+// Stage-schema synthesis of the `unnest` stage. The overlay is `addFields`-shaped
+// (the alias — and index field — merged over the input context, added-field-wins,
+// so the whole context survives), and the alias/index descriptors are derived
+// from the source array's descriptor by two DIFFERENT rules. The matrix here is
+// derived from that domain structure: the three source-descriptor rows of
+// `docs/pipeline-query-unnest-research.md` (`array(E)` / `nullable(array(E))` /
+// `optional(array(E))`, E = the element descriptor) × (with / without an index
+// field), plus the placement cases (nested source path, alias-replaces-source,
+// alias-collides-unrelated, index-collides-existing, bare `Field` vs aliased,
+// optional ANCESTOR on the source path). Each pins ONE oracle on BOTH sides via
+// `expectTypedStrictEqual` (the return type IS `UnnestSchema<...>`), the safety
+// net for the bridging assertions inside `buildUnnestSchema`.
+describe('buildUnnestSchema (runtime)', () => {
+  // The three source-descriptor rows share one context, so every case also shows
+  // the surviving input fields (the `addFields`-shaped overlay).
+  const schema = {
+    tag: array(string()), //           array(E)
+    ntag: nullable(array(string())), // nullable(array(E))
+    otag: optional(array(string())), // optional(array(E))
+  } satisfies DocumentSchema;
+  const tag = field(schema.tag, 'tag');
+  const ntag = field(schema.ntag, 'ntag');
+  const otag = field(schema.otag, 'otag');
+
+  describe('source descriptor → alias / index descriptor', () => {
+    it('array(E): alias E, index int64 (both never null — every row is from a real array)', () => {
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: string(),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, tag.as('e')), oracle);
+    });
+
+    it('array(E) with an index field: index is a plain int64', () => {
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: string(),
+        i: int64(),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, tag.as('e'), 'i'), oracle);
+    });
+
+    it('nullable(array(E)): alias nullable(E) (a null source emits a null-alias no-op row)', () => {
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: nullable(string()),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, ntag.as('e')), oracle);
+    });
+
+    it('nullable(array(E)) with an index field: index nullable(int64) (null on the no-op row)', () => {
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: nullable(string()),
+        i: nullable(int64()),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, ntag.as('e'), 'i'), oracle);
+    });
+
+    it('optional(array(E)): alias E & Optional — absence reaches the ALIAS (absent no-op row)', () => {
+      // The asymmetry: an ABSENT source emits a no-op row whose alias is itself
+      // ABSENT (Optional), NOT null — so absence carries onto the alias, unlike
+      // the index below which nulls on the same row.
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: optional(string()),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, otag.as('e')), oracle);
+    });
+
+    it('optional(array(E)) with an index field: index nullable(int64) — the index picks up NULL from absence', () => {
+      // Same absent-source row as above, but the index is null (present, not
+      // absent). The alias and the index do NOT travel together.
+      const oracle = {
+        tag: array(string()),
+        ntag: nullable(array(string())),
+        otag: optional(array(string())),
+        e: optional(string()),
+        i: nullable(int64()),
+      };
+      expectTypedStrictEqual(buildUnnestSchema(schema, otag.as('e'), 'i'), oracle);
+    });
+  });
+
+  it('unnests a NESTED array via a dotted source path (only the OUTPUT name is top-level)', () => {
+    const nested = { m: map({ k: array(string()) }) } satisfies DocumentSchema;
+    const oracle = { m: map({ k: array(string()) }), e: string() };
+    const mk = field(array(string()), 'm.k');
+    expectTypedStrictEqual(buildUnnestSchema(nested, mk.as('e')), oracle);
+  });
+
+  it('an alias onto the SOURCE own name replaces the array with the element', () => {
+    // Probed: `field('t').as('t')` yields rows whose `t` is the ELEMENT, no
+    // trace of the array. The `addFields` added-field-wins overlay expresses it.
+    const one = { tag: array(string()) } satisfies DocumentSchema;
+    const oracle = { tag: string() };
+    expectTypedStrictEqual(buildUnnestSchema(one, field(one.tag, 'tag').as('tag')), oracle);
+  });
+
+  it('an alias colliding with an UNRELATED existing field overwrites it (added-field-wins)', () => {
+    // The element descriptor (int64) replaces the existing `other: string()`.
+    const withOther = { tag: array(int64()), other: string() } satisfies DocumentSchema;
+    const oracle = { tag: array(int64()), other: int64() };
+    const actual = buildUnnestSchema(withOther, field(withOther.tag, 'tag').as('other'));
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('an index field colliding with an existing field overwrites it with the int64 offset', () => {
+    // Probed: `indexField: 'n'` replaces the document's `n`.
+    const withN = { tag: array(string()), n: string() } satisfies DocumentSchema;
+    const oracle = { tag: array(string()), n: int64(), e: string() };
+    const actual = buildUnnestSchema(withN, field(withN.tag, 'tag').as('e'), 'n');
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('a bare Field selectable equals the aliased-same-name form (its path IS its output name)', () => {
+    // A bare `Field` folds exactly as `field(p).as(p)` — output name = its path,
+    // so it too replaces the source array with the element.
+    const one = { tag: array(string()) } satisfies DocumentSchema;
+    const oracle = { tag: string() };
+    const bare = buildUnnestSchema(one, field(one.tag, 'tag'));
+    expectTypedStrictEqual(bare, oracle);
+    expectTypedStrictEqual(bare, buildUnnestSchema(one, field(one.tag, 'tag').as('tag')));
+  });
+
+  it('a COMPUTED array-valued expression selectable projects the expression at its alias', () => {
+    // The `functionCall` arm of the source dispatch: a computed array (never a
+    // field path, so never conditional) — its own descriptor is the source, the
+    // element is the alias. `arrayReverse` of a plain array stays non-null.
+    const one = { tag: array(string()) } satisfies DocumentSchema;
+    const oracle = { tag: array(string()), e: string() };
+    const actual = buildUnnestSchema(one, arrayReverse(field(one.tag, 'tag')).as('e'));
+    expectTypedStrictEqual(actual, oracle);
+  });
+
+  it('an optional ANCESTOR on the source path is conditional exactly as a leaf-optional array is', () => {
+    // `a?.b.c` shape: the source array is REQUIRED at its leaf, but the path
+    // crosses an optional ancestor (`WithConditionality`), so the source reads
+    // back `optional(array(E))` — alias `E & Optional`, index nullable — the
+    // same cell as the direct optional-array row, reached via an ancestor.
+    const deep = { om: optional(map({ k: array(string()) })) } satisfies DocumentSchema;
+    const oracle = {
+      om: optional(map({ k: array(string()) })),
+      e: optional(string()),
+      i: nullable(int64()),
+    };
+    const omk = field(array(string()), 'om.k');
+    expectTypedStrictEqual(buildUnnestSchema(deep, omk.as('e'), 'i'), oracle);
   });
 });

--- a/packages/firestore-repository/src/pipelines/selection.ts
+++ b/packages/firestore-repository/src/pipelines/selection.ts
@@ -3,6 +3,8 @@ import {
   type FieldType,
   type FieldTypeOfPath,
   fieldTypeOfPath,
+  int64,
+  type Int64Type,
   isMapType,
   map,
   type MapFieldPath,
@@ -16,8 +18,16 @@ import {
 import { assertNever } from '../util.js';
 import {
   type AggregateWithAlias,
+  type ArrayElementType,
+  arrayElementType,
+  type ArrayValued,
   type ExpressionWithAlias,
   type Field,
+  type PreserveOptional,
+  preserveOptional,
+  type PropagateNull,
+  propagateNullType,
+  type UndottedKey,
   type WithoutOptional,
   withoutOptional,
 } from './expression.js';
@@ -105,16 +115,41 @@ export type SelectionNode = string | Field | ExpressionWithAlias;
  * (`WithoutDottedFieldNames`).
  */
 export type UndottedGroupAliases<G> = {
-  [I in keyof G]: G[I] extends { alias: infer A extends string }
-    ? A extends `${string}.${string}`
-      ? never
-      : G[I]
-    : G[I] extends Field<FieldType, infer P>
-      ? P extends `${string}.${string}`
-        ? never
-        : G[I]
-      : G[I];
+  [I in keyof G]: UndottedSelectionAlias<G[I]>;
 };
+
+/**
+ * The top-level-output guard for a SINGLE selection — the scalar core
+ * {@link UndottedGroupAliases} maps over a tuple, and the guard
+ * `Pipeline.unnest` applies to its lone `selectable` (whose alias and whose
+ * `indexField` are both restricted to top level — probed, both INVALID_ARGUMENT
+ * when dotted).
+ *
+ * A selection whose output name contains the path separator collapses to
+ * `never`: an aliased selection by its `alias`, a bare {@link Field} by its
+ * `path` (which is its alias). Sharing this one operator is what makes the two
+ * dotted forms produce the same error at the same place, in every stage whose
+ * outputs are top-level-only.
+ */
+export type UndottedSelectionAlias<S> = S extends { alias: infer A extends string }
+  ? A extends `${string}.${string}`
+    ? never
+    : S
+  : S extends Field<FieldType, infer P>
+    ? P extends `${string}.${string}`
+      ? never
+      : S
+    : S;
+
+/**
+ * The top-level-output guard for an `unnest` index field: `undefined` (no index
+ * field) passes through, a name passes through {@link UndottedKey}. A separate
+ * operator from {@link UndottedSelectionAlias} only because the value is a bare
+ * key rather than a selection — the restriction is the same one.
+ */
+export type UndottedIndexField<Index extends string | undefined> = Index extends string
+  ? UndottedKey<Index>
+  : Index;
 
 /**
  * Folds a tuple of selections into a single nested output schema.
@@ -252,6 +287,135 @@ export type DistinctSchema<
   Context extends Fields,
   Groups extends readonly AggregateGroup<Context>[],
 > = GroupSchema<Context, Groups>;
+
+/**
+ * Output schema of the `unnest` stage: the input context with the array's
+ * ELEMENT overlaid under the selectable's output name — plus the element's
+ * offset under `indexField` when one is requested.
+ *
+ * The overlay is `addFields`-shaped: the exact
+ * `MergeSchemas<additions, Context>` composition of {@link BuildAddFieldsSchema}
+ * (added-field-wins), which is why aliasing onto the SOURCE's own name replaces
+ * the array with the element — what the backend does (probed). The source field
+ * otherwise survives alongside the alias.
+ *
+ * The alias and the index descriptors are derived from the source array's
+ * descriptor by DIFFERENT rules (they do not travel together — see
+ * {@link UnnestAliasType} / {@link UnnestIndexType}):
+ *
+ * | source               | alias           | index               |
+ * | -------------------- | --------------- | ------------------- |
+ * | `array(E)`           | `E`             | `int64()`           |
+ * | `nullable(array(E))` | `nullable(E)`   | `nullable(int64())` |
+ * | `optional(array(E))` | `E & Optional`  | `nullable(int64())` |
+ *
+ * (An empty array emits NO row at all, so a row produced from a real array
+ * always carries a real element and a real int64 index.)
+ */
+export type UnnestSchema<
+  Context extends Fields,
+  Sel extends UnnestSelectable<Context>,
+  Index extends string | undefined,
+> = MergeSchemas<UnnestOverlay<Context, Sel, Index>, Context>;
+
+/**
+ * A selectable of the `unnest` stage: a bare ARRAY-valued {@link Field} of the
+ * context, or an aliased ARRAY-valued expression. Array-valued by construction
+ * ({@link ArrayValued}), which is what makes the non-array no-op row of the
+ * backend (an alias carrying the source VALUE — probed, contradicting the SDK's
+ * doc comment) unreachable through this library.
+ *
+ * A bare `Field` is accepted for the same reason as in {@link Selection}: its
+ * `path` IS its output name. A bare path STRING is deliberately NOT offered —
+ * the SDK takes a `Selectable`, and the bare-`Field` form already covers it.
+ *
+ * The SOURCE path may be dotted (`field('m.k').as('e')` unnests a nested array
+ * — probed); only the OUTPUT name is restricted to top level, which is enforced
+ * one level up by {@link UndottedSelectionAlias} at the `Pipeline.unnest`
+ * parameter, so a dotted bare `Field` and a dotted alias fail the same way.
+ */
+export type UnnestSelectable<Context extends Fields> =
+  | Field<ArrayValued, MapFieldPath<Context>>
+  | ExpressionWithAlias<ArrayValued>;
+
+/**
+ * The fields `unnest` overlays on its input context: the element at the
+ * selectable's output name, merged with the index field's contribution (`{}`
+ * when no index field was requested).
+ *
+ * The alias comes FIRST so it wins a name collision with the index field —
+ * a merge order that is never actually exercised: the backend rejects an
+ * `indexField` equal to the alias outright (INVALID_ARGUMENT, "Index field `e`
+ * cannot be the same name as the alias `e`" — probed). Left unguarded at the
+ * type level on purpose, per the rule stated on `ExpressionBase.as`: ban what
+ * would silently succeed against the type model, leave what fails loudly to the
+ * backend.
+ */
+type UnnestOverlay<
+  Context extends Fields,
+  Sel extends UnnestSelectable<Context>,
+  Index extends string | undefined,
+> = MergeSchemas<
+  PathToSchema<SelectionPath<Sel>, UnnestAliasType<UnnestSourceType<Context, Sel>>>,
+  UnnestIndexSchema<Index, UnnestIndexType<UnnestSourceType<Context, Sel>>>
+>;
+
+/**
+ * The descriptor of the ARRAY `unnest` reads, as the ROW sees it — the
+ * selectable's own descriptor with ancestor optionality moved onto it
+ * ({@link WithConditionality}) when it reads a field path. Mirrors
+ * {@link SelectionToSchema}'s dispatch arm for arm (a path-reading selection is
+ * conditional, a computed expression always produces a value), minus the bare
+ * string arm that {@link UnnestSelectable} does not offer.
+ */
+type UnnestSourceType<Context extends Fields, Sel> = Sel extends {
+  expression: Field<infer T, infer P>;
+  alias: string;
+}
+  ? WithConditionality<Context, P, T>
+  : Sel extends ExpressionWithAlias<infer T, string>
+    ? T
+    : Sel extends Field<infer T, infer P>
+      ? WithConditionality<Context, P, T>
+      : never;
+
+/**
+ * The descriptor bound to the ALIAS, derived from the source array's
+ * descriptor: the element type, carrying the source's null-ness but NOT
+ * observing its absence as null.
+ *
+ * Both halves of that asymmetry are deliberate, and both are visible in the
+ * composition: `PropagateNull` is fed `WithoutOptional<Source>` so the ABSENCE
+ * arm of its condition cannot fire (a null source emits a no-op row whose alias
+ * is `null`, but an ABSENT source emits a no-op row whose alias is likewise
+ * ABSENT — probed), and {@link PreserveOptional} then carries that absence over
+ * as the `Optional` marker instead. Contrast {@link UnnestIndexType}, which
+ * takes the source unstripped and so nulls on BOTH.
+ */
+type UnnestAliasType<Source extends FieldType> = PreserveOptional<
+  Source,
+  PropagateNull<WithoutOptional<Source>, ArrayElementType<Source>>
+>;
+
+/**
+ * The descriptor bound to the INDEX field: the element's int64 offset, nullable
+ * when the source can be null OR absent.
+ *
+ * Plain {@link PropagateNull} — its condition (`'null'` tag OR the `Optional`
+ * marker) is exactly the probed rule: the index field is ALWAYS PRESENT on an
+ * emitted row and is `null` on every no-op row, including the absent-source row
+ * where the alias itself is absent. So it is `int64()` only for a source that
+ * is neither nullable nor optional, whose rows all come from a real array.
+ */
+type UnnestIndexType<Source extends FieldType> = PropagateNull<Source, Int64Type>;
+
+/**
+ * The index field's contribution to the overlay: its descriptor at its (always
+ * top-level) name, or `{}` when no index field was requested.
+ */
+type UnnestIndexSchema<Index extends string | undefined, T extends FieldType> = Index extends string
+  ? PathToSchema<Index, T>
+  : {};
 
 /**
  * Folds the accumulators into a flat `alias -> result descriptor` record. A
@@ -475,6 +639,113 @@ export const buildDistinctSchema = <
   schema: Context,
   groups: Groups,
 ): DistinctSchema<Context, Groups> => groupSchema(schema, groups);
+
+/**
+ * Runtime counterpart of {@link UnnestSchema}: the same
+ * `MergeSchemas<UnnestOverlay<...>, Context>` composition (the overlay wins on
+ * overlap — the `addFields` rule, which is what lets an alias onto the source's
+ * own name replace the array with the element). The result feeds the executors'
+ * row decoding, so it must mirror the type exactly — the tests in
+ * `selection.test.ts` pin both halves.
+ */
+export const buildUnnestSchema = <
+  Context extends Fields,
+  const Sel extends UnnestSelectable<Context>,
+  const Index extends string | undefined = undefined,
+>(
+  schema: Context,
+  selectable: Sel,
+  indexField: Index | undefined = undefined,
+): UnnestSchema<Context, Sel, Index> => {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: an omitted `indexField` argument means "no index field" and leaves `Index` at its `undefined` default, but the compiler does not tie a parameter's absence to a type parameter's default.
+  const index = indexField as Index;
+  return mergeSchemas(unnestOverlay(schema, selectable, index), schema);
+};
+
+/**
+ * Runtime counterpart of {@link UnnestOverlay}: the alias's single-entry schema
+ * merged over the index field's contribution.
+ *
+ * The source descriptor is resolved ONCE and fed to both derivations, which is
+ * where their asymmetry is visible side by side — `unnestAliasType` strips the
+ * absence marker before propagating null and re-applies it, `unnestIndexType`
+ * propagates from the same descriptor unstripped.
+ *
+ * Typed as `UnnestOverlay<...>` and computed from helpers that are each typed
+ * as their own type-level twin, so the compiler — not a comment — checks that
+ * the composition matches the type's decomposition; no assertion of its own.
+ */
+const unnestOverlay = <
+  Context extends Fields,
+  Sel extends UnnestSelectable<Context>,
+  Index extends string | undefined,
+>(
+  schema: Context,
+  selectable: Sel,
+  indexField: Index,
+): UnnestOverlay<Context, Sel, Index> => {
+  const source = unnestSourceType(schema, selectable);
+  return mergeSchemas(
+    pathToSchema(selectionPath(selectable), unnestAliasType(source)),
+    unnestIndexSchema(indexField, unnestIndexType(source)),
+  );
+};
+
+/**
+ * Runtime counterpart of {@link UnnestSourceType}, mirroring
+ * {@link selectionToSchema}'s dispatch arm for arm (minus the bare string arm,
+ * which {@link UnnestSelectable} does not offer).
+ */
+const unnestSourceType = <Context extends Fields, Sel extends UnnestSelectable<Context>>(
+  schema: Context,
+  selectable: Sel,
+): UnnestSourceType<Context, Sel> => {
+  // Widened to the union first: narrowing a generic `Sel` in place leaves it a
+  // type parameter that `in` cannot discriminate.
+  const node: UnnestSelectable<Fields> = selectable;
+  const result = ((): FieldType => {
+    if (!('alias' in node)) {
+      // A bare `Field`: its own `type` is the source descriptor, conditional on
+      // its path — the exact resolution the aliased `field(p).as(a)` arm runs.
+      return withConditionality(schema, node.path, node.type);
+    }
+    const { expression } = node;
+    switch (expression.kind) {
+      case 'field':
+        return withConditionality(schema, expression.path, expression.type);
+      case 'constant':
+      case 'functionCall':
+        return expression.type;
+      default:
+        return assertNever(expression);
+    }
+  })();
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `UnnestSourceType` dispatches on the shape of `Sel` with a conditional type, the runtime on the shape of the VALUE; narrowing the value does not narrow `Sel`, so the arms cannot be matched up by the compiler.
+  return result as UnnestSourceType<Context, Sel>;
+};
+
+/**
+ * Runtime counterpart of {@link UnnestAliasType}, typed as that operator applied
+ * to its input — the same `preserveOptional(source, propagateNullType(withoutOptional(source), ...))`
+ * composition, so the absence/null asymmetry is checked step for step and needs
+ * no assertion here.
+ */
+const unnestAliasType = <Source extends FieldType>(source: Source): UnnestAliasType<Source> =>
+  preserveOptional(source, propagateNullType(withoutOptional(source), arrayElementType(source)));
+
+/** Runtime counterpart of {@link UnnestIndexType}, typed as that operator applied to its input. */
+const unnestIndexType = <Source extends FieldType>(source: Source): UnnestIndexType<Source> =>
+  propagateNullType(source, int64());
+
+/** Runtime counterpart of {@link UnnestIndexSchema}, typed as that operator applied to its inputs. */
+const unnestIndexSchema = <Index extends string | undefined, T extends FieldType>(
+  indexField: Index,
+  type: T,
+): UnnestIndexSchema<Index, T> => {
+  const result = indexField === undefined ? {} : pathToSchema(indexField, type);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- bridges ONE step: `UnnestIndexSchema` branches on `Index extends string`, a type-level test the runtime performs with an `undefined` check; the compiler does not relate the two.
+  return result as UnnestIndexSchema<Index, T>;
+};
 
 /**
  * Runtime counterpart of {@link GroupSchema}, shared by `buildAggregateSchema`

--- a/packages/firestore-repository/src/pipelines/stage.ts
+++ b/packages/firestore-repository/src/pipelines/stage.ts
@@ -44,7 +44,12 @@ export type TransformStage =
   | { kind: 'sort'; orderings: Ordering[] }
   | { kind: 'limit'; limit: number }
   | { kind: 'offset'; offset: number }
-  | { kind: 'unnest' }
+  // Emits one row per element of the array `selectable` evaluates to, adding the
+  // element under the selectable's output name and (when set) its offset under
+  // `indexField`. `selectable` is already the context-free {@link SelectionNode}
+  // (its output name top-level, guarded by `Pipeline.unnest`), so an executor
+  // translates it 1:1 like a `select` selection.
+  | { kind: 'unnest'; selectable: SelectionNode; indexField?: string }
   // `accumulators` are the aliased accumulator calls; `groups` are the group
   // keys post-conflict-resolution (last-wins applied by `Pipeline.aggregate`,
   // mirroring `select`), so an executor translates both 1:1. Empty `groups`

--- a/packages/google-cloud-firestore/src/pipeline.ts
+++ b/packages/google-cloud-firestore/src/pipeline.ts
@@ -136,6 +136,13 @@ const applyStage = (
     case 'offset':
       return sdk.offset(stage.offset);
     case 'unnest':
+      // The options-object form: `selectable` translates exactly like a `select`
+      // selection (a bare `Field` or an aliased expression), and `indexField` is
+      // passed through only when set (spread, for `exactOptionalPropertyTypes`).
+      return sdk.unnest({
+        selectable: toSdkSelectable(db, stage.selectable),
+        ...(stage.indexField !== undefined ? { indexField: stage.indexField } : {}),
+      });
     case 'replaceWith':
     case 'union':
     case 'findNearest':


### PR DESCRIPTION
Implements the `unnest` pipeline stage — one row per array element — end-to-end through both executors, **identity-preserving**.

Probed semantics: `docs/pipeline-query-unnest-research.md`.

## Behavior

`unnest((field) => ({ selectable, indexField? }))` emits one row per element of the array the selectable evaluates to, adding the element under the selectable's output name and (optionally) its zero-based offset under `indexField`.

- **Identity is PRESERVED** (`Id` threads through) — but ids are no longer unique across rows: an n-element array yields n rows carrying the SAME id. Verified live.
- **Schema effect is `addFields`-shaped**: `UnnestSchema = MergeSchemas<overlay, Context>`, so aliasing onto the source's own name replaces the array with the element, and the source field otherwise survives.
- **Output names are top-level only** (probed: `TOP_LEVEL_PROPERTY_PATH_ONLY` — a dotted alias AND a dotted `indexField` both rejected, guarded via the shared `UndottedSelectionAlias` / `UndottedIndexField`). The **source** path may be dotted.

## The alias/index asymmetry (probed)

Both descriptors derive from the same source by different operators:

| source descriptor    | alias descriptor | index descriptor    |
| -------------------- | ---------------- | ------------------- |
| `array(E)`           | `E`              | `int64()`           |
| `nullable(array(E))` | `nullable(E)`    | `nullable(int64())` |
| `optional(array(E))` | `E & Optional`   | `nullable(int64())` |

- **Alias** = `PreserveOptional<Source, PropagateNull<WithoutOptional<Source>, ArrayElementType<Source>>>` — feeding `PropagateNull` the null-stripped source disables its absence arm, so absence reaches the alias as ABSENCE (not null); `PreserveOptional` re-applies the marker.
- **Index** = `PropagateNull<Source, Int64Type>` — nulls on BOTH the null and absent cases.

So an absent source reaches the alias as absence but the index as `null` — the two do not travel together (pinned live).

## New primitives (expression.ts)

`arrayElementType` / `propagateNullType` / `preserveOptional` (+ a typed `withoutOptional`), each an overload-signature bridge with its type-level twin — no `as`. Three step-local `as` assertions remain in `selection.ts`'s runtime twins, each naming the one step it bridges and covered by the `buildUnnestSchema (runtime)` matrix.

## Probe gap found and filled

The research doc's matrix omitted the **alias-name === indexField-name** cell; probed it (backend rejects it outright: `INVALID_ARGUMENT: Index field 'e' cannot be the same name as the alias 'e'`), left it unguarded at the type level per the "leave what fails loudly to the backend" rule, and documented it on `UnnestOverlay`.

## Note on the base

This branch was cut before #238 (union normalization) merged; `origin/pipeline-query` (with #238) is merged in here. The merge is the real proof that #238's normalization and the unnest descriptor derivation coexist — the unnest oracles normalize identically on both sides.

## Verification

`pnpm check` clean; full suite incl. live Enterprise DB: **780 passed | 90 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)